### PR TITLE
Fix generic parameter checking.

### DIFF
--- a/built_value_generator/lib/src/built_parameters_visitor.dart
+++ b/built_value_generator/lib/src/built_parameters_visitor.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+/// Extracts the type parameters used for the `Built` interface.
+class BuiltParametersVisitor extends RecursiveAstVisitor {
+  String result;
+
+  @override
+  void visitExtendsClause(ExtendsClause extendsClause) {
+    result ??= _extractParameters('extends Built<', extendsClause.toString());
+  }
+
+  @override
+  void visitImplementsClause(ImplementsClause implementsClause) {
+    result ??= _extractParameters('implements Built<', implementsClause.toString());
+  }
+
+  /// If [[code]] starts with [[prefix]] then strips it off, strips off the
+  /// last character, and returns it.
+  ///
+  /// Otherwise returns null.
+  String _extractParameters(String prefix, String code) {
+    if (code.startsWith(prefix)) {
+      return code.substring(prefix.length, code.length - 1);
+    } else {
+      return null;
+    }
+  }
+}

--- a/built_value_generator/lib/src/source_class.dart
+++ b/built_value_generator/lib/src/source_class.dart
@@ -7,6 +7,7 @@ library built_value_generator.source_class;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/built_parameters_visitor.dart';
 import 'package:built_value_generator/src/source_field.dart';
 import 'package:quiver/iterables.dart';
 import 'package:source_gen/source_gen.dart';
@@ -42,7 +43,7 @@ abstract class SourceClass implements Built<SourceClass, SourceClassBuilder> {
     final result = new SourceClassBuilder();
     result
       ..name = name
-      ..builtParameters = _getBuildParameters(classElement)
+      ..builtParameters = _getBuiltParameters(classElement)
       ..hasBuilder = hasBuilder
       ..partStatement = _getPartStatement(classElement)
       ..hasPartStatement = _getHasPartStatement(classElement)
@@ -73,13 +74,10 @@ abstract class SourceClass implements Built<SourceClass, SourceClassBuilder> {
     return result.build();
   }
 
-  static String _getBuildParameters(ClassElement classElement) {
-    return classElement.allSupertypes
-        .where((interfaceType) => interfaceType.name == 'Built')
-        .single
-        .typeArguments
-        .map((element) => element.displayName)
-        .join(', ');
+  static String _getBuiltParameters(ClassElement classElement) {
+    final visitor = new BuiltParametersVisitor();
+    classElement.computeNode().accept(visitor);
+    return visitor.result;
   }
 
   static String _getBuilderParameters(ClassElement classElement) {

--- a/built_value_generator/test/built_value_generator_test.dart
+++ b/built_value_generator/test/built_value_generator_test.dart
@@ -53,7 +53,34 @@ abstract class ValueBuilder extends Builder<Value, ValueBuilder> {
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
           contains('1. Make class implement Built<Value, ValueBuilder>. '
-              'Currently: Built<dynamic, dynamic>'));
+              'Currently: Built<Foo, Bar>'));
+    });
+
+    test('suggests correct Built type parameters for implements', () async {
+      expect(
+          await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Foo, Bar> {
+  Value._();
+  factory Value([updates(ValueBuilder b)]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+          contains('1. Make class implement Built<Value, ValueBuilder>. '
+              'Currently: Built<Foo, Bar>'));
+    });
+
+    test('handles unresolved Built type parameters', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value extends Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([updates(ValueBuilder b)]) = _\$Value;
+}'''), isNot(contains('1.')));
     });
 
     test('suggests to add constructor to value class', () async {
@@ -273,7 +300,7 @@ abstract class ValueBuilder extends Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
   set foo(int foo) => print(foo);
-}'''), isNot(contains('TODO')));
+}'''), isNot(contains('1.')));
     });
   });
 }


### PR DESCRIPTION
Don't assume builder can be resolved, it might be generated and so not available yet.

Switch to AST-based check so the builder doesn't need to exist yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/46)
<!-- Reviewable:end -->
