### PR TITLE
Merge in built_json and built_json_generator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ script:
   - pub get
   - pub run tool/build.dart
   - pub run test
+  - cd ../chat_example
+  - pub get
+  - pub run tool/build.dart
+  - pub run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 0.2.1 (unreleased)
+## 0.3.0
 
+- Merged built_json and built_json_generator into built_value and
+  built_value_generator. These are intended to be used together, and make
+  more sense as a single package.
 - Fix generation when class extends multiple interfaces.
 
 ## 0.2.0

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 [![Build Status](https://travis-ci.org/google/built_value.dart.svg?branch=master)](https://travis-ci.org/google/built_value.dart)
 ## Introduction
 
-Built Values provides immutable "value types" and Enum Classes for Dart and 
-is part of the
-[Libraries for Object Oriented Dart](https://github.com/google/built_value.dart/blob/master/libraries_for_object_oriented_dart.md#libraries-for-object-oriented-dart).
+Built Values provides immutable "value types" and Enum Classes. It uses
+[Built Collections]
+(https://github.com/google/built_collection.dart#built-collections-for-dart)
+and provides JSON serialization.
 
 ## Value Types
 
@@ -53,6 +54,56 @@ Design:
   and are real classes that can hold code and implement interfaces
 * Generated `values` method that returns all the enum values in a `BuiltSet` (immutable set)
 * Generated `valueOf` method that takes a `String`
+
+## Serialization
+
+Built Values comes with JSON serialization support which allows you to
+serialize a complete data model of Built Values, Enum Classes and
+Built Collections. The [chat example]
+(https://github.com/google/built_value.dart/tree/master/chat_example) shows 
+how easy this makes building a full application with Dart on the server and
+client.
+
+Here are the major features of the serialization support:
+
+It _fully supports object oriented design_: any object model that you can 
+design can be serialized, including full use of generics and interfaces.
+Some other libraries require concrete types or do not fully support generics.
+
+It _allows different object oriented models over the same data_. For
+example, in a client server application, it's likely that the client and server
+want different functionality from their data model. So, they are allowed to have
+different classes that map to the same data. Most other libraries enforce a 1:1
+mapping between classes and types on the wire.
+
+It _requires well behaved types_. They must be immutable, can use
+interface but not concrete inheritance, must have predictable nullability,
+`hashCode`, `equals` and `toString`. In fact, they must be Enum Classes, Built
+Collections or Built Values. Some other libraries allow badly behaved types to
+be serialized.
+
+It _supports changes to the data model_. Optional fields can be added or
+removed, and fields can be switched from optional to required, allowing your
+data model to evolve without breaking compatbility. Some other libraries break
+compatability on any change to any serializable class.
+
+It's _modular_. Each endpoint can choose which classes to know about;
+for example, you can have multiple clients that each know about only a subset of
+the classes the server knows. Most other libraries are monolithic, requiring all
+endpoints to know all types.
+
+It's _multi language_. Support will be come first for Dart, Java and
+Java/GWT. Many other libraries support a single language only.
+
+It _has first class support for validation_ via Built Values. An important 
+part of a powerful data model is ensuring it's valid, so classes can make
+guarantees about what they can do. Other libraries also support validation
+but usually in a less prominent way.
+
+It's _pluggable_. Arbitrary extensions can be added to give 
+custom JSON serialization for your own types. This could be used to
+interoperate with other tools or to add hand coded high performance serializers
+for specific classes. Some other libraries are not so extensible.
 
 ## Examples
 

--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value;
-
 /// Implement this for a Built Value.
 ///
 /// Then use built_value_generator.dart code generation functionality to

--- a/built_value/lib/serializer.dart
+++ b/built_value/lib/serializer.dart
@@ -1,0 +1,180 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'src/bool_serializer.dart';
+import 'src/built_json_serializers.dart';
+import 'src/built_list_serializer.dart';
+import 'src/built_map_serializer.dart';
+import 'src/built_set_serializer.dart';
+import 'src/double_serializer.dart';
+import 'src/int_serializer.dart';
+import 'src/string_serializer.dart';
+
+/// Serializes all known classes.
+///
+/// See: https://github.com/google/built_json.dart/tree/master/example
+abstract class Serializers {
+  /// Default [Serializers] that can serialize primitives and collections.
+  ///
+  /// Use [toBuilder] to add more serializers.
+  factory Serializers() {
+    return (new SerializersBuilder()
+          ..add(new BoolSerializer())
+          ..add(new BuiltListSerializer())
+          ..add(new BuiltMapSerializer())
+          ..add(new BuiltSetSerializer())
+          ..add(new DoubleSerializer())
+          ..add(new IntSerializer())
+          ..add(new StringSerializer()))
+        .build();
+  }
+
+  /// Serializes [object].
+  ///
+  /// A [Serializer] must have been provided for every type the object uses.
+  ///
+  /// Types that are known statically can be provided via [specifiedType]. This
+  /// will reduce the amount of data needed on the wire. The exact same
+  /// [specifiedType] will be needed to deserialize.
+  ///
+  /// Create one using [SerializersBuilder].
+  ///
+  /// TODO(davidmorgan): document the wire format.
+  Object serialize(Object object,
+      {FullType specifiedType: FullType.unspecified});
+
+  /// Deserializes [serialized].
+  ///
+  /// A [Serializer] must have been provided for every type the object uses.
+  ///
+  /// If [serialized] was produced by calling [serialize] with [specifiedType],
+  /// the exact same [specifiedType] must be provided to deserialize.
+  Object deserialize(Object serialized,
+      {FullType specifiedType: FullType.unspecified});
+
+  /// Creates a new builder for the type represented by [fullType].
+  ///
+  /// For example, if [fullType] is `BuiltList<int, String>`, returns a
+  /// `ListBuilder<int, String>`. This helps serializers to instantiate with
+  /// correct generic type parameters.
+  ///
+  /// May return null if no matching builder factory has been added. In this
+  /// case the serializer should throw a [StateError].
+  Object newBuilder(FullType fullType);
+
+  /// Whether a builder for [fullType] is available via [newBuilder].
+  bool hasBuilder(FullType fullType);
+
+  SerializersBuilder toBuilder();
+}
+
+/// Builder for [Serializers].
+abstract class SerializersBuilder {
+  factory SerializersBuilder() = BuiltJsonSerializersBuilder;
+
+  void add(Serializer serializer);
+
+  void addBuilderFactory(FullType specifiedType, Function function);
+
+  Serializers build();
+}
+
+/// A [Type] with, optionally, [FullType] generic type parameters.
+///
+/// May also be [unspecified], indicating that no type information is
+/// available.
+class FullType {
+  // An unspecified type.
+  static const unspecified = const FullType(null);
+
+  /// The root of the type.
+  final Type root;
+
+  /// Type parameters of the type.
+  final List<FullType> parameters;
+
+  const FullType(this.root, [this.parameters = const []]);
+
+  bool get isUnspecified => identical(root, null);
+
+  @override
+  String toString() => isUnspecified
+      ? 'unspecified'
+      : parameters.isEmpty
+          ? root.toString()
+          : '${root.toString()}<${parameters.join(", ")}>';
+}
+
+/// Serializes a single type.
+///
+/// You should not usually need to implement this interface. Implementations
+/// are provided for collections and primitives in `built_json`. Classes using
+/// `built_value` and enums using `EnumClass` can have implementations
+/// generated using `built_json_generator`.
+///
+/// Implementations must extend either [PrimitiveSerializer] or
+/// [StructuredSerializer].
+abstract class Serializer<T> {
+  /// The [Type]s that can be serialized.
+  ///
+  /// They must all be equal to T or a subclass of T. Subclasses are used when
+  /// T is an abstract class, which is the case with built_value generated
+  /// serializers.
+  Iterable<Type> get types;
+
+  /// The wire name of the serializable type. For most classes, the class name.
+  /// For primitives and collections a lower-case name is defined as part of
+  /// the `built_json` wire format.
+  String get wireName;
+}
+
+/// A [Serializer] that serializes to and from primitive JSON values.
+abstract class PrimitiveSerializer<T> implements Serializer<T> {
+  /// Serializes [object].
+  ///
+  /// Use [serializers] as needed for nested serialization. Information about
+  /// the type being serialized is provided in [specifiedType].
+  ///
+  /// Returns a value that can be represented as a JSON primitive: a boolean,
+  /// an integer, a double, or a String.
+  ///
+  /// TODO(davidmorgan): document the wire format.
+  Object serialize(Serializers serializers, T object,
+      {FullType specifiedType: FullType.unspecified});
+
+  /// Deserializes [serialized].
+  ///
+  /// [serialized] is a boolean, an integer, a double or a String.
+  ///
+  /// Use [serializers] as needed for nested deserialization. Information about
+  /// the type being deserialized is provided in [specifiedType].
+  T deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified});
+}
+
+/// A [Serializer] that serializes to and from an [Iterable] of primitive JSON
+/// values.
+abstract class StructuredSerializer<T> implements Serializer<T> {
+  /// Serializes [object].
+  ///
+  /// Use [serializers] as needed for nested serialization. Information about
+  /// the type being serialized is provided in [specifiedType].
+  ///
+  /// Returns an [Iterable] of values that can be represented as structured
+  /// JSON: booleans, integers, doubles, Strings and [Iterable]s.
+  ///
+  /// TODO(davidmorgan): document the wire format.
+  Iterable serialize(Serializers serializers, T object,
+      {FullType specifiedType: FullType.unspecified});
+
+  /// Deserializes [serialized].
+  ///
+  /// [serialized] is an [Iterable] that may contain booleans, integers,
+  /// doubles, Strings and/or [Iterable]s.
+  ///
+  /// Use [serializers] as needed for nested deserialization. Information about
+  /// the type being deserialized is provided in [specifiedType].
+  T deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified});
+}

--- a/built_value/lib/src/bool_serializer.dart
+++ b/built_value/lib/src/bool_serializer.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BoolSerializer implements PrimitiveSerializer<bool> {
+  final bool structured = false;
+  final Iterable<Type> types = new BuiltList<Type>([bool]);
+  final String wireName = 'bool';
+
+  @override
+  Object serialize(Serializers serializers, bool boolean,
+      {FullType specifiedType: FullType.unspecified}) {
+    return boolean;
+  }
+
+  @override
+  bool deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return serialized as bool;
+  }
+}

--- a/built_value/lib/src/built_json_serializers.dart
+++ b/built_value/lib/src/built_json_serializers.dart
@@ -1,0 +1,182 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Default implementation of [Serializers].
+class BuiltJsonSerializers implements Serializers {
+  final BuiltMap<Type, Serializer> _typeToSerializer;
+
+  // Implementation note: wire name is what gets sent in the JSON, type name is
+  // the runtime type name. Type name is complicated for two reasons:
+  //
+  // 1. Built Value classes have two types, the abstract class and the
+  // generated implementation.
+  //
+  // 2. When compiled to javascript the runtime type names are obfuscated.
+  final BuiltMap<String, Serializer> _wireNameToSerializer;
+  final BuiltMap<String, Serializer> _typeNameToSerializer;
+
+  final BuiltMap<FullType, Function> _builderFactories;
+
+  BuiltJsonSerializers._(this._typeToSerializer, this._wireNameToSerializer,
+      this._typeNameToSerializer, this._builderFactories);
+
+  @override
+  Object serialize(Object object,
+      {FullType specifiedType: FullType.unspecified}) {
+    if (specifiedType.isUnspecified) {
+      final serializer = _getSerializerByType(object.runtimeType);
+      if (serializer == null) {
+        throw new StateError("No serializer for '${object.runtimeType}'.");
+      }
+      if (serializer is StructuredSerializer) {
+        final result = <Object>[serializer.wireName];
+        return result..addAll(serializer.serialize(this, object));
+      } else if (serializer is PrimitiveSerializer) {
+        return <Object>[
+          serializer.wireName,
+          serializer.serialize(this, object)
+        ];
+      } else {
+        throw new StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    } else {
+      final serializer = _getSerializerByType(specifiedType.root);
+      if (serializer == null) {
+        // Might be an interface; try resolving using the runtime type.
+        return serialize(object);
+      }
+      if (serializer is StructuredSerializer) {
+        return serializer
+            .serialize(this, object, specifiedType: specifiedType)
+            .toList();
+      } else if (serializer is PrimitiveSerializer) {
+        return serializer.serialize(this, object, specifiedType: specifiedType);
+      } else {
+        throw new StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    }
+  }
+
+  @override
+  Object deserialize(Object object,
+      {FullType specifiedType: FullType.unspecified}) {
+    if (specifiedType.isUnspecified) {
+      final wireName = (object as List).first;
+
+      final serializer = _wireNameToSerializer[wireName];
+      if (serializer == null) {
+        throw new StateError("No serializer for '${wireName}'.");
+      }
+
+      if (serializer is StructuredSerializer) {
+        return serializer.deserialize(this, (object as List).sublist(1));
+      } else if (serializer is PrimitiveSerializer) {
+        return serializer.deserialize(this, (object as List)[1]);
+      } else {
+        throw new StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    } else {
+      final serializer = _getSerializerByType(specifiedType.root);
+      if (serializer == null) {
+        // Might be an interface; try resolving using the runtime type.
+        return deserialize(object);
+      }
+
+      if (serializer is StructuredSerializer) {
+        return serializer.deserialize(this, object as Iterable,
+            specifiedType: specifiedType);
+      } else if (serializer is PrimitiveSerializer) {
+        return serializer.deserialize(this, object,
+            specifiedType: specifiedType);
+      } else {
+        throw new StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    }
+  }
+
+  @override
+  Object newBuilder(FullType fullType) {
+    final builderFactory = _builderFactories[fullType];
+    return builderFactory == null ? null : builderFactory();
+  }
+
+  @override
+  bool hasBuilder(FullType fullType) {
+    return _builderFactories.containsKey(fullType);
+  }
+
+  @override
+  SerializersBuilder toBuilder() {
+    return new BuiltJsonSerializersBuilder._(
+        _typeToSerializer.toBuilder(),
+        _wireNameToSerializer.toBuilder(),
+        _typeNameToSerializer.toBuilder(),
+        _builderFactories.toBuilder());
+  }
+
+  Serializer _getSerializerByType(Type type) {
+    return _typeToSerializer[type] ?? _typeNameToSerializer[_getRawName(type)];
+  }
+}
+
+/// Default implementation of [SerializersBuilder].
+class BuiltJsonSerializersBuilder implements SerializersBuilder {
+  MapBuilder<Type, Serializer> _typeToSerializer =
+      new MapBuilder<Type, Serializer>();
+  MapBuilder<String, Serializer> _wireNameToSerializer =
+      new MapBuilder<String, Serializer>();
+  MapBuilder<String, Serializer> _typeNameToSerializer =
+      new MapBuilder<String, Serializer>();
+
+  MapBuilder<FullType, Function> _builderFactories =
+      new MapBuilder<FullType, Function>();
+
+  BuiltJsonSerializersBuilder();
+
+  BuiltJsonSerializersBuilder._(
+      this._typeToSerializer,
+      this._wireNameToSerializer,
+      this._typeNameToSerializer,
+      this._builderFactories);
+
+  void add(Serializer serializer) {
+    if (serializer is! StructuredSerializer &&
+        serializer is! PrimitiveSerializer) {
+      throw new ArgumentError(
+          'serializer must be StructuredSerializer or PrimitiveSerializer');
+    }
+
+    _wireNameToSerializer[serializer.wireName] = serializer;
+    for (final type in serializer.types) {
+      _typeToSerializer[type] = serializer;
+      _typeNameToSerializer[_getRawName(type)] = serializer;
+    }
+  }
+
+  void addBuilderFactory(FullType types, Function function) {
+    _builderFactories[types] = function;
+  }
+
+  Serializers build() {
+    return new BuiltJsonSerializers._(
+        _typeToSerializer.build(),
+        _wireNameToSerializer.build(),
+        _typeNameToSerializer.build(),
+        _builderFactories.build());
+  }
+}
+
+String _getRawName(Type type) {
+  final name = type.toString();
+  final genericsStart = name.indexOf('<');
+  return genericsStart == -1 ? name : name.substring(0, genericsStart);
+}

--- a/built_value/lib/src/built_list_serializer.dart
+++ b/built_value/lib/src/built_list_serializer.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltListSerializer implements StructuredSerializer<BuiltList> {
+  final bool structured = true;
+  final Iterable<Type> types = new BuiltList<Type>([BuiltList]);
+  final String wireName = 'list';
+
+  @override
+  Iterable serialize(Serializers serializers, BuiltList builtList,
+      {FullType specifiedType: FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    final elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    if (!isUnderspecified && !serializers.hasBuilder(specifiedType)) {
+      throw new StateError('No builder for $specifiedType, cannot serialize.');
+    }
+
+    return builtList
+        .map((item) => serializers.serialize(item, specifiedType: elementType));
+  }
+
+  @override
+  BuiltList deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    final elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    ListBuilder result = isUnderspecified
+        ? new ListBuilder<Object>()
+        : serializers.newBuilder(specifiedType) as ListBuilder;
+    if (result == null) {
+      throw new StateError(
+          'No builder for $specifiedType, cannot deserialize.');
+    }
+    result.addAll(serialized.map(
+        (item) => serializers.deserialize(item, specifiedType: elementType)));
+    return result.build();
+  }
+}

--- a/built_value/lib/src/built_map_serializer.dart
+++ b/built_value/lib/src/built_map_serializer.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltMapSerializer implements StructuredSerializer<BuiltMap> {
+  final bool structured = true;
+  final Iterable<Type> types = new BuiltList<Type>([BuiltMap]);
+  final String wireName = 'map';
+
+  @override
+  Iterable serialize(Serializers serializers, BuiltMap builtMap,
+      {FullType specifiedType: FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    final keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    final valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    if (!isUnderspecified && !serializers.hasBuilder(specifiedType)) {
+      throw new StateError('No builder for $specifiedType, cannot serialize.');
+    }
+
+    final result = <Object>[];
+    for (final key in builtMap.keys) {
+      result.add(serializers.serialize(key, specifiedType: keyType));
+      final value = builtMap[key];
+      result.add(serializers.serialize(value, specifiedType: valueType));
+    }
+    return result;
+  }
+
+  @override
+  BuiltMap deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    final keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    final valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    MapBuilder result = isUnderspecified
+        ? new MapBuilder<Object, Object>()
+        : serializers.newBuilder(specifiedType) as MapBuilder;
+    if (result == null) {
+      throw new StateError(
+          'No builder for $specifiedType, cannot deserialize.');
+    }
+
+    if (serialized.length % 2 == 1) {
+      throw new ArgumentError('odd length');
+    }
+
+    for (int i = 0; i != serialized.length; i += 2) {
+      final key = serializers.deserialize(serialized.elementAt(i),
+          specifiedType: keyType);
+      final value = serializers.deserialize(serialized.elementAt(i + 1),
+          specifiedType: valueType);
+      result[key] = value;
+    }
+
+    return result.build();
+  }
+}

--- a/built_value/lib/src/built_set_serializer.dart
+++ b/built_value/lib/src/built_set_serializer.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltSetSerializer implements StructuredSerializer<BuiltSet> {
+  final bool structured = true;
+  final Iterable<Type> types = new BuiltList<Type>([BuiltSet]);
+  final String wireName = 'set';
+
+  @override
+  Iterable serialize(Serializers serializers, BuiltSet builtSet,
+      {FullType specifiedType: FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    final elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    if (!isUnderspecified && !serializers.hasBuilder(specifiedType)) {
+      throw new StateError('No builder for $specifiedType, cannot serialize.');
+    }
+
+    return builtSet
+        .map((item) => serializers.serialize(item, specifiedType: elementType));
+  }
+
+  @override
+  BuiltSet deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    final elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    SetBuilder result = isUnderspecified
+        ? new SetBuilder<Object>()
+        : serializers.newBuilder(specifiedType) as SetBuilder;
+    if (result == null) {
+      throw new StateError(
+          'No builder for $specifiedType, cannot deserialize.');
+    }
+    result.addAll(serialized.map(
+        (item) => serializers.deserialize(item, specifiedType: elementType)));
+    return result.build();
+  }
+}

--- a/built_value/lib/src/double_serializer.dart
+++ b/built_value/lib/src/double_serializer.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+// TODO(davidmorgan): support special values.
+class DoubleSerializer implements PrimitiveSerializer<double> {
+  final bool structured = false;
+  final Iterable<Type> types = new BuiltList<Type>([double]);
+  final String wireName = 'double';
+
+  @override
+  Object serialize(Serializers serializers, double aDouble,
+      {FullType specifiedType: FullType.unspecified}) {
+    return aDouble;
+  }
+
+  @override
+  double deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return (serialized as num).toDouble();
+  }
+}

--- a/built_value/lib/src/int_serializer.dart
+++ b/built_value/lib/src/int_serializer.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class IntSerializer implements PrimitiveSerializer<int> {
+  final bool structured = false;
+  final Iterable<Type> types = new BuiltList<Type>([int]);
+  final String wireName = 'int';
+
+  @override
+  Object serialize(Serializers serializers, int integer,
+      {FullType specifiedType: FullType.unspecified}) {
+    return integer;
+  }
+
+  @override
+  int deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return serialized as int;
+  }
+}

--- a/built_value/lib/src/string_serializer.dart
+++ b/built_value/lib/src/string_serializer.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class StringSerializer implements PrimitiveSerializer<String> {
+  final bool structured = false;
+  final Iterable<Type> types = new BuiltList<Type>([String]);
+  final String wireName = 'String';
+
+  @override
+  Object serialize(Serializers serializers, String string,
+      {FullType specifiedType: FullType.unspecified}) {
+    return string;
+  }
+
+  @override
+  String deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return serialized as String;
+  }
+}

--- a/built_value/pubspec.yaml
+++ b/built_value/pubspec.yaml
@@ -1,14 +1,17 @@
 name: built_value
-version: 0.2.1
+version: 0.3.0
 description: >
-  Value types with builders, Dart classes as enums. This library is the runtime
-  dependency.
+  Value types with builders, Dart classes as enums, and serialization.
+  This library is the runtime dependency.
 authors:
 - David Morgan <davidmorgan@google.com>
 homepage: https://github.com/google/built_value.dart
 
 environment:
   sdk: '>=1.8.0 <2.0.0'
+
+dependencies:
+  built_collection: ^1.0.0
 
 dev_dependencies:
   test: any

--- a/built_value/test/bool_serializer_test.dart
+++ b/built_value/test/bool_serializer_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final serializers = new Serializers();
+
+  group('bool with known specifiedType', () {
+    final data = true;
+    final serialized = true;
+    final specifiedType = const FullType(bool);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('bool with unknown specifiedType', () {
+    final data = true;
+    final serialized = ['bool', true];
+    final specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value/test/built_list_serializer_test.dart
+++ b/built_value/test/built_list_serializer_test.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltList with known specifiedType but missing builder', () {
+    final data = new BuiltList<int>([1, 2, 3]);
+    final specifiedType =
+        const FullType(BuiltList, const [const FullType(int)]);
+    final serializers = new Serializers();
+    final serialized = [1, 2, 3];
+
+    test('serialize throws', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throws);
+    });
+
+    test('deserialize throws', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throws);
+    });
+  });
+
+  group('BuiltList with known specifiedType and correct builder', () {
+    final data = new BuiltList<int>([1, 2, 3]);
+    final specifiedType =
+        const FullType(BuiltList, const [const FullType(int)]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => new ListBuilder<int>()))
+        .build();
+    final serialized = [1, 2, 3];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType
+              .toString(),
+          'BuiltList<int>');
+    });
+  });
+
+  group('BuiltList nested with known specifiedType and correct builders', () {
+    final data = new BuiltList<BuiltList<int>>([
+      new BuiltList<int>([1, 2, 3]),
+      new BuiltList<int>([4, 5, 6]),
+      new BuiltList<int>([7, 8, 9])
+    ]);
+    final specifiedType = const FullType(BuiltList, const [
+      const FullType(BuiltList, const [const FullType(int)])
+    ]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => new ListBuilder<BuiltList<int>>())
+          ..addBuilderFactory(
+              const FullType(BuiltList, const [const FullType(int)]),
+              () => new ListBuilder<int>()))
+        .build();
+    final serialized = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltList with unknown specifiedType and no builders', () {
+    final data = new BuiltList<int>([1, 2, 3]);
+    final specifiedType = FullType.unspecified;
+    final serializers = new Serializers();
+    final serialized = [
+      'list',
+      ['int', 1],
+      ['int', 2],
+      ['int', 3]
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value/test/built_map_serializer_test.dart
+++ b/built_value/test/built_map_serializer_test.dart
@@ -1,0 +1,292 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltMap with known specifiedType but missing builder', () {
+    final data = new BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+    final specifiedType = const FullType(
+        BuiltMap, const [const FullType(int), const FullType(String)]);
+    final serializers = new Serializers();
+    final serialized = [1, 'one', 2, 'two', 3, 'three'];
+
+    test('cannot be serialized', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throws);
+    });
+
+    test('cannot be deserialized', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throws);
+    });
+  });
+
+  group('BuiltMap with known specifiedType and correct builder', () {
+    final data = new BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+    final specifiedType = const FullType(
+        BuiltMap, const [const FullType(int), const FullType(String)]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => new MapBuilder<int, String>()))
+        .build();
+    final serialized = [1, 'one', 2, 'two', 3, 'three'];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType
+              .toString(),
+          'BuiltMap<int, String>');
+    });
+  });
+
+  group('BuiltMap nested left with known specifiedType', () {
+    final data = new BuiltMap<BuiltMap<int, String>, String>({
+      new BuiltMap<int, String>({1: 'one'}): 'one!',
+      new BuiltMap<int, String>({2: 'two'}): 'two!'
+    });
+    const innerTypeLeft = const FullType(
+        BuiltMap, const [const FullType(int), const FullType(String)]);
+    final specifiedType =
+        const FullType(BuiltMap, const [innerTypeLeft, const FullType(String)]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              innerTypeLeft, () => new MapBuilder<int, String>())
+          ..addBuilderFactory(specifiedType,
+              () => new MapBuilder<BuiltMap<int, String>, String>()))
+        .build();
+    final serialized = [
+      [1, 'one'],
+      'one!',
+      [2, 'two'],
+      'two!'
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap nested right with known specifiedType', () {
+    final data = new BuiltMap<int, BuiltMap<String, String>>({
+      1: new BuiltMap<String, String>({'one': 'one!'}),
+      2: new BuiltMap<String, String>({'two': 'two!'})
+    });
+    const innerTypeRight = const FullType(
+        BuiltMap, const [const FullType(String), const FullType(String)]);
+    final specifiedType =
+        const FullType(BuiltMap, const [const FullType(int), innerTypeRight]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              innerTypeRight, () => new MapBuilder<String, String>())
+          ..addBuilderFactory(specifiedType,
+              () => new MapBuilder<int, BuiltMap<String, String>>()))
+        .build();
+    final serialized = [
+      1,
+      ['one', 'one!'],
+      2,
+      ['two', 'two!']
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap nested both with known specifiedType', () {
+    final data = new BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>({
+      new BuiltMap<int, int>({1: 1}):
+          new BuiltMap<String, String>({'one': 'one!'}),
+      new BuiltMap<int, int>({2: 2}):
+          new BuiltMap<String, String>({'two': 'two!'})
+    });
+    const builtMapOfIntIntGenericType = const FullType(
+        BuiltMap, const [const FullType(int), const FullType(int)]);
+    const builtMapOfStringStringGenericType = const FullType(
+        BuiltMap, const [const FullType(String), const FullType(String)]);
+    final specifiedType = const FullType(BuiltMap,
+        const [builtMapOfIntIntGenericType, builtMapOfStringStringGenericType]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              builtMapOfIntIntGenericType, () => new MapBuilder<int, int>())
+          ..addBuilderFactory(builtMapOfStringStringGenericType,
+              () => new MapBuilder<String, String>())
+          ..addBuilderFactory(
+              specifiedType,
+              () => new MapBuilder<BuiltMap<int, int>,
+                  BuiltMap<String, String>>()))
+        .build();
+    final serialized = [
+      [1, 1],
+      ['one', 'one!'],
+      [2, 2],
+      ['two', 'two!']
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type on deserialization', () {
+      final genericSerializer = (serializers.toBuilder()
+            ..addBuilderFactory(
+                specifiedType,
+                () => new MapBuilder<BuiltMap<int, int>,
+                    BuiltMap<String, String>>())
+            ..addBuilderFactory(
+                builtMapOfIntIntGenericType, () => new MapBuilder<int, int>())
+            ..addBuilderFactory(builtMapOfStringStringGenericType,
+                () => new MapBuilder<String, String>()))
+          .build();
+
+      expect(
+          genericSerializer
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType
+              .toString(),
+          'BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>');
+    });
+  });
+
+  group('BuiltMap with Object values', () {
+    final data = new BuiltMap<int, Object>({1: 'one', 2: 2, 3: 'three'});
+    final specifiedType = const FullType(
+        BuiltMap, const [const FullType(int), FullType.unspecified]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => new MapBuilder<int, Object>()))
+        .build();
+    final serialized = [
+      1,
+      ['String', 'one'],
+      2,
+      ['int', 2],
+      3,
+      ['String', 'three']
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap with Object keys', () {
+    final data =
+        new BuiltMap<Object, String>({1: 'one', 'two': 'two', 3: 'three'});
+    final specifiedType = const FullType(
+        BuiltMap, const [FullType.unspecified, const FullType(String)]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => new MapBuilder<Object, String>()))
+        .build();
+    final serialized = [
+      ['int', 1],
+      'one',
+      ['String', 'two'],
+      'two',
+      ['int', 3],
+      'three'
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap with Object keys and values', () {
+    final data = new BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
+    final specifiedType = const FullType(BuiltMap);
+    final serializers = new Serializers();
+    final serialized = [
+      ['int', 1],
+      ['String', 'one'],
+      ['String', 'two'],
+      ['int', 2],
+      ['int', 3],
+      ['String', 'three']
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap with unknown specifiedType', () {
+    final data = new BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
+    final specifiedType = FullType.unspecified;
+    final serializers = new Serializers();
+    final serialized = [
+      'map',
+      ['int', 1],
+      ['String', 'one'],
+      ['String', 'two'],
+      ['int', 2],
+      ['int', 3],
+      ['String', 'three']
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value/test/built_set_serializer_test.dart
+++ b/built_value/test/built_set_serializer_test.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+// Note: BuiltSet preserves order, so comparisons in these tests can assume a
+// specific ordering. In fact, these tests are exactly the BuiltListSerializer
+// tests with "list" replaced by "set".
+void main() {
+  group('BuiltSet with known specifiedType but missing builder', () {
+    final data = new BuiltSet<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltSet, const [const FullType(int)]);
+    final serializers = new Serializers();
+    final serialized = [1, 2, 3];
+
+    test('serialize throws', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throws);
+    });
+
+    test('deserialize throws', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throws);
+    });
+  });
+
+  group('BuiltSet with known specifiedType and correct builder', () {
+    final data = new BuiltSet<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltSet, const [const FullType(int)]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => new SetBuilder<int>()))
+        .build();
+    final serialized = [1, 2, 3];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType
+              .toString(),
+          'BuiltSet<int>');
+    });
+  });
+
+  group('BuiltSet nested with known specifiedType and correct builders', () {
+    final data = new BuiltSet<BuiltSet<int>>([
+      new BuiltSet<int>([1, 2, 3]),
+      new BuiltSet<int>([4, 5, 6]),
+      new BuiltSet<int>([7, 8, 9])
+    ]);
+    final specifiedType = const FullType(BuiltSet, const [
+      const FullType(BuiltSet, const [const FullType(int)])
+    ]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => new SetBuilder<BuiltSet<int>>())
+          ..addBuilderFactory(
+              const FullType(BuiltSet, const [const FullType(int)]),
+              () => new SetBuilder<int>()))
+        .build();
+    final serialized = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltSet with unknown specifiedType and no builders', () {
+    final data = new BuiltSet<int>([1, 2, 3]);
+    final specifiedType = FullType.unspecified;
+    final serializers = new Serializers();
+    final serialized = [
+      'set',
+      ['int', 1],
+      ['int', 2],
+      ['int', 3]
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value/test/double_serializer_test.dart
+++ b/built_value/test/double_serializer_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final serializers = new Serializers();
+
+  group('double with known specifiedType', () {
+    final data = 3.141592653589793;
+    final serialized = data;
+    final specifiedType = const FullType(double);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('double with unknown specifiedType', () {
+    final data = 3.141592653589793;
+    final serialized = ['double', data];
+    final specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value/test/int_serializer_test.dart
+++ b/built_value/test/int_serializer_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final serializers = new Serializers();
+
+  group('int with known specifiedType', () {
+    final data = 42;
+    final serialized = 42;
+    final specifiedType = const FullType(int);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('int with unknown specifiedType', () {
+    final data = 42;
+    final serialized = ['int', 42];
+    final specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value/test/string_serializer_test.dart
+++ b/built_value/test/string_serializer_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final serializers = new Serializers();
+
+  group('String with known specifiedType', () {
+    final data = 'testing, testing';
+    final serialized = 'testing, testing';
+    final specifiedType = const FullType(String);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('String with unknown specifiedType', () {
+    final data = 'testing, testing';
+    final serialized = ['String', 'testing, testing'];
+    final specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value_generator/lib/built_value_generator.dart
+++ b/built_value_generator/lib/built_value_generator.dart
@@ -8,8 +8,9 @@ import 'dart:async';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
-import 'package:built_value_generator/src/value_source_class.dart';
 import 'package:built_value_generator/src/enum_source_library.dart';
+import 'package:built_value_generator/src/value_source_class.dart';
+import 'package:built_value_generator/src/serializer_source_library.dart';
 import 'package:source_gen/source_gen.dart';
 
 /// Generator for Enum Class and Built Values.
@@ -21,7 +22,17 @@ class BuiltValueGenerator extends Generator {
     if (element is ClassElement && ValueSourceClass.needsBuiltValue(element)) {
       return new ValueSourceClass.fromClassElement(element).generateCode();
     } else if (element is LibraryElement) {
-      return new EnumSourceLibrary.fromLibraryElement(element).generateCode();
+      final enumCode =
+          new EnumSourceLibrary.fromLibraryElement(element).generateCode();
+
+      final serializerSourceLibrary =
+          SerializerSourceLibrary.fromLibraryElement(element);
+      if (serializerSourceLibrary.needsBuiltJson ||
+          serializerSourceLibrary.hasSerializers) {
+        return (enumCode ?? '') + '\n' + serializerSourceLibrary.generate();
+      } else {
+        return enumCode;
+      }
     } else {
       return null;
     }

--- a/built_value_generator/lib/src/built_parameters_visitor.dart
+++ b/built_value_generator/lib/src/built_parameters_visitor.dart
@@ -17,8 +17,7 @@ class BuiltParametersVisitor extends RecursiveAstVisitor {
   @override
   void visitImplementsClause(ImplementsClause implementsClause) {
     for (final interface in implementsClause.interfaces) {
-      result ??=
-          _extractParameters('Built<', interface.toString());
+      result ??= _extractParameters('Built<', interface.toString());
     }
   }
 

--- a/built_value_generator/lib/src/library_elements.dart
+++ b/built_value_generator/lib/src/library_elements.dart
@@ -14,6 +14,17 @@ class LibraryElements {
     libraryElement.visitChildren(result);
     return new BuiltList<ClassElement>(result.classElements);
   }
+
+  static BuiltList<ClassElement> getTransitiveClassElements(
+      LibraryElement libraryElement) {
+    final result = new ListBuilder<ClassElement>();
+    for (final source in libraryElement.context.librarySources) {
+      final otherLibraryElement =
+          libraryElement.context.computeLibraryElement(source);
+      result.addAll(getClassElements(otherLibraryElement));
+    }
+    return result.build();
+  }
 }
 
 /// Visitor that gets all [ClassElement]s.

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -1,0 +1,212 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_class;
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/serializer_source_field.dart';
+
+part 'serializer_source_class.g.dart';
+
+abstract class SerializerSourceClass
+    implements Built<SerializerSourceClass, SerializerSourceClassBuilder> {
+  String get name;
+  bool get isBuiltValue;
+  bool get isEnumClass;
+  BuiltList<SerializerSourceField> get fields;
+
+  factory SerializerSourceClass([updates(SerializerSourceClassBuilder b)]) =
+      _$SerializerSourceClass;
+  SerializerSourceClass._();
+
+  static SerializerSourceClass fromClassElements(
+      ClassElement classElement, ClassElement builderClassElement) {
+    final result = new SerializerSourceClassBuilder();
+
+    result.name = classElement.name;
+
+    // TODO(davidmorgan): better check.
+    result.isBuiltValue = classElement.allSupertypes
+            .map((type) => type.name)
+            .any((name) => name.startsWith('Built')) &&
+        !classElement.name.startsWith(r'_$') &&
+        classElement.fields.any((field) => field.name == 'serializer');
+
+    // TODO(davidmorgan): better check.
+    result.isEnumClass = classElement.allSupertypes
+            .map((type) => type.name)
+            .any((name) => name == 'EnumClass') &&
+        !classElement.name.startsWith(r'_$') &&
+        classElement.fields.any((field) => field.name == 'serializer');
+
+    for (final fieldElement in classElement.fields) {
+      final builderFieldElement =
+          builderClassElement?.getField(fieldElement.displayName);
+      final sourceField = SerializerSourceField.fromFieldElements(
+          fieldElement, builderFieldElement);
+      if (sourceField.isSerializable) {
+        result.fields.add(sourceField);
+      }
+    }
+
+    return result.build();
+  }
+
+  bool get needsBuiltJson => isBuiltValue || isEnumClass;
+
+  String generateTransitiveSerializerAdder() {
+    return '..add(${name}.serializer)';
+  }
+
+  String generateBuilderFactoryAdders() {
+    return fields
+        .where((field) => field.needsBuilder)
+        .map((field) =>
+            '..addBuilderFactory(${field.generateFullType()}, () => ${field.generateBuilder()})')
+        .join('\n');
+  }
+
+  String generateSerializerDeclaration() {
+    final camelCaseName = _toCamelCase(name);
+    return 'Serializer<$name> '
+        '_\$${camelCaseName}Serializer = '
+        'new _\$${name}Serializer();';
+  }
+
+  String generateSerializer() {
+    if (isBuiltValue) {
+      return '''
+class _\$${name}Serializer implements StructuredSerializer<$name> {
+  final Iterable<Type> types = const [$name, _\$$name];
+  final String wireName = '$name';
+
+  @override
+  Iterable serialize(Serializers serializers, $name object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [${_generateRequiredFieldSerializers()}];
+    ${_generateNullableFieldSerializers()}
+    return result;
+  }
+
+  @override
+  $name deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ${name}Builder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          ${_generateFieldDeserializers()}
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+''';
+    } else if (isEnumClass) {
+      return '''
+class _\$${name}Serializer implements PrimitiveSerializer<$name> {
+  final Iterable<Type> types = const [$name];
+  final String wireName = '$name';
+
+  @override
+  Object serialize(Serializers serializers, $name object,
+      {FullType specifiedType: FullType.unspecified}) {
+    return object.name;
+  }
+
+  @override
+  $name deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return ${name}.valueOf(serialized);
+  }
+}
+''';
+    } else {
+      throw new UnsupportedError('not serializable');
+    }
+  }
+
+  String _generateRequiredFieldSerializers() {
+    return fields
+        .where((field) => !field.isNullable)
+        .map((field) => "'${field.name}', "
+            "serializers.serialize(object.${field.name}, "
+            "specifiedType: ${field.generateFullType()}),")
+        .join('');
+  }
+
+  String _generateNullableFieldSerializers() {
+    return fields.where((field) => field.isNullable).map((field) => '''
+    if (object.${field.name} != null) {
+      result.add('${field.name}');
+      result.add(serializers.serialize(
+          object.${field.name}, specifiedType: ${field.generateFullType()}));
+    }
+''').join('');
+  }
+
+  String _generateFieldDeserializers() {
+    return fields.map((field) {
+      if (field.builderFieldUsesNestedBuilder) {
+        return '''
+case '${field.name}':
+  result.${field.name}.replace(serializers.deserialize(
+      value, specifiedType: ${field.generateFullType()}));
+  break;
+''';
+      } else {
+        return '''
+case '${field.name}':
+  result.${field.name} = serializers.deserialize(
+      value, specifiedType: ${field.generateFullType()});
+  break;
+''';
+      }
+    }).join('');
+  }
+
+  static String _toCamelCase(String name) {
+    var result = '';
+    var upperCase = false;
+    var firstCharacter = true;
+    for (final char in name.split('')) {
+      if (char == '_') {
+        upperCase = true;
+      } else {
+        result += firstCharacter
+            ? char.toLowerCase()
+            : (upperCase ? char.toUpperCase() : char);
+        upperCase = false;
+        firstCharacter = false;
+      }
+    }
+    return result;
+  }
+}
+
+abstract class SerializerSourceClassBuilder
+    implements Builder<SerializerSourceClass, SerializerSourceClassBuilder> {
+  String name;
+  bool isBuiltValue;
+  bool isEnumClass;
+  ListBuilder<SerializerSourceField> fields =
+      new ListBuilder<SerializerSourceField>();
+
+  factory SerializerSourceClassBuilder() = _$SerializerSourceClassBuilder;
+  SerializerSourceClassBuilder._();
+}

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -1,0 +1,79 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of built_value_generator.source_class;
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class SerializerSourceClass
+// **************************************************************************
+
+class _$SerializerSourceClass extends SerializerSourceClass {
+  final String name;
+  final bool isBuiltValue;
+  final bool isEnumClass;
+  final BuiltList<SerializerSourceField> fields;
+
+  _$SerializerSourceClass._(
+      {this.name, this.isBuiltValue, this.isEnumClass, this.fields})
+      : super._() {
+    if (name == null) throw new ArgumentError.notNull('name');
+    if (isBuiltValue == null) throw new ArgumentError.notNull('isBuiltValue');
+    if (isEnumClass == null) throw new ArgumentError.notNull('isEnumClass');
+    if (fields == null) throw new ArgumentError.notNull('fields');
+  }
+
+  factory _$SerializerSourceClass([updates(SerializerSourceClassBuilder b)]) =>
+      (new SerializerSourceClassBuilder()..update(updates)).build();
+
+  SerializerSourceClass rebuild(updates(SerializerSourceClassBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  _$SerializerSourceClassBuilder toBuilder() =>
+      new _$SerializerSourceClassBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! SerializerSourceClass) return false;
+    return name == other.name &&
+        isBuiltValue == other.isBuiltValue &&
+        isEnumClass == other.isEnumClass &&
+        fields == other.fields;
+  }
+
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc(0, name.hashCode), isBuiltValue.hashCode),
+            isEnumClass.hashCode),
+        fields.hashCode));
+  }
+
+  String toString() {
+    return 'SerializerSourceClass {'
+        'name=${name.toString()},\n'
+        'isBuiltValue=${isBuiltValue.toString()},\n'
+        'isEnumClass=${isEnumClass.toString()},\n'
+        'fields=${fields.toString()},\n'
+        '}';
+  }
+}
+
+class _$SerializerSourceClassBuilder extends SerializerSourceClassBuilder {
+  _$SerializerSourceClassBuilder() : super._();
+  void replace(SerializerSourceClass other) {
+    super.name = other.name;
+    super.isBuiltValue = other.isBuiltValue;
+    super.isEnumClass = other.isEnumClass;
+    super.fields = other.fields?.toBuilder();
+  }
+
+  void update(updates(SerializerSourceClassBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  SerializerSourceClass build() {
+    return new _$SerializerSourceClass._(
+        name: name,
+        isBuiltValue: isBuiltValue,
+        isEnumClass: isEnumClass,
+        fields: fields?.build());
+  }
+}

--- a/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_value_generator/lib/src/serializer_source_field.dart
@@ -1,0 +1,137 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_field;
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+
+part 'serializer_source_field.g.dart';
+
+BuiltSet<String> _builtCollectionNames = new BuiltSet<String>([
+  'BuiltList',
+  'BuiltListMultimap',
+  'BuiltMap',
+  'BuiltSet',
+  'BuiltSetMultimap',
+]);
+
+abstract class SerializerSourceField
+    implements Built<SerializerSourceField, SerializerSourceFieldBuilder> {
+  static final BuiltMap<String, String> typesWithBuilder =
+      new BuiltMap<String, String>({
+    'BuiltList': 'ListBuilder',
+    'BuiltMap': 'MapBuilder',
+    'BuiltSet': 'SetBuilder',
+  });
+
+  bool get isSerializable;
+  bool get isNullable;
+  String get name;
+  String get type;
+  bool get builderFieldUsesNestedBuilder;
+
+  factory SerializerSourceField([updates(SerializerSourceFieldBuilder b)]) =
+      _$SerializerSourceField;
+  SerializerSourceField._();
+
+  String get rawType => _getBareType(type);
+
+  static SerializerSourceField fromFieldElements(
+      FieldElement fieldElement, FieldElement builderFieldElement) {
+    final result = new SerializerSourceFieldBuilder();
+    final isSerializable = fieldElement.getter != null &&
+        fieldElement.getter.isAbstract &&
+        !fieldElement.isStatic;
+
+    result.isSerializable = isSerializable;
+
+    if (isSerializable) {
+      result.isNullable = fieldElement.getter.metadata.any(
+          (metadata) => metadata.constantValue.toStringValue() == 'nullable');
+      result.name = fieldElement.displayName;
+      result.type = fieldElement.getter.returnType.displayName;
+
+      // If the builder is present, check it to determine whether a nested
+      // builder is needed. Otherwise, use the same logic as built_value when
+      // it decides whether to use a nested builder.
+      result.builderFieldUsesNestedBuilder = builderFieldElement == null
+          ? _needsNestedBuilder(fieldElement.getter.returnType)
+          : fieldElement.getter.returnType.displayName !=
+              builderFieldElement.getter.returnType.displayName;
+    }
+
+    return result.build();
+  }
+
+  String generateFullType() {
+    return _generateFullType(type);
+  }
+
+  bool get needsBuilder => typesWithBuilder.containsKey(_getBareType(type));
+
+  String generateBuilder() {
+    return 'new ${typesWithBuilder[_getBareType(type)]}<${_getGenerics(type)}>()';
+  }
+
+  static String _generateFullType(String type) {
+    // TODO(davidmorgan): support more than one level of nesting.
+    final bareType = _getBareType(type);
+    final generics = _getGenerics(type);
+    final genericItems = generics.split(', ');
+
+    if (generics.isEmpty) {
+      return 'const FullType($bareType)';
+    } else {
+      return 'const FullType($bareType, const [${genericItems.map(_generateFullType).join(', ')}])';
+    }
+  }
+
+  static String _getBareType(String name) {
+    final genericsStart = name.indexOf('<');
+    return genericsStart == -1 ? name : name.substring(0, genericsStart);
+  }
+
+  static String _getGenerics(String name) {
+    final genericsStart = name.indexOf('<');
+    return genericsStart == -1
+        ? ''
+        : name
+            .substring(genericsStart + 1)
+            .substring(0, name.length - genericsStart - 2);
+  }
+
+  // These three methods are copied from built_value to match the behaviour
+  // when a builder is not explicitly defined.
+  // TODO(davidmorgan): dedupe.
+  static bool _needsNestedBuilder(DartType type) {
+    return _isBuiltValue(type) || _isBuiltCollection(type);
+  }
+
+  static bool _isBuiltValue(DartType type) {
+    if (type.element is! ClassElement) return false;
+    return (type.element as ClassElement)
+        .allSupertypes
+        .any((interfaceType) => interfaceType.name == 'Built');
+  }
+
+  static bool _isBuiltCollection(DartType type) {
+    return _builtCollectionNames
+        .any((name) => type.displayName.startsWith('${name}<'));
+  }
+}
+
+abstract class SerializerSourceFieldBuilder
+    implements Builder<SerializerSourceField, SerializerSourceFieldBuilder> {
+  bool isSerializable;
+  bool isNullable = false;
+  String name = '';
+  String type = '';
+  bool builderFieldUsesNestedBuilder = false;
+
+  factory SerializerSourceFieldBuilder() = _$SerializerSourceFieldBuilder;
+  SerializerSourceFieldBuilder._();
+}

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -1,0 +1,93 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of built_value_generator.source_field;
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class SerializerSourceField
+// **************************************************************************
+
+class _$SerializerSourceField extends SerializerSourceField {
+  final bool isSerializable;
+  final bool isNullable;
+  final String name;
+  final String type;
+  final bool builderFieldUsesNestedBuilder;
+
+  _$SerializerSourceField._(
+      {this.isSerializable,
+      this.isNullable,
+      this.name,
+      this.type,
+      this.builderFieldUsesNestedBuilder})
+      : super._() {
+    if (isSerializable == null)
+      throw new ArgumentError.notNull('isSerializable');
+    if (isNullable == null) throw new ArgumentError.notNull('isNullable');
+    if (name == null) throw new ArgumentError.notNull('name');
+    if (type == null) throw new ArgumentError.notNull('type');
+    if (builderFieldUsesNestedBuilder == null)
+      throw new ArgumentError.notNull('builderFieldUsesNestedBuilder');
+  }
+
+  factory _$SerializerSourceField([updates(SerializerSourceFieldBuilder b)]) =>
+      (new SerializerSourceFieldBuilder()..update(updates)).build();
+
+  SerializerSourceField rebuild(updates(SerializerSourceFieldBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  _$SerializerSourceFieldBuilder toBuilder() =>
+      new _$SerializerSourceFieldBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! SerializerSourceField) return false;
+    return isSerializable == other.isSerializable &&
+        isNullable == other.isNullable &&
+        name == other.name &&
+        type == other.type &&
+        builderFieldUsesNestedBuilder == other.builderFieldUsesNestedBuilder;
+  }
+
+  int get hashCode {
+    return $jf($jc(
+        $jc(
+            $jc($jc($jc(0, isSerializable.hashCode), isNullable.hashCode),
+                name.hashCode),
+            type.hashCode),
+        builderFieldUsesNestedBuilder.hashCode));
+  }
+
+  String toString() {
+    return 'SerializerSourceField {'
+        'isSerializable=${isSerializable.toString()},\n'
+        'isNullable=${isNullable.toString()},\n'
+        'name=${name.toString()},\n'
+        'type=${type.toString()},\n'
+        'builderFieldUsesNestedBuilder=${builderFieldUsesNestedBuilder.toString()},\n'
+        '}';
+  }
+}
+
+class _$SerializerSourceFieldBuilder extends SerializerSourceFieldBuilder {
+  _$SerializerSourceFieldBuilder() : super._();
+  void replace(SerializerSourceField other) {
+    super.isSerializable = other.isSerializable;
+    super.isNullable = other.isNullable;
+    super.name = other.name;
+    super.type = other.type;
+    super.builderFieldUsesNestedBuilder = other.builderFieldUsesNestedBuilder;
+  }
+
+  void update(updates(SerializerSourceFieldBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  SerializerSourceField build() {
+    return new _$SerializerSourceField._(
+        isSerializable: isSerializable,
+        isNullable: isNullable,
+        name: name,
+        type: type,
+        builderFieldUsesNestedBuilder: builderFieldUsesNestedBuilder);
+  }
+}

--- a/built_value_generator/lib/src/serializer_source_library.dart
+++ b/built_value_generator/lib/src/serializer_source_library.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_library;
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/library_elements.dart';
+import 'package:built_value_generator/src/serializer_source_class.dart';
+
+part 'serializer_source_library.g.dart';
+
+abstract class SerializerSourceLibrary
+    implements Built<SerializerSourceLibrary, SerializerSourceLibraryBuilder> {
+  bool get hasSerializers;
+  BuiltSet<SerializerSourceClass> get sourceClasses;
+  BuiltSet<SerializerSourceClass> get transitiveSourceClasses;
+
+  factory SerializerSourceLibrary([updates(SerializerSourceLibraryBuilder b)]) =
+      _$SerializerSourceLibrary;
+  SerializerSourceLibrary._();
+
+  static SerializerSourceLibrary fromLibraryElement(
+      LibraryElement libraryElement) {
+    final result = new SerializerSourceLibraryBuilder();
+
+    // TODO(davidmorgan): better way of checking for top level declaration.
+    result.hasSerializers = libraryElement.definingCompilationUnit.accessors
+        .any((element) => element.displayName == 'serializers');
+
+    final classElements = LibraryElements.getClassElements(libraryElement);
+    for (final classElement in classElements) {
+      final builderClassElement =
+          libraryElement.getType(classElement.displayName + 'Builder');
+      final sourceClass = SerializerSourceClass.fromClassElements(
+          classElement, builderClassElement);
+      if (sourceClass.needsBuiltJson) {
+        result.sourceClasses.add(sourceClass);
+      }
+    }
+
+    final transitiveClassElements =
+        LibraryElements.getTransitiveClassElements(libraryElement);
+    for (final classElement in transitiveClassElements) {
+      final sourceClass =
+          SerializerSourceClass.fromClassElements(classElement, null);
+      if (sourceClass.needsBuiltJson) {
+        result.transitiveSourceClasses.add(sourceClass);
+      }
+    }
+
+    return result.build();
+  }
+
+  bool get needsBuiltJson => sourceClasses.isNotEmpty;
+
+  /// Generates serializer source for this library.
+  String generate() {
+    return (hasSerializers
+            ? 'Serializers _\$serializers = (new Serializers().toBuilder()' +
+                transitiveSourceClasses
+                    .map((sourceClass) =>
+                        sourceClass.generateTransitiveSerializerAdder() +
+                        '\n' +
+                        sourceClass.generateBuilderFactoryAdders())
+                    .join('\n') +
+                ').build();'
+            : '') +
+        sourceClasses
+            .map((sourceClass) => sourceClass.generateSerializerDeclaration())
+            .join('\n') +
+        sourceClasses
+            .map((sourceClass) => sourceClass.generateSerializer())
+            .join('\n');
+  }
+}
+
+abstract class SerializerSourceLibraryBuilder
+    implements
+        Builder<SerializerSourceLibrary, SerializerSourceLibraryBuilder> {
+  bool hasSerializers = false;
+  SetBuilder<SerializerSourceClass> sourceClasses =
+      new SetBuilder<SerializerSourceClass>();
+  SetBuilder<SerializerSourceClass> transitiveSourceClasses =
+      new SetBuilder<SerializerSourceClass>();
+
+  factory SerializerSourceLibraryBuilder() = _$SerializerSourceLibraryBuilder;
+  SerializerSourceLibraryBuilder._();
+}

--- a/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -1,0 +1,74 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of built_value_generator.source_library;
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class SerializerSourceLibrary
+// **************************************************************************
+
+class _$SerializerSourceLibrary extends SerializerSourceLibrary {
+  final bool hasSerializers;
+  final BuiltSet<SerializerSourceClass> sourceClasses;
+  final BuiltSet<SerializerSourceClass> transitiveSourceClasses;
+
+  _$SerializerSourceLibrary._(
+      {this.hasSerializers, this.sourceClasses, this.transitiveSourceClasses})
+      : super._() {
+    if (hasSerializers == null)
+      throw new ArgumentError.notNull('hasSerializers');
+    if (sourceClasses == null) throw new ArgumentError.notNull('sourceClasses');
+    if (transitiveSourceClasses == null)
+      throw new ArgumentError.notNull('transitiveSourceClasses');
+  }
+
+  factory _$SerializerSourceLibrary(
+          [updates(SerializerSourceLibraryBuilder b)]) =>
+      (new SerializerSourceLibraryBuilder()..update(updates)).build();
+
+  SerializerSourceLibrary rebuild(updates(SerializerSourceLibraryBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  _$SerializerSourceLibraryBuilder toBuilder() =>
+      new _$SerializerSourceLibraryBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! SerializerSourceLibrary) return false;
+    return hasSerializers == other.hasSerializers &&
+        sourceClasses == other.sourceClasses &&
+        transitiveSourceClasses == other.transitiveSourceClasses;
+  }
+
+  int get hashCode {
+    return $jf($jc($jc($jc(0, hasSerializers.hashCode), sourceClasses.hashCode),
+        transitiveSourceClasses.hashCode));
+  }
+
+  String toString() {
+    return 'SerializerSourceLibrary {'
+        'hasSerializers=${hasSerializers.toString()},\n'
+        'sourceClasses=${sourceClasses.toString()},\n'
+        'transitiveSourceClasses=${transitiveSourceClasses.toString()},\n'
+        '}';
+  }
+}
+
+class _$SerializerSourceLibraryBuilder extends SerializerSourceLibraryBuilder {
+  _$SerializerSourceLibraryBuilder() : super._();
+  void replace(SerializerSourceLibrary other) {
+    super.hasSerializers = other.hasSerializers;
+    super.sourceClasses = other.sourceClasses?.toBuilder();
+    super.transitiveSourceClasses = other.transitiveSourceClasses?.toBuilder();
+  }
+
+  void update(updates(SerializerSourceLibraryBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  SerializerSourceLibrary build() {
+    return new _$SerializerSourceLibrary._(
+        hasSerializers: hasSerializers,
+        sourceClasses: sourceClasses?.build(),
+        transitiveSourceClasses: transitiveSourceClasses?.build());
+  }
+}

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -146,8 +146,7 @@ abstract class ValueSourceClass
     final expectedFactory =
         'factory $name([updates(${name}Builder b)]) = _\$$name;';
     if (!valueClassFactories.any((factory) => factory == expectedFactory)) {
-      result.add(
-          'Make class have factory: $expectedFactory');
+      result.add('Make class have factory: $expectedFactory');
     }
 
     return result;

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -1,8 +1,8 @@
 name: built_value_generator
-version: 0.2.1
+version: 0.3.0
 description: >
-  Value types with builders, Dart classes as enums. This library is the dev
-  dependency.
+  Value types with builders, Dart classes as enums, and serialization.
+  This library is the dev dependency.
 authors:
 - David Morgan <davidmorgan@google.com>
 homepage: https://github.com/google/built_value.dart
@@ -14,7 +14,7 @@ dependencies:
   analyzer: '>=0.28.0 <0.29.0'
   build: '^0.4.0'
   built_collection: '^1.0.0'
-#  built_value: '^0.2.1'
+  #built_value: '^0.3.0'
   built_value:
     path: ../built_value
   source_gen: '>=0.5.0+03 <0.6.0'

--- a/built_value_generator/test/serializer_generator_test.dart
+++ b/built_value_generator/test/serializer_generator_test.dart
@@ -1,0 +1,480 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:built_value_generator/built_value_generator.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('generator', () {
+    test('ignores empty library', () async {
+      expect(await generate('library value;'), isEmpty);
+    });
+
+    test('ignores normal class', () async {
+      expect(await generate(r'''
+library value;
+
+class EmptyClass {}
+'''), isEmpty);
+    });
+
+    test('ignores built_value class without serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {}
+'''), isNot(contains('Serializer<Value>')));
+    });
+
+    test('generates for built_value class with serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static final Serializer<Value> serializer = _$serializer;
+}
+'''), contains('Serializer<Value>'));
+    });
+
+    test('ignores EnumClass without serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+class Enum extends EnumClass {}
+'''), isNot(contains('Serializer<Enum>')));
+    });
+
+    test('generates for EnumClass with serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+class Enum extends EnumClass {
+  static final Serializer<Enum> serializer = _$serializer;
+}
+'''), isNotEmpty);
+    });
+
+    test('generates for serializers', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+final Serializers serializers = _$serializers;
+'''), isNotEmpty);
+    });
+
+    test('generates correct serializer for built_value with primitives',
+        () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static final Serializer<Value> serializer = _$serializer;
+  bool get aBool;
+  double get aDouble;
+  int get anInt;
+  String get aString;
+}
+
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  bool aBool;
+  double aDouble;
+  int anInt;
+  String aString;
+}
+'''), contains(r'''
+Serializer<Value> _$valueSerializer = new _$ValueSerializer();
+
+class _$ValueSerializer implements StructuredSerializer<Value> {
+  final Iterable<Type> types = const [Value, _$Value];
+  final String wireName = 'Value';
+
+  @override
+  Iterable serialize(Serializers serializers, Value object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'aBool',
+      serializers.serialize(object.aBool, specifiedType: const FullType(bool)),
+      'aDouble',
+      serializers.serialize(object.aDouble,
+          specifiedType: const FullType(double)),
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+      'aString',
+      serializers.serialize(object.aString,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Value deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ValueBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'aBool':
+            result.aBool = serializers.deserialize(value,
+                specifiedType: const FullType(bool));
+            break;
+          case 'aDouble':
+            result.aDouble = serializers.deserialize(value,
+                specifiedType: const FullType(double));
+            break;
+          case 'anInt':
+            result.anInt = serializers.deserialize(value,
+                specifiedType: const FullType(int));
+            break;
+          case 'aString':
+            result.aString = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+'''));
+    });
+
+    test('generates correct serializer for built_value with nullables',
+        () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static final Serializer<Value> serializer = _$serializer;
+  bool get aBool;
+  @nullable double get aDouble;
+  @nullable int get anInt;
+}
+
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  bool aBool;
+  @nullable double aDouble;
+  @nullable int anInt;
+}
+'''), contains(r'''
+Serializer<Value> _$valueSerializer = new _$ValueSerializer();
+
+class _$ValueSerializer implements StructuredSerializer<Value> {
+  final Iterable<Type> types = const [Value, _$Value];
+  final String wireName = 'Value';
+
+  @override
+  Iterable serialize(Serializers serializers, Value object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'aBool',
+      serializers.serialize(object.aBool, specifiedType: const FullType(bool)),
+    ];
+    if (object.aDouble != null) {
+      result.add('aDouble');
+      result.add(serializers.serialize(object.aDouble,
+          specifiedType: const FullType(double)));
+    }
+    if (object.anInt != null) {
+      result.add('anInt');
+      result.add(serializers.serialize(object.anInt,
+          specifiedType: const FullType(int)));
+    }
+
+    return result;
+  }
+
+  @override
+  Value deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ValueBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'aBool':
+            result.aBool = serializers.deserialize(value,
+                specifiedType: const FullType(bool));
+            break;
+          case 'aDouble':
+            result.aDouble = serializers.deserialize(value,
+                specifiedType: const FullType(double));
+            break;
+          case 'anInt':
+            result.anInt = serializers.deserialize(value,
+                specifiedType: const FullType(int));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+'''));
+    });
+
+    test('generates correct serializer for built_value with collections',
+        () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static final Serializer<Value> serializer = _$serializer;
+  BuiltList<String> get aList;
+  BuiltMap<String, int> get aMap;
+}
+
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ListBuilder<String> aList;
+  MapBuilder<String, int> aMap;
+}
+'''), contains(r'''
+Serializer<Value> _$valueSerializer = new _$ValueSerializer();
+
+class _$ValueSerializer implements StructuredSerializer<Value> {
+  final Iterable<Type> types = const [Value, _$Value];
+  final String wireName = 'Value';
+
+  @override
+  Iterable serialize(Serializers serializers, Value object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'aList',
+      serializers.serialize(object.aList,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+      'aMap',
+      serializers.serialize(object.aMap,
+          specifiedType: const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  Value deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ValueBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'aList':
+            result.aList.replace(serializers.deserialize(value,
+                specifiedType:
+                    const FullType(BuiltList, const [const FullType(String)])));
+            break;
+          case 'aMap':
+            result.aMap.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltMap,
+                    const [const FullType(String), const FullType(int)])));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+'''));
+    });
+
+    test('generates correct serializer for nested built_value', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static final Serializer<Value> serializer = _$serializer;
+  Value get value;
+}
+
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder value;
+}
+'''), contains(r'''
+Serializer<Value> _$valueSerializer = new _$ValueSerializer();
+
+class _$ValueSerializer implements StructuredSerializer<Value> {
+  final Iterable<Type> types = const [Value, _$Value];
+  final String wireName = 'Value';
+
+  @override
+  Iterable serialize(Serializers serializers, Value object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(Value)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Value deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ValueBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'value':
+            result.value.replace(serializers.deserialize(value,
+                specifiedType: const FullType(Value)));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+'''));
+    });
+
+    test('generates correct serializer for EnumClass', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+abstract class TestEnum extends EnumClass {
+  static final Serializer<TestEnum> serializer = _$serializer;
+
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''
+Serializer<TestEnum> _$testEnumSerializer = new _$TestEnumSerializer();
+
+class _$TestEnumSerializer implements PrimitiveSerializer<TestEnum> {
+  final Iterable<Type> types = const [TestEnum];
+  final String wireName = 'TestEnum';
+
+  @override
+  Object serialize(Serializers serializers, TestEnum object,
+      {FullType specifiedType: FullType.unspecified}) {
+    return object.name;
+  }
+
+  @override
+  TestEnum deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return TestEnum.valueOf(serialized);
+  }
+}
+'''));
+    });
+  });
+}
+
+// Test setup.
+
+final String pkgName = 'pkg';
+final PackageGraph packageGraph =
+    new PackageGraph.fromRoot(new PackageNode(pkgName, null, null, null));
+
+final PhaseGroup phaseGroup = new PhaseGroup.singleAction(
+    new GeneratorBuilder([new BuiltValueGenerator()]),
+    new InputSet(pkgName, const ['lib/*.dart']));
+
+Future<String> generate(String source) async {
+  final srcs = <String, String>{
+    'test_support|lib/test_support.dart': testSupportSource,
+    '$pkgName|lib/value.dart': source,
+  };
+
+  final writer = new InMemoryAssetWriter();
+  await testPhases(phaseGroup, srcs,
+      packageGraph: packageGraph, writer: writer);
+  return writer.assets[new AssetId(pkgName, 'lib/value.g.dart')]?.value ?? '';
+}
+
+// Classes mentioned in the test input need to exist, but we don't need the
+// real versions. So just use minimal ones.
+const String testSupportSource = r'''
+const String nullable = 'nullable';
+
+class Built<V, B> {}
+
+class BuiltList<E> {}
+
+class BuiltMap<K, V> {}
+
+class EnumClass {}
+
+class Serializer<T> {}
+
+class Serializers {}
+''';

--- a/chat_example/README.md
+++ b/chat_example/README.md
@@ -1,0 +1,17 @@
+# built_value chat example
+
+A simple chat client (dart2js) and server (Dart VM).
+
+Launch the server:
+
+`dart bin/main.dart`
+
+This will immediately work in Dartium, connect to `localhost:26199`. To build for js, run:
+
+`pub build`
+
+When developing, run
+
+`dart tool/watch.dart`
+
+to continuously update generated source.

--- a/chat_example/bin/main.dart
+++ b/chat_example/bin/main.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/server/http_server_connection.dart';
+import 'package:chat_example/server/resource_server.dart';
+import 'package:chat_example/server/server.dart';
+
+void main() {
+  final server = new Server();
+  new ResourceServer().start(
+      (webSocket) => server.addConnection(new HttpServerConnection(webSocket)));
+}

--- a/chat_example/lib/client/client.dart
+++ b/chat_example/lib/client/client.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:chat_example/client/client_connection.dart';
+import 'package:chat_example/client/display.dart';
+import 'package:chat_example/data_model/data_model.dart';
+import 'package:chat_example/data_model/serializers.dart';
+
+typedef CommandRunner(String command);
+
+/// Client-side logic for built_value chat example.
+class Client {
+  final Stream<String> _keyboardInput;
+  final Display _display;
+  final ClientConnection _connection;
+
+  /// A chat client needs a keyboard, a display and a connection.
+  Client(this._keyboardInput, this._display, this._connection) {
+    _keyboardInput.listen(_runLocalCommand);
+    _connection.dataFromServer.listen(_handleServerData);
+  }
+
+  void _handleServerData(String data) {
+    final response = serializers.deserialize(JSON.decode(data));
+
+    if (response is Response) {
+      _display.add(response.render());
+    } else {
+      throw new StateError('Invalid data from server: $response');
+    }
+  }
+
+  void _runLocalCommand(String command) {
+    final handlers = <String, CommandRunner>{
+      '/away': _runAway,
+      '/help': _runHelp,
+      '/list': _runList,
+      '/login': _runLogin,
+      '/quit': _runQuit,
+      '/status': _runStatus,
+      '/tell': _runTell,
+    };
+
+    var found = false;
+    handlers.forEach((prefix, commandRunner) {
+      if (command.startsWith(prefix)) {
+        commandRunner(command);
+        found = true;
+      }
+    });
+    if (found) return;
+
+    if (command.startsWith('/')) {
+      _display.addLocal(command);
+      _display.add('Unknown command.');
+      return;
+    }
+
+    _send(new Chat((b) => b..text = command));
+  }
+
+  void _runAway(String command) {
+    _send(new Status((b) => b
+      ..message = command.substring('/away '.length)
+      ..type = StatusType.away));
+  }
+
+  void _runHelp(String command) {
+    _display.add('''Commands:
+
+/away <message> -- sets away message
+/help -- for help
+/list -- list online users
+/login <username> <password> -- log in or create new user
+/quit <message> -- quits with message
+/status <message> -- sets status message
+/tell <username> <message> -- private message
+''');
+  }
+
+  void _runList(String command) {
+    _display.addLocal(command);
+    _send(new ListUsers(
+        (b) => b..statusTypes.replace([StatusType.online, StatusType.away])));
+  }
+
+  void _runLogin(String command) {
+    final words = command.split(' ');
+    _display.addLocal('/login ${words[1]} ********');
+    _send(new Login((b) => b
+      ..username = words[1]
+      ..password = words[2]));
+  }
+
+  void _runQuit(String command) {
+    _display.addLocal(command);
+    _send(new Status((b) => b
+      ..message = command.substring('/quit '.length)
+      ..type = StatusType.offline));
+  }
+
+  void _runStatus(String command) {
+    _display.addLocal(command);
+    _display.addLocal(command);
+    _send(new Status((b) => b
+      ..message = command.substring('/status '.length)
+      ..type = StatusType.online));
+  }
+
+  void _runTell(String command) {
+    _display.addLocal(command);
+    final words = command.split(' ');
+    final targets = words[1].split(',');
+    _send(new Chat((b) => b
+      ..text = words.sublist(2).join(' ')
+      ..targets.replace(targets)));
+  }
+
+  void _send(Command command) {
+    _connection.sendToServer(JSON.encode(serializers.serialize(command)));
+  }
+}

--- a/chat_example/lib/client/client_connection.dart
+++ b/chat_example/lib/client/client_connection.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// Two-way connection between client and server; the client.
+abstract class ClientConnection {
+  Stream<String> get dataFromServer;
+
+  void sendToServer(String string);
+}

--- a/chat_example/lib/client/display.dart
+++ b/chat_example/lib/client/display.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Chat window main text display.
+abstract class Display {
+  /// Adds [text] to the display, coloured to indicate a local command.
+  void addLocal(String text);
+
+  /// Adds [text] to the display.
+  void add(String text);
+}

--- a/chat_example/lib/client/html_display.dart
+++ b/chat_example/lib/client/html_display.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:html';
+
+import 'package:chat_example/client/display.dart';
+
+/// [Display] using `dart:html`.
+class HtmlDisplay implements Display {
+  final Element _element;
+  final HtmlEscape _htmlEscape = const HtmlEscape();
+
+  factory HtmlDisplay() {
+    return new HtmlDisplay._(querySelector('#text'));
+  }
+
+  HtmlDisplay._(this._element) {
+    add('Welcome to the built_value chat example. For help, type /help.');
+  }
+
+  void addLocal(String text) {
+    _element.innerHtml +=
+        '<div class="local">${_htmlEscape.convert(text)}</div>';
+    window.scrollTo(0, document.body.scrollHeight);
+  }
+
+  void add(String text) {
+    _element.innerHtml +=
+        '${_htmlEscape.convert(text).replaceAll('\n', '<br>')}<br>';
+    window.scrollTo(0, document.body.scrollHeight);
+  }
+}

--- a/chat_example/lib/client/http_client_connection.dart
+++ b/chat_example/lib/client/http_client_connection.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:chat_example/client/client_connection.dart';
+
+/// [ClientConnection] using a web socket.
+class HttpClientConnection implements ClientConnection {
+  final WebSocket _websocket;
+  final StreamController<String> _streamController =
+      new StreamController<String>();
+
+  factory HttpClientConnection() {
+    return new HttpClientConnection._(
+        new WebSocket('ws://${window.location.host}/ws'));
+  }
+
+  HttpClientConnection._(this._websocket) {
+    _websocket.onMessage.listen((message) {
+      _streamController.add(message.data as String);
+    });
+  }
+
+  Stream<String> get dataFromServer => _streamController.stream;
+
+  void sendToServer(String data) {
+    _websocket.send(data);
+  }
+}

--- a/chat_example/lib/client/input.dart
+++ b/chat_example/lib/client/input.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:html';
+
+/// An input box using `dart:html`.
+class Input {
+  final StreamController<String> _streamController =
+      new StreamController<String>();
+
+  Input() {
+    final input = querySelector('#input') as InputElement;
+
+    input.onKeyPress.listen((keyEvent) {
+      if (keyEvent.keyCode == KeyCode.ENTER) {
+        _streamController.add(input.value);
+        input.value = '';
+      }
+    });
+  }
+
+  Stream<String> get keyboardInput => _streamController.stream;
+}

--- a/chat_example/lib/client/layout.dart
+++ b/chat_example/lib/client/layout.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:html';
+
+/// Forces focus to the input box.
+class Layout {
+  Layout() {
+    final screen = querySelector('#screen');
+    final text = querySelector('#text');
+    final input = querySelector('#input');
+
+    input.focus();
+
+    for (final element in [screen, text]) {
+      element.onClick.listen((e) {
+        input.focus();
+      });
+    }
+  }
+}

--- a/chat_example/lib/data_model/data_model.dart
+++ b/chat_example/lib/data_model/data_model.dart
@@ -1,0 +1,170 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Data model for the built_value chat example.
+library data_model;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'data_model.g.dart';
+
+/// Marker interface for classes sent from client to server.
+abstract class Command {}
+
+/// Sends a chat.
+abstract class Chat implements Built<Chat, ChatBuilder>, Command {
+  static Serializer<Chat> get serializer => _$chatSerializer;
+
+  // Chat text.
+  String get text;
+
+  /// Set of usernames to send the chat to, or empty to send to everyone.
+  BuiltSet<String> get targets;
+
+  Chat._();
+  factory Chat([updates(ChatBuilder b)]) = _$Chat;
+}
+
+/// Logs in.
+abstract class Login implements Built<Login, LoginBuilder>, Command {
+  static Serializer<Login> get serializer => _$loginSerializer;
+  String get username;
+  String get password;
+
+  Login._();
+  factory Login([updates(LoginBuilder b)]) = _$Login;
+}
+
+/// User status: online, away or offline, and a message.
+///
+/// Sent as a command, sets the current user status.
+abstract class Status implements Built<Status, StatusBuilder>, Command {
+  static Serializer<Status> get serializer => _$statusSerializer;
+  String get message;
+  StatusType get type;
+
+  Status._();
+  factory Status([updates(StatusBuilder b)]) = _$Status;
+}
+
+/// User status: online, away or offline.
+class StatusType extends EnumClass {
+  static Serializer<StatusType> serializer = _$statusTypeSerializer;
+
+  static const StatusType online = _$online;
+  static const StatusType away = _$away;
+  static const StatusType offline = _$offline;
+
+  const StatusType._(String name) : super(name);
+
+  static BuiltSet<StatusType> get values => _$stValues;
+  static StatusType valueOf(String name) => _$stValueOf(name);
+}
+
+/// Lists users, filtered by status.
+abstract class ListUsers
+    implements Built<ListUsers, ListUsersBuilder>, Command {
+  static Serializer<ListUsers> get serializer => _$listUsersSerializer;
+
+  /// Set of statuses to filter by.
+  BuiltSet<StatusType> get statusTypes;
+
+  ListUsers._();
+  factory ListUsers([updates(ListUsersBuilder b)]) = _$ListUsers;
+}
+
+/// Classes sent from server to client.
+abstract class Response {
+  String render();
+}
+
+/// Response to a login attempt.
+class LoginResponse extends EnumClass implements Response {
+  static Serializer<LoginResponse> get serializer => _$loginResponseSerializer;
+  static const LoginResponse success = _$success;
+  static const LoginResponse badPassword = _$badPassword;
+  static const LoginResponse reset = _$reset;
+
+  const LoginResponse._(String name) : super(name);
+
+  static BuiltSet<LoginResponse> get values => _$lrValues;
+  static LoginResponse valueOf(String name) => _$lrValueOf(name);
+
+  @override
+  String render() {
+    switch (this) {
+      case success:
+        return 'You have logged in successfully.';
+      case badPassword:
+        return 'Incorrect password.';
+      case reset:
+        return 'You have been logged out.';
+      default:
+        throw new StateError(this.name);
+    }
+  }
+}
+
+/// Displays a chat message.
+abstract class ShowChat implements Built<ShowChat, ShowChatBuilder>, Response {
+  static Serializer<ShowChat> get serializer => _$showChatSerializer;
+
+  /// Originator of the message.
+  String get username;
+
+  /// Whether the message is a /tell or a general message.
+  bool get private;
+
+  /// Message text.
+  String get text;
+
+  ShowChat._();
+  factory ShowChat([updates(ShowChatBuilder b)]) = _$ShowChat;
+
+  @override
+  String render() => '$username${private ? " (private)" : ""}: $text';
+}
+
+abstract class Welcome implements Built<Welcome, WelcomeBuilder>, Response {
+  static Serializer<Welcome> get serializer => _$welcomeSerializer;
+
+  BuiltList<Response> get log;
+
+  String get message;
+
+  Welcome._();
+  factory Welcome([updates(WelcomeBuilder b)]) = _$Welcome;
+
+  @override
+  String render() =>
+      log.map((response) => response.render()).join('\n') + '\n' + message;
+}
+
+/// Displays a list of users and their status messages.
+abstract class ListUsersResponse
+    implements Built<ListUsersResponse, ListUsersResponseBuilder>, Response {
+  static Serializer<ListUsersResponse> get serializer =>
+      _$listUsersResponseSerializer;
+
+  /// Map from username to status.
+  BuiltMap<String, Status> get statuses;
+
+  ListUsersResponse._();
+  factory ListUsersResponse([updates(ListUsersResponseBuilder b)]) =
+      _$ListUsersResponse;
+
+  @override
+  String render() {
+    final result = new StringBuffer('The following users are online:\n\n');
+    for (final username in statuses.keys) {
+      final status = statuses[username];
+      result.write(
+          status.message.isEmpty ? username : '$username ${status.message}');
+      result.write('\n');
+    }
+    return result.toString();
+  }
+}

--- a/chat_example/lib/data_model/data_model.g.dart
+++ b/chat_example/lib/data_model/data_model.g.dart
@@ -1,0 +1,870 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of data_model;
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: library data_model
+// **************************************************************************
+
+const StatusType _$online = const StatusType._('online');
+const StatusType _$away = const StatusType._('away');
+const StatusType _$offline = const StatusType._('offline');
+
+StatusType _$stValueOf(String name) {
+  switch (name) {
+    case 'online':
+      return _$online;
+    case 'away':
+      return _$away;
+    case 'offline':
+      return _$offline;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<StatusType> _$stValues = new BuiltSet<StatusType>(const [
+  _$online,
+  _$away,
+  _$offline,
+]);
+
+const LoginResponse _$success = const LoginResponse._('success');
+const LoginResponse _$badPassword = const LoginResponse._('badPassword');
+const LoginResponse _$reset = const LoginResponse._('reset');
+
+LoginResponse _$lrValueOf(String name) {
+  switch (name) {
+    case 'success':
+      return _$success;
+    case 'badPassword':
+      return _$badPassword;
+    case 'reset':
+      return _$reset;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<LoginResponse> _$lrValues = new BuiltSet<LoginResponse>(const [
+  _$success,
+  _$badPassword,
+  _$reset,
+]);
+
+Serializer<Chat> _$chatSerializer = new _$ChatSerializer();
+Serializer<Login> _$loginSerializer = new _$LoginSerializer();
+Serializer<Status> _$statusSerializer = new _$StatusSerializer();
+Serializer<StatusType> _$statusTypeSerializer = new _$StatusTypeSerializer();
+Serializer<ListUsers> _$listUsersSerializer = new _$ListUsersSerializer();
+Serializer<LoginResponse> _$loginResponseSerializer =
+    new _$LoginResponseSerializer();
+Serializer<ShowChat> _$showChatSerializer = new _$ShowChatSerializer();
+Serializer<Welcome> _$welcomeSerializer = new _$WelcomeSerializer();
+Serializer<ListUsersResponse> _$listUsersResponseSerializer =
+    new _$ListUsersResponseSerializer();
+
+class _$ChatSerializer implements StructuredSerializer<Chat> {
+  final Iterable<Type> types = const [Chat, _$Chat];
+  final String wireName = 'Chat';
+
+  @override
+  Iterable serialize(Serializers serializers, Chat object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'text',
+      serializers.serialize(object.text, specifiedType: const FullType(String)),
+      'targets',
+      serializers.serialize(object.targets,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  Chat deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ChatBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'text':
+            result.text = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+          case 'targets':
+            result.targets.replace(serializers.deserialize(value,
+                specifiedType:
+                    const FullType(BuiltSet, const [const FullType(String)])));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$LoginSerializer implements StructuredSerializer<Login> {
+  final Iterable<Type> types = const [Login, _$Login];
+  final String wireName = 'Login';
+
+  @override
+  Iterable serialize(Serializers serializers, Login object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'username',
+      serializers.serialize(object.username,
+          specifiedType: const FullType(String)),
+      'password',
+      serializers.serialize(object.password,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Login deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new LoginBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'username':
+            result.username = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+          case 'password':
+            result.password = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$StatusSerializer implements StructuredSerializer<Status> {
+  final Iterable<Type> types = const [Status, _$Status];
+  final String wireName = 'Status';
+
+  @override
+  Iterable serialize(Serializers serializers, Status object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'message',
+      serializers.serialize(object.message,
+          specifiedType: const FullType(String)),
+      'type',
+      serializers.serialize(object.type,
+          specifiedType: const FullType(StatusType)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Status deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new StatusBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'message':
+            result.message = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+          case 'type':
+            result.type = serializers.deserialize(value,
+                specifiedType: const FullType(StatusType));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$StatusTypeSerializer implements PrimitiveSerializer<StatusType> {
+  final Iterable<Type> types = const [StatusType];
+  final String wireName = 'StatusType';
+
+  @override
+  Object serialize(Serializers serializers, StatusType object,
+      {FullType specifiedType: FullType.unspecified}) {
+    return object.name;
+  }
+
+  @override
+  StatusType deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return StatusType.valueOf(serialized);
+  }
+}
+
+class _$ListUsersSerializer implements StructuredSerializer<ListUsers> {
+  final Iterable<Type> types = const [ListUsers, _$ListUsers];
+  final String wireName = 'ListUsers';
+
+  @override
+  Iterable serialize(Serializers serializers, ListUsers object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'statusTypes',
+      serializers.serialize(object.statusTypes,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(StatusType)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ListUsers deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ListUsersBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'statusTypes':
+            result.statusTypes.replace(serializers.deserialize(value,
+                specifiedType: const FullType(
+                    BuiltSet, const [const FullType(StatusType)])));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$LoginResponseSerializer implements PrimitiveSerializer<LoginResponse> {
+  final Iterable<Type> types = const [LoginResponse];
+  final String wireName = 'LoginResponse';
+
+  @override
+  Object serialize(Serializers serializers, LoginResponse object,
+      {FullType specifiedType: FullType.unspecified}) {
+    return object.name;
+  }
+
+  @override
+  LoginResponse deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return LoginResponse.valueOf(serialized);
+  }
+}
+
+class _$ShowChatSerializer implements StructuredSerializer<ShowChat> {
+  final Iterable<Type> types = const [ShowChat, _$ShowChat];
+  final String wireName = 'ShowChat';
+
+  @override
+  Iterable serialize(Serializers serializers, ShowChat object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'username',
+      serializers.serialize(object.username,
+          specifiedType: const FullType(String)),
+      'private',
+      serializers.serialize(object.private,
+          specifiedType: const FullType(bool)),
+      'text',
+      serializers.serialize(object.text, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ShowChat deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ShowChatBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'username':
+            result.username = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+          case 'private':
+            result.private = serializers.deserialize(value,
+                specifiedType: const FullType(bool));
+            break;
+          case 'text':
+            result.text = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$WelcomeSerializer implements StructuredSerializer<Welcome> {
+  final Iterable<Type> types = const [Welcome, _$Welcome];
+  final String wireName = 'Welcome';
+
+  @override
+  Iterable serialize(Serializers serializers, Welcome object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'log',
+      serializers.serialize(object.log,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(Response)])),
+      'message',
+      serializers.serialize(object.message,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Welcome deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new WelcomeBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'log':
+            result.log.replace(serializers.deserialize(value,
+                specifiedType: const FullType(
+                    BuiltList, const [const FullType(Response)])));
+            break;
+          case 'message':
+            result.message = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ListUsersResponseSerializer
+    implements StructuredSerializer<ListUsersResponse> {
+  final Iterable<Type> types = const [ListUsersResponse, _$ListUsersResponse];
+  final String wireName = 'ListUsersResponse';
+
+  @override
+  Iterable serialize(Serializers serializers, ListUsersResponse object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'statuses',
+      serializers.serialize(object.statuses,
+          specifiedType: const FullType(BuiltMap,
+              const [const FullType(String), const FullType(Status)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ListUsersResponse deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ListUsersResponseBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'statuses':
+            result.statuses.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltMap,
+                    const [const FullType(String), const FullType(Status)])));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class Chat
+// **************************************************************************
+
+class _$Chat extends Chat {
+  final String text;
+  final BuiltSet<String> targets;
+
+  _$Chat._({this.text, this.targets}) : super._() {
+    if (text == null) throw new ArgumentError.notNull('text');
+    if (targets == null) throw new ArgumentError.notNull('targets');
+  }
+
+  factory _$Chat([updates(ChatBuilder b)]) =>
+      (new ChatBuilder()..update(updates)).build();
+
+  Chat rebuild(updates(ChatBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  ChatBuilder toBuilder() => new ChatBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! Chat) return false;
+    return text == other.text && targets == other.targets;
+  }
+
+  int get hashCode {
+    return $jf($jc($jc(0, text.hashCode), targets.hashCode));
+  }
+
+  String toString() {
+    return 'Chat {'
+        'text=${text.toString()},\n'
+        'targets=${targets.toString()},\n'
+        '}';
+  }
+}
+
+class ChatBuilder implements Builder<Chat, ChatBuilder> {
+  ChatBuilder();
+  String text;
+  SetBuilder<String> targets = new SetBuilder<String>();
+
+  void replace(Chat other) {
+    this.text = other.text;
+    this.targets = other.targets?.toBuilder();
+  }
+
+  void update(updates(ChatBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  Chat build() {
+    return new _$Chat._(text: text, targets: targets?.build());
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class Login
+// **************************************************************************
+
+class _$Login extends Login {
+  final String username;
+  final String password;
+
+  _$Login._({this.username, this.password}) : super._() {
+    if (username == null) throw new ArgumentError.notNull('username');
+    if (password == null) throw new ArgumentError.notNull('password');
+  }
+
+  factory _$Login([updates(LoginBuilder b)]) =>
+      (new LoginBuilder()..update(updates)).build();
+
+  Login rebuild(updates(LoginBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  LoginBuilder toBuilder() => new LoginBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! Login) return false;
+    return username == other.username && password == other.password;
+  }
+
+  int get hashCode {
+    return $jf($jc($jc(0, username.hashCode), password.hashCode));
+  }
+
+  String toString() {
+    return 'Login {'
+        'username=${username.toString()},\n'
+        'password=${password.toString()},\n'
+        '}';
+  }
+}
+
+class LoginBuilder implements Builder<Login, LoginBuilder> {
+  LoginBuilder();
+  String username;
+  String password;
+
+  void replace(Login other) {
+    this.username = other.username;
+    this.password = other.password;
+  }
+
+  void update(updates(LoginBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  Login build() {
+    return new _$Login._(username: username, password: password);
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class Status
+// **************************************************************************
+
+class _$Status extends Status {
+  final String message;
+  final StatusType type;
+
+  _$Status._({this.message, this.type}) : super._() {
+    if (message == null) throw new ArgumentError.notNull('message');
+    if (type == null) throw new ArgumentError.notNull('type');
+  }
+
+  factory _$Status([updates(StatusBuilder b)]) =>
+      (new StatusBuilder()..update(updates)).build();
+
+  Status rebuild(updates(StatusBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  StatusBuilder toBuilder() => new StatusBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! Status) return false;
+    return message == other.message && type == other.type;
+  }
+
+  int get hashCode {
+    return $jf($jc($jc(0, message.hashCode), type.hashCode));
+  }
+
+  String toString() {
+    return 'Status {'
+        'message=${message.toString()},\n'
+        'type=${type.toString()},\n'
+        '}';
+  }
+}
+
+class StatusBuilder implements Builder<Status, StatusBuilder> {
+  StatusBuilder();
+  String message;
+  StatusType type;
+
+  void replace(Status other) {
+    this.message = other.message;
+    this.type = other.type;
+  }
+
+  void update(updates(StatusBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  Status build() {
+    return new _$Status._(message: message, type: type);
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class ListUsers
+// **************************************************************************
+
+class _$ListUsers extends ListUsers {
+  final BuiltSet<StatusType> statusTypes;
+
+  _$ListUsers._({this.statusTypes}) : super._() {
+    if (statusTypes == null) throw new ArgumentError.notNull('statusTypes');
+  }
+
+  factory _$ListUsers([updates(ListUsersBuilder b)]) =>
+      (new ListUsersBuilder()..update(updates)).build();
+
+  ListUsers rebuild(updates(ListUsersBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  ListUsersBuilder toBuilder() => new ListUsersBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! ListUsers) return false;
+    return statusTypes == other.statusTypes;
+  }
+
+  int get hashCode {
+    return $jf($jc(0, statusTypes.hashCode));
+  }
+
+  String toString() {
+    return 'ListUsers {'
+        'statusTypes=${statusTypes.toString()},\n'
+        '}';
+  }
+}
+
+class ListUsersBuilder implements Builder<ListUsers, ListUsersBuilder> {
+  ListUsersBuilder();
+  SetBuilder<StatusType> statusTypes = new SetBuilder<StatusType>();
+
+  void replace(ListUsers other) {
+    this.statusTypes = other.statusTypes?.toBuilder();
+  }
+
+  void update(updates(ListUsersBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  ListUsers build() {
+    return new _$ListUsers._(statusTypes: statusTypes?.build());
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class ShowChat
+// **************************************************************************
+
+class _$ShowChat extends ShowChat {
+  final String username;
+  final bool private;
+  final String text;
+
+  _$ShowChat._({this.username, this.private, this.text}) : super._() {
+    if (username == null) throw new ArgumentError.notNull('username');
+    if (private == null) throw new ArgumentError.notNull('private');
+    if (text == null) throw new ArgumentError.notNull('text');
+  }
+
+  factory _$ShowChat([updates(ShowChatBuilder b)]) =>
+      (new ShowChatBuilder()..update(updates)).build();
+
+  ShowChat rebuild(updates(ShowChatBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  ShowChatBuilder toBuilder() => new ShowChatBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! ShowChat) return false;
+    return username == other.username &&
+        private == other.private &&
+        text == other.text;
+  }
+
+  int get hashCode {
+    return $jf(
+        $jc($jc($jc(0, username.hashCode), private.hashCode), text.hashCode));
+  }
+
+  String toString() {
+    return 'ShowChat {'
+        'username=${username.toString()},\n'
+        'private=${private.toString()},\n'
+        'text=${text.toString()},\n'
+        '}';
+  }
+}
+
+class ShowChatBuilder implements Builder<ShowChat, ShowChatBuilder> {
+  ShowChatBuilder();
+  String username;
+  bool private;
+  String text;
+
+  void replace(ShowChat other) {
+    this.username = other.username;
+    this.private = other.private;
+    this.text = other.text;
+  }
+
+  void update(updates(ShowChatBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  ShowChat build() {
+    return new _$ShowChat._(username: username, private: private, text: text);
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class Welcome
+// **************************************************************************
+
+class _$Welcome extends Welcome {
+  final BuiltList<Response> log;
+  final String message;
+
+  _$Welcome._({this.log, this.message}) : super._() {
+    if (log == null) throw new ArgumentError.notNull('log');
+    if (message == null) throw new ArgumentError.notNull('message');
+  }
+
+  factory _$Welcome([updates(WelcomeBuilder b)]) =>
+      (new WelcomeBuilder()..update(updates)).build();
+
+  Welcome rebuild(updates(WelcomeBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  WelcomeBuilder toBuilder() => new WelcomeBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! Welcome) return false;
+    return log == other.log && message == other.message;
+  }
+
+  int get hashCode {
+    return $jf($jc($jc(0, log.hashCode), message.hashCode));
+  }
+
+  String toString() {
+    return 'Welcome {'
+        'log=${log.toString()},\n'
+        'message=${message.toString()},\n'
+        '}';
+  }
+}
+
+class WelcomeBuilder implements Builder<Welcome, WelcomeBuilder> {
+  WelcomeBuilder();
+  ListBuilder<Response> log = new ListBuilder<Response>();
+  String message;
+
+  void replace(Welcome other) {
+    this.log = other.log?.toBuilder();
+    this.message = other.message;
+  }
+
+  void update(updates(WelcomeBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  Welcome build() {
+    return new _$Welcome._(log: log?.build(), message: message);
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class ListUsersResponse
+// **************************************************************************
+
+class _$ListUsersResponse extends ListUsersResponse {
+  final BuiltMap<String, Status> statuses;
+
+  _$ListUsersResponse._({this.statuses}) : super._() {
+    if (statuses == null) throw new ArgumentError.notNull('statuses');
+  }
+
+  factory _$ListUsersResponse([updates(ListUsersResponseBuilder b)]) =>
+      (new ListUsersResponseBuilder()..update(updates)).build();
+
+  ListUsersResponse rebuild(updates(ListUsersResponseBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  ListUsersResponseBuilder toBuilder() =>
+      new ListUsersResponseBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! ListUsersResponse) return false;
+    return statuses == other.statuses;
+  }
+
+  int get hashCode {
+    return $jf($jc(0, statuses.hashCode));
+  }
+
+  String toString() {
+    return 'ListUsersResponse {'
+        'statuses=${statuses.toString()},\n'
+        '}';
+  }
+}
+
+class ListUsersResponseBuilder
+    implements Builder<ListUsersResponse, ListUsersResponseBuilder> {
+  ListUsersResponseBuilder();
+  MapBuilder<String, Status> statuses = new MapBuilder<String, Status>();
+
+  void replace(ListUsersResponse other) {
+    this.statuses = other.statuses?.toBuilder();
+  }
+
+  void update(updates(ListUsersResponseBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  ListUsersResponse build() {
+    return new _$ListUsersResponse._(statuses: statuses?.build());
+  }
+}

--- a/chat_example/lib/data_model/serializers.dart
+++ b/chat_example/lib/data_model/serializers.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library serializers;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:chat_example/data_model/data_model.dart';
+
+part 'serializers.g.dart';
+
+/// Collection of generated serializers for the built_json chat example.
+Serializers serializers = _$serializers;

--- a/chat_example/lib/data_model/serializers.g.dart
+++ b/chat_example/lib/data_model/serializers.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of serializers;
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: library serializers
+// **************************************************************************
+
+Serializers _$serializers = (new Serializers().toBuilder()
+      ..add(Chat.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(String)]),
+          () => new SetBuilder<String>())
+      ..add(Login.serializer)
+      ..add(Status.serializer)
+      ..add(StatusType.serializer)
+      ..add(ListUsers.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(StatusType)]),
+          () => new SetBuilder<StatusType>())
+      ..add(LoginResponse.serializer)
+      ..add(ShowChat.serializer)
+      ..add(Welcome.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(Response)]),
+          () => new ListBuilder<Response>())
+      ..add(ListUsersResponse.serializer)
+      ..addBuilderFactory(
+          const FullType(
+              BuiltMap, const [const FullType(String), const FullType(Status)]),
+          () => new MapBuilder<String, Status>()))
+    .build();

--- a/chat_example/lib/server/http_server_connection.dart
+++ b/chat_example/lib/server/http_server_connection.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:chat_example/server/server_connection.dart';
+
+/// [ServerConnection] using a web socket.
+class HttpServerConnection implements ServerConnection {
+  final WebSocket _webSocket;
+  final StreamController<String> _streamController =
+      new StreamController<String>();
+
+  @override
+  String username;
+
+  HttpServerConnection(this._webSocket) {
+    _webSocket.listen((data) {
+      _streamController.add(data);
+    });
+  }
+
+  Stream<String> get dataFromClient => _streamController.stream;
+
+  void sendToClient(String data) {
+    _webSocket.add(data);
+  }
+
+  @override
+  void close() {
+    _webSocket.close();
+  }
+}

--- a/chat_example/lib/server/resource_server.dart
+++ b/chat_example/lib/server/resource_server.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:package_resolver/package_resolver.dart';
+import 'package:route/server.dart';
+
+typedef SocketReceiver(WebSocket webSocket);
+
+/// Serves static resources for the built_value chat example.
+///
+/// Also, accepts web socket connections.
+class ResourceServer {
+  /// Serves resources, passing new sockets to [socketReceiver].
+  Future start(SocketReceiver socketReceiver) async {
+    final server = await HttpServer.bind('localhost', 26199);
+    print('Serving at localhost:26199.');
+    final router = new Router(server);
+    router.serve('/').listen((request) {
+      request.response
+        ..statusCode = HttpStatus.OK
+        ..headers.contentType =
+            new ContentType('text', 'html', charset: 'utf-8')
+        ..write(new File('web/index.html').readAsStringSync())
+        ..close();
+    });
+
+    router.serve('/main.dart').listen((request) {
+      request.response
+        ..statusCode = HttpStatus.OK
+        ..headers.contentType =
+            new ContentType('application', 'dart', charset: 'utf-8')
+        ..write(new File('web/main.dart').readAsStringSync())
+        ..close();
+    });
+
+    router.serve(new RegExp(r'.*\.dart$')).listen((request) async {
+      var path = request.uri.path;
+
+      if (path.startsWith('/packages/')) {
+        final package = path
+            .replaceFirst('/packages/', '')
+            .replaceFirst(new RegExp('/.*'), '');
+        final resolved = await PackageResolver.current.packagePath(package);
+        path = resolved + '/lib' + path.replaceFirst('/packages/$package', '');
+      } else {
+        path = '.$path';
+      }
+
+      request.response
+        ..statusCode = HttpStatus.OK
+        ..headers.contentType =
+            new ContentType('application', 'dart', charset: 'utf-8')
+        ..write(new File(path).readAsStringSync())
+        ..close();
+    });
+
+    router.serve('/main.css').listen((request) {
+      request.response
+        ..statusCode = HttpStatus.OK
+        ..headers.contentType = new ContentType('text', 'css', charset: 'utf-8')
+        ..write(new File('web/main.css').readAsStringSync())
+        ..close();
+    });
+
+    router
+        .serve('/ws')
+        .transform(
+            new WebSocketTransformer(compression: CompressionOptions.OFF))
+        .listen(socketReceiver);
+  }
+}

--- a/chat_example/lib/server/server.dart
+++ b/chat_example/lib/server/server.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:chat_example/data_model/data_model.dart';
+import 'package:chat_example/data_model/serializers.dart';
+import 'package:chat_example/server/server_connection.dart';
+
+/// Server-side logic for the built_value chat example.
+class Server {
+  final Random random = new Random();
+  final Set<ServerConnection> _connections = new Set<ServerConnection>();
+  final Map<String, String> _passwords = <String, String>{};
+  final Map<String, Status> _statuses = <String, Status>{};
+  final List<Response> _log = <Response>[];
+
+  /// Adds a new connection to the server.
+  ///
+  /// A random username is assigned.
+  void addConnection(ServerConnection connection) {
+    final username = 'anon${random.nextInt(10000)}';
+    connection.username = username;
+    _connections.add(connection);
+    _send(
+        connection,
+        new Welcome((b) => b
+          ..log.addAll(_log)
+          ..message = 'You are connected as $username.'));
+    connection.dataFromClient
+        .listen((string) => _handleDataFromClient(connection, string));
+  }
+
+  void _handleDataFromClient(ServerConnection connection, String data) {
+    final command = serializers.deserialize(JSON.decode(data));
+
+    if (command is Chat) {
+      _chat(connection, command);
+    } else if (command is Login) {
+      _login(connection, command);
+    } else if (command is Status) {
+      _status(connection, command);
+    } else if (command is ListUsers) {
+      _listUsers(connection, command);
+    } else {
+      throw new StateError('Invalid data from client: $command');
+    }
+  }
+
+  void _chat(ServerConnection connection, Chat chat) {
+    if (chat.targets.isEmpty) {
+      _sendToAll(new ShowChat((b) => b
+        ..username = connection.username
+        ..private = false
+        ..text = chat.text));
+    } else {
+      _sendTo(
+          chat.targets,
+          new ShowChat((b) => b
+            ..username = connection.username
+            ..private = true
+            ..text = chat.text));
+    }
+  }
+
+  void _listUsers(ServerConnection connection, ListUsers listUsers) {
+    _send(
+        connection,
+        new ListUsersResponse((b) => _statuses.forEach((username, status) {
+              if (listUsers.statusTypes.contains(status.type)) {
+                b.statuses[username] = status;
+              }
+            })));
+  }
+
+  void _login(ServerConnection connection, Login login) {
+    if (_passwords.containsKey(login.username)) {
+      if (_passwords[login.username] != login.password) {
+        _send(connection, LoginResponse.badPassword);
+        return;
+      }
+    } else {
+      _passwords[login.username] = login.password;
+    }
+
+    for (final existingConnection in _connections) {
+      if (existingConnection.username == login.username) {
+        existingConnection.username = 'anon${random.nextInt(10000)}';
+        _send(existingConnection, LoginResponse.reset);
+      }
+    }
+
+    _statuses[login.username] = new Status((b) => b
+      ..message = ''
+      ..type = StatusType.online);
+
+    connection.username = login.username;
+    _send(connection, LoginResponse.success);
+  }
+
+  void _status(ServerConnection connection, Status status) {
+    _statuses[connection.username] = status;
+    if (status.type == StatusType.offline) {
+      _connections.remove(connection);
+      connection.close();
+    }
+  }
+
+  void _sendTo(BuiltSet<String> usernames, Response response) {
+    for (final connection in _connections) {
+      if (usernames.contains(connection.username)) {
+        _send(connection, response);
+      }
+    }
+  }
+
+  void _sendToAll(Response response) {
+    _log.add(response);
+    for (final connection in _connections) {
+      _send(connection, response);
+    }
+  }
+
+  static void _send(ServerConnection connection, Response response) {
+    connection.sendToClient(JSON.encode(serializers.serialize(response)));
+  }
+}

--- a/chat_example/lib/server/server_connection.dart
+++ b/chat_example/lib/server/server_connection.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// Two-way connection between client and server; the server.
+abstract class ServerConnection {
+  /// The username associated with this connection.
+  String get username;
+  set username(String username);
+
+  Stream<String> get dataFromClient;
+  void sendToClient(String data);
+  void close();
+}

--- a/chat_example/lib/testing/fake_client_connection.dart
+++ b/chat_example/lib/testing/fake_client_connection.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/client/client_connection.dart';
+
+/// Fake [ClientConnection] that exposes stream controllers.
+class FakeClientConnection implements ClientConnection {
+  final StreamController<String> toServerStreamController =
+      new StreamController<String>(sync: true);
+  final StreamController<String> fromServerStreamController =
+      new StreamController<String>(sync: true);
+
+  @override
+  void sendToServer(String string) {
+    toServerStreamController.add(string);
+  }
+
+  @override
+  Stream<String> get dataFromServer => fromServerStreamController.stream;
+}

--- a/chat_example/lib/testing/fake_display.dart
+++ b/chat_example/lib/testing/fake_display.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/client/display.dart';
+
+/// Fake [Display] that stores added text.
+class FakeDisplay implements Display {
+  List<String> text = <String>[];
+
+  @override
+  void add(String text) {
+    this.text.add(text);
+  }
+
+  @override
+  void addLocal(String text) {}
+}

--- a/chat_example/lib/testing/fake_environment.dart
+++ b/chat_example/lib/testing/fake_environment.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/client/client.dart';
+import 'package:chat_example/server/server.dart';
+import 'package:chat_example/testing/fake_client_connection.dart';
+import 'package:chat_example/testing/fake_display.dart';
+import 'package:chat_example/testing/fake_server_connection.dart';
+import 'package:chat_example/testing/test_user.dart';
+
+/// Environment for testing server and client logic together.
+///
+/// The HTML display and input are faked, as are the HTTP connections. This
+/// leaves the client logic and server logic available for testing.
+class FakeEnvironment {
+  final Server server;
+
+  factory FakeEnvironment() {
+    final server = new Server();
+
+    return new FakeEnvironment._(server);
+  }
+
+  FakeEnvironment._(this.server);
+
+  /// Creates a new user connected to this environment.
+  TestUser newUser() {
+    final clientConnection = new FakeClientConnection();
+    final serverConnection = new FakeServerConnection();
+
+    clientConnection.toServerStreamController.stream.listen((string) {
+      serverConnection.fromClientStreamController.add(string);
+    });
+    serverConnection.toClientStreamController.stream.listen((string) {
+      clientConnection.fromServerStreamController.add(string);
+    });
+
+    final keyboardInputController = new StreamController<String>(sync: true);
+    final display = new FakeDisplay();
+    new Client(keyboardInputController.stream, display, clientConnection);
+    server.addConnection(serverConnection);
+    return new TestUser(display, keyboardInputController);
+  }
+}

--- a/chat_example/lib/testing/fake_server_connection.dart
+++ b/chat_example/lib/testing/fake_server_connection.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/server/server_connection.dart';
+
+/// Fake [ClientConnection] that exposes stream controllers.
+class FakeServerConnection implements ServerConnection {
+  final StreamController<String> toClientStreamController =
+      new StreamController<String>(sync: true);
+  final StreamController<String> fromClientStreamController =
+      new StreamController<String>(sync: true);
+
+  @override
+  String username;
+
+  @override
+  void sendToClient(String data) {
+    toClientStreamController.add(data);
+  }
+
+  @override
+  Stream<String> get dataFromClient => fromClientStreamController.stream;
+
+  @override
+  void close() {}
+}

--- a/chat_example/lib/testing/test_user.dart
+++ b/chat_example/lib/testing/test_user.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/testing/fake_display.dart';
+import 'package:test/test.dart';
+
+/// A test user connected to the fake environment.
+class TestUser {
+  final FakeDisplay _display;
+  final StreamController<String> _inputController;
+
+  TestUser(this._display, this._inputController);
+
+  /// Types text as this user.
+  void type(String text) {
+    _inputController.add(text);
+  }
+
+  /// Checks server responses to this user.
+  void expectMatch(Pattern pattern) {
+    expect(_display.text, anyElement(matches(pattern)));
+  }
+
+  /// Checks server responses to this user.
+  void expectNoMatch(Pattern pattern) {
+    expect(_display.text, isNot(anyElement(matches(pattern))));
+  }
+}

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -1,0 +1,24 @@
+name: chat_example
+version: 0.3.0
+description: >
+  Just an example, not for publishing.
+authors:
+- David Morgan <davidmorgan@google.com>
+homepage: https://github.com/google/built_value.dart
+
+environment:
+  sdk: '>=1.8.0 <2.0.0'
+
+dependencies:
+  built_collection: '^1.0.0'
+#  built_value: '^0.3.0'
+  built_value:
+    path: ../built_value
+  package_resolver: ^1.0.0
+  route: '>=0.4.6'
+
+dev_dependencies:
+#  built_value_generator: '^0.3.0'
+  built_value_generator:
+    path: ../built_value_generator
+  test: any

--- a/chat_example/test/chat_test.dart
+++ b/chat_example/test/chat_test.dart
@@ -1,0 +1,155 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/data_model/data_model.dart';
+import 'package:chat_example/testing/fake_environment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  FakeEnvironment environment;
+
+  setUp(() {
+    environment = new FakeEnvironment();
+  });
+
+  group('on connect', () {
+    test('client sees login message', () async {
+      final alice = environment.newUser();
+
+      alice.expectMatch('.*You are connected as .*');
+    });
+
+    test('clients can exchange messages', () async {
+      final alice = environment.newUser();
+      final bob = environment.newUser();
+
+      alice.type('Hi, Bob!');
+      bob.expectMatch('anon.*: Hi, Bob!');
+
+      bob.type('Hi, Alice!');
+      alice.expectMatch('anon.*: Hi, Alice!');
+    });
+
+    test('clients can see log', () async {
+      final alice = environment.newUser();
+      alice.type('Hi, Bob!');
+
+      final bob = environment.newUser();
+      bob.expectMatch('anon.*: Hi, Bob!');
+    });
+  });
+
+  group('login', () {
+    test('announces success to self', () async {
+      final alice = environment.newUser();
+
+      alice
+        ..type('/login Alice letmein')
+        ..expectMatch(LoginResponse.success.render());
+    });
+
+    test('changes name', () async {
+      final alice = environment.newUser();
+      final bob = environment.newUser();
+
+      alice..type('/login Alice letmein')..type('Hi, Bob!');
+      bob.expectMatch('Alice: Hi, Bob!');
+    });
+
+    test('fails with wrong password', () async {
+      final alice = environment.newUser();
+      final bob = environment.newUser();
+
+      alice.type('/login Alice letmein');
+      bob.type('/login Alice wrongpassword');
+      bob.expectMatch(LoginResponse.badPassword.render());
+    });
+
+    test('logs out existing user', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      environment.newUser()..type('/login Alice letmein');
+
+      alice.expectMatch(LoginResponse.reset.render());
+    });
+  });
+
+  group('list', () {
+    test('shows online users', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      environment.newUser()..type('/login Bob letmein');
+
+      alice
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Alice
+Bob
+''');
+    });
+  });
+
+  group('status', () {
+    test('changes message in user list', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+
+      alice
+        ..type('/status Waiting around.')
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Alice Waiting around.
+''');
+    });
+  });
+
+  group('away', () {
+    test('changes message in user list', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+
+      alice
+        ..type('/away Not here.')
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Alice Not here.
+''');
+    });
+  });
+
+  group('quit', () {
+    test('removes from online list', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      final bob = environment.newUser()..type('/login Bob letmein');
+
+      alice.type('/quit Gone.');
+      bob
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Bob
+''');
+    });
+
+    test('stops getting messages', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      final bob = environment.newUser()..type('/login Bob letmein');
+
+      alice.type('/quit Gone.');
+      bob.type('Hi Alice.');
+      alice.expectNoMatch('Hi Alice.');
+    });
+  });
+
+  group('tell', () {
+    test('goes to a single user', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      final bob = environment.newUser()..type('/login Bob letmein');
+      final eve = environment.newUser();
+
+      alice.type('/tell Bob Hi there.');
+      bob..expectMatch(r'Alice \(private\): Hi there.');
+      eve.expectNoMatch('Hi there.');
+    });
+  });
+}

--- a/chat_example/tool/build.dart
+++ b/chat_example/tool/build.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:built_value_generator/built_value_generator.dart';
+import 'package:source_gen/source_gen.dart';
+
+/// Build the generated files in the built_value chat example.
+Future main(List<String> args) async {
+  await build(
+      new PhaseGroup.singleAction(
+          new GeneratorBuilder([
+            new BuiltValueGenerator(),
+          ]),
+          new InputSet('chat_example', const ['lib/**/*.dart'])),
+      deleteFilesByDefault: true);
+}

--- a/chat_example/tool/watch.dart
+++ b/chat_example/tool/watch.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:built_value_generator/built_value_generator.dart';
+import 'package:source_gen/source_gen.dart';
+
+/// Start a watcher that automatically builds the generated files in the
+/// built_value chat example on changes.
+Future main(List<String> args) async {
+  await watch(
+      new PhaseGroup.singleAction(
+          new GeneratorBuilder([
+            new BuiltValueGenerator(),
+          ]),
+          new InputSet('chat_example', const ['lib/**/*.dart'])),
+      deleteFilesByDefault: true);
+}

--- a/chat_example/web/index.html
+++ b/chat_example/web/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <link rel="stylesheet" href="main.css">
+</head>
+<body class="screen" id="screen">
+<div class="text" id="text"></div>
+<input class="input" id="input">
+<script type="application/dart" src="main.dart"></script>
+<script type="text/javascript" src="packages/browser/dart.js"></script></body>
+</html>

--- a/chat_example/web/main.css
+++ b/chat_example/web/main.css
@@ -1,0 +1,38 @@
+body {
+  overflow-y: scroll;
+}
+
+.input:focus {
+  outline: 0;
+}
+
+.screen {
+  background-color: black;
+  color: gray;
+  padding: 0px;
+  width: 48em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.text {
+  width: 100%;
+  font-family: Ariel, sans-serif;
+  font-size: 16px;
+}
+
+.local {
+  color: green;
+}
+
+.input {
+  position: relative;
+  top: 0px;
+  left: 0px;
+  font-family: Ariel, sans-serif;
+  font-size: 16px;
+  background-color: black;
+  color: green;
+  border-style: none;
+  width: 100%;
+}

--- a/chat_example/web/main.dart
+++ b/chat_example/web/main.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/client/client.dart';
+import 'package:chat_example/client/html_display.dart';
+import 'package:chat_example/client/http_client_connection.dart';
+import 'package:chat_example/client/input.dart';
+import 'package:chat_example/client/layout.dart';
+
+void main() {
+  new Layout();
+  final input = new Input();
+  new Client(input.keyboardInput, new HtmlDisplay(), new HttpClientConnection());
+}

--- a/example/lib/collections.dart
+++ b/example/lib/collections.dart
@@ -6,6 +6,7 @@ library collections;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
 
 part 'collections.g.dart';
 
@@ -14,6 +15,13 @@ part 'collections.g.dart';
 /// Classes can contain collections; these must be from built_collection. In
 /// the builder, the builder corresponding to the collection is provided.
 abstract class Collections implements Built<Collections, CollectionsBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializers] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static final Serializer<Collections> serializer = _$collectionsSerializer;
+
   BuiltList<int> get list;
   BuiltSet<String> get set;
   BuiltMap<String, int> get map;

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -4,6 +4,151 @@ part of collections;
 
 // **************************************************************************
 // Generator: BuiltValueGenerator
+// Target: library collections
+// **************************************************************************
+
+Serializer<Collections> _$collectionsSerializer = new _$CollectionsSerializer();
+
+class _$CollectionsSerializer implements StructuredSerializer<Collections> {
+  final Iterable<Type> types = const [Collections, _$Collections];
+  final String wireName = 'Collections';
+
+  @override
+  Iterable serialize(Serializers serializers, Collections object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'list',
+      serializers.serialize(object.list,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(int)])),
+      'set',
+      serializers.serialize(object.set,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])),
+      'map',
+      serializers.serialize(object.map,
+          specifiedType: const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)])),
+      'listMultimap',
+      serializers.serialize(object.listMultimap,
+          specifiedType: const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)])),
+      'setMultimap',
+      serializers.serialize(object.setMultimap,
+          specifiedType: const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)])),
+    ];
+    if (object.nullableList != null) {
+      result.add('nullableList');
+      result.add(serializers.serialize(object.nullableList,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(int)])));
+    }
+    if (object.nullableSet != null) {
+      result.add('nullableSet');
+      result.add(serializers.serialize(object.nullableSet,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])));
+    }
+    if (object.nullableMap != null) {
+      result.add('nullableMap');
+      result.add(serializers.serialize(object.nullableMap,
+          specifiedType: const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)])));
+    }
+    if (object.nullableListMultimap != null) {
+      result.add('nullableListMultimap');
+      result.add(serializers.serialize(object.nullableListMultimap,
+          specifiedType: const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)])));
+    }
+    if (object.nullableSetMultimap != null) {
+      result.add('nullableSetMultimap');
+      result.add(serializers.serialize(object.nullableSetMultimap,
+          specifiedType: const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)])));
+    }
+
+    return result;
+  }
+
+  @override
+  Collections deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new CollectionsBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'list':
+            result.list.replace(serializers.deserialize(value,
+                specifiedType:
+                    const FullType(BuiltList, const [const FullType(int)])));
+            break;
+          case 'set':
+            result.set.replace(serializers.deserialize(value,
+                specifiedType:
+                    const FullType(BuiltSet, const [const FullType(String)])));
+            break;
+          case 'map':
+            result.map.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltMap,
+                    const [const FullType(String), const FullType(int)])));
+            break;
+          case 'listMultimap':
+            result.listMultimap.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltListMultimap,
+                    const [const FullType(int), const FullType(bool)])));
+            break;
+          case 'setMultimap':
+            result.setMultimap.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltSetMultimap,
+                    const [const FullType(String), const FullType(bool)])));
+            break;
+          case 'nullableList':
+            result.nullableList.replace(serializers.deserialize(value,
+                specifiedType:
+                    const FullType(BuiltList, const [const FullType(int)])));
+            break;
+          case 'nullableSet':
+            result.nullableSet.replace(serializers.deserialize(value,
+                specifiedType:
+                    const FullType(BuiltSet, const [const FullType(String)])));
+            break;
+          case 'nullableMap':
+            result.nullableMap.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltMap,
+                    const [const FullType(String), const FullType(int)])));
+            break;
+          case 'nullableListMultimap':
+            result.nullableListMultimap.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltListMultimap,
+                    const [const FullType(int), const FullType(bool)])));
+            break;
+          case 'nullableSetMultimap':
+            result.nullableSetMultimap.replace(serializers.deserialize(value,
+                specifiedType: const FullType(BuiltSetMultimap,
+                    const [const FullType(String), const FullType(bool)])));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
 // Target: abstract class Collections
 // **************************************************************************
 

--- a/example/lib/compound_value.dart
+++ b/example/lib/compound_value.dart
@@ -5,8 +5,9 @@
 library compound_value;
 
 import 'package:built_value/built_value.dart';
-
+import 'package:built_value/serializer.dart';
 import 'package:example/validated_value.dart';
+
 import 'simple_value.dart';
 
 part 'compound_value.g.dart';
@@ -17,6 +18,13 @@ part 'compound_value.g.dart';
 /// represented as nested builders.
 abstract class CompoundValue
     implements Built<CompoundValue, CompoundValueBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializers] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static final Serializer<CompoundValue> serializer = _$compoundValueSerializer;
+
   SimpleValue get simpleValue;
   @nullable
   ValidatedValue get validatedValue;

--- a/example/lib/compound_value.g.dart
+++ b/example/lib/compound_value.g.dart
@@ -4,6 +4,68 @@ part of compound_value;
 
 // **************************************************************************
 // Generator: BuiltValueGenerator
+// Target: library compound_value
+// **************************************************************************
+
+Serializer<CompoundValue> _$compoundValueSerializer =
+    new _$CompoundValueSerializer();
+
+class _$CompoundValueSerializer implements StructuredSerializer<CompoundValue> {
+  final Iterable<Type> types = const [CompoundValue, _$CompoundValue];
+  final String wireName = 'CompoundValue';
+
+  @override
+  Iterable serialize(Serializers serializers, CompoundValue object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'simpleValue',
+      serializers.serialize(object.simpleValue,
+          specifiedType: const FullType(SimpleValue)),
+    ];
+    if (object.validatedValue != null) {
+      result.add('validatedValue');
+      result.add(serializers.serialize(object.validatedValue,
+          specifiedType: const FullType(ValidatedValue)));
+    }
+
+    return result;
+  }
+
+  @override
+  CompoundValue deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new CompoundValueBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'simpleValue':
+            result.simpleValue.replace(serializers.deserialize(value,
+                specifiedType: const FullType(SimpleValue)));
+            break;
+          case 'validatedValue':
+            result.validatedValue.replace(serializers.deserialize(value,
+                specifiedType: const FullType(ValidatedValue)));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
 // Target: abstract class CompoundValue
 // **************************************************************************
 

--- a/example/lib/has_int.dart
+++ b/example/lib/has_int.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library has_int;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'has_int.g.dart';
+
+/// Example "serializable" interface.
+///
+/// In fact it is the implementations of the interface that must be
+/// serializable. See examples below.
+abstract class HasInt {
+  int get anInt;
+}
+
+/// Example [HasInt] implementation that is not serializable.
+///
+/// To be serializable it must use built_value or enum_class.
+abstract class WrongHasInt implements HasInt {
+  int anInt = 4;
+}
+
+/// Example [HasInt] that is serializable because it uses built_value.
+abstract class ValueWithInt
+    implements Built<ValueWithInt, ValueWithIntBuilder>, HasInt {
+  /// Serializer field makes the built_value serializable.
+  static final Serializer<ValueWithInt> serializer = _$valueWithIntSerializer;
+  static final int youCanHaveStaticFields = 3;
+
+  @override
+  int get anInt;
+
+  String get note;
+
+  ValueWithInt._();
+
+  factory ValueWithInt([updates(ValueWithIntBuilder b)]) = _$ValueWithInt;
+}
+
+/// Builder class for [ValueWithInt].
+abstract class ValueWithIntBuilder
+    implements Builder<ValueWithInt, ValueWithIntBuilder> {
+  int anInt;
+  String note;
+
+  ValueWithIntBuilder._();
+
+  factory ValueWithIntBuilder() = _$ValueWithIntBuilder;
+}
+
+/// Example [HasInt] that is serializable because it uses enum_class.
+class EnumWithInt extends EnumClass implements HasInt {
+  /// Serializer field makes the enum_class serializable.
+  static final Serializer<EnumWithInt> serializer = _$enumWithIntSerializer;
+
+  static const EnumWithInt one = _$one;
+  static const EnumWithInt two = _$two;
+  static const EnumWithInt three = _$three;
+
+  const EnumWithInt._(String name) : super(name);
+
+  static BuiltSet<EnumWithInt> get values => _$values;
+
+  static EnumWithInt valueOf(String name) => _$valueOf(name);
+
+  @override
+  int get anInt {
+    switch (this) {
+      case one:
+        return 1;
+      case two:
+        return 2;
+      case three:
+        return 3;
+      default:
+        throw new StateError(this.toString());
+    }
+  }
+}

--- a/example/lib/has_int.g.dart
+++ b/example/lib/has_int.g.dart
@@ -1,0 +1,158 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of has_int;
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: library has_int
+// **************************************************************************
+
+const EnumWithInt _$one = const EnumWithInt._('one');
+const EnumWithInt _$two = const EnumWithInt._('two');
+const EnumWithInt _$three = const EnumWithInt._('three');
+
+EnumWithInt _$valueOf(String name) {
+  switch (name) {
+    case 'one':
+      return _$one;
+    case 'two':
+      return _$two;
+    case 'three':
+      return _$three;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<EnumWithInt> _$values = new BuiltSet<EnumWithInt>(const [
+  _$one,
+  _$two,
+  _$three,
+]);
+
+Serializer<ValueWithInt> _$valueWithIntSerializer =
+    new _$ValueWithIntSerializer();
+Serializer<EnumWithInt> _$enumWithIntSerializer = new _$EnumWithIntSerializer();
+
+class _$ValueWithIntSerializer implements StructuredSerializer<ValueWithInt> {
+  final Iterable<Type> types = const [ValueWithInt, _$ValueWithInt];
+  final String wireName = 'ValueWithInt';
+
+  @override
+  Iterable serialize(Serializers serializers, ValueWithInt object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+      'note',
+      serializers.serialize(object.note, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ValueWithInt deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ValueWithIntBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'anInt':
+            result.anInt = serializers.deserialize(value,
+                specifiedType: const FullType(int));
+            break;
+          case 'note':
+            result.note = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$EnumWithIntSerializer implements PrimitiveSerializer<EnumWithInt> {
+  final Iterable<Type> types = const [EnumWithInt];
+  final String wireName = 'EnumWithInt';
+
+  @override
+  Object serialize(Serializers serializers, EnumWithInt object,
+      {FullType specifiedType: FullType.unspecified}) {
+    return object.name;
+  }
+
+  @override
+  EnumWithInt deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return EnumWithInt.valueOf(serialized);
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: abstract class ValueWithInt
+// **************************************************************************
+
+class _$ValueWithInt extends ValueWithInt {
+  final int anInt;
+  final String note;
+
+  _$ValueWithInt._({this.anInt, this.note}) : super._() {
+    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (note == null) throw new ArgumentError.notNull('note');
+  }
+
+  factory _$ValueWithInt([updates(ValueWithIntBuilder b)]) =>
+      (new ValueWithIntBuilder()..update(updates)).build();
+
+  ValueWithInt rebuild(updates(ValueWithIntBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  _$ValueWithIntBuilder toBuilder() =>
+      new _$ValueWithIntBuilder()..replace(this);
+
+  bool operator ==(other) {
+    if (other is! ValueWithInt) return false;
+    return anInt == other.anInt && note == other.note;
+  }
+
+  int get hashCode {
+    return $jf($jc($jc(0, anInt.hashCode), note.hashCode));
+  }
+
+  String toString() {
+    return 'ValueWithInt {'
+        'anInt=${anInt.toString()},\n'
+        'note=${note.toString()},\n'
+        '}';
+  }
+}
+
+class _$ValueWithIntBuilder extends ValueWithIntBuilder {
+  _$ValueWithIntBuilder() : super._();
+  void replace(ValueWithInt other) {
+    super.anInt = other.anInt;
+    super.note = other.note;
+  }
+
+  void update(updates(ValueWithIntBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  ValueWithInt build() {
+    return new _$ValueWithInt._(anInt: anInt, note: note);
+  }
+}

--- a/example/lib/serializers.dart
+++ b/example/lib/serializers.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library serializers;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:example/collections.dart';
+import 'package:example/compound_value.dart';
+import 'package:example/has_int.dart';
+import 'package:example/test_enum.dart';
+import 'package:example/simple_value.dart';
+import 'package:example/validated_value.dart';
+
+part 'serializers.g.dart';
+
+/// Example of how to use built_json.
+///
+/// Declare a top level [Serializers] field called
+/// serializers. The built_value code generator will provide the
+/// implementation. You usually only need to do this once per project.
+Serializers serializers = _$serializers;

--- a/example/lib/serializers.g.dart
+++ b/example/lib/serializers.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of serializers;
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
+// Target: library serializers
+// **************************************************************************
+
+Serializers _$serializers = (new Serializers().toBuilder()
+      ..add(CompoundValue.serializer)
+      ..add(TestEnum.serializer)
+      ..add(ValueWithInt.serializer)
+      ..add(EnumWithInt.serializer)
+      ..add(ValidatedValue.serializer)
+      ..add(Collections.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => new ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(String)]),
+          () => new SetBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)]),
+          () => new MapBuilder<String, int>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => new ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(String)]),
+          () => new SetBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)]),
+          () => new MapBuilder<String, int>())
+      ..add(SimpleValue.serializer))
+    .build();

--- a/example/lib/simple_value.dart
+++ b/example/lib/simple_value.dart
@@ -5,6 +5,7 @@
 library simple_value;
 
 import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
 
 part 'simple_value.g.dart';
 
@@ -14,6 +15,13 @@ part 'simple_value.g.dart';
 /// fields declared as abstract getters. Finally, it must have a particular
 /// constructor and factory, as shown here.
 abstract class SimpleValue implements Built<SimpleValue, SimpleValueBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static final Serializer<SimpleValue> serializer = _$simpleValueSerializer;
+
   int get anInt;
 
   // Only fields marked @nullable can hold null.

--- a/example/lib/simple_value.g.dart
+++ b/example/lib/simple_value.g.dart
@@ -4,6 +4,66 @@ part of simple_value;
 
 // **************************************************************************
 // Generator: BuiltValueGenerator
+// Target: library simple_value
+// **************************************************************************
+
+Serializer<SimpleValue> _$simpleValueSerializer = new _$SimpleValueSerializer();
+
+class _$SimpleValueSerializer implements StructuredSerializer<SimpleValue> {
+  final Iterable<Type> types = const [SimpleValue, _$SimpleValue];
+  final String wireName = 'SimpleValue';
+
+  @override
+  Iterable serialize(Serializers serializers, SimpleValue object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+    if (object.aString != null) {
+      result.add('aString');
+      result.add(serializers.serialize(object.aString,
+          specifiedType: const FullType(String)));
+    }
+
+    return result;
+  }
+
+  @override
+  SimpleValue deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new SimpleValueBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'anInt':
+            result.anInt = serializers.deserialize(value,
+                specifiedType: const FullType(int));
+            break;
+          case 'aString':
+            result.aString = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
 // Target: abstract class SimpleValue
 // **************************************************************************
 

--- a/example/lib/test_enum.dart
+++ b/example/lib/test_enum.dart
@@ -6,6 +6,7 @@ library test_enum;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
 
 part 'test_enum.g.dart';
 
@@ -19,6 +20,13 @@ part 'test_enum.g.dart';
 /// You need to write three pieces of boilerplate to hook up the generated
 /// code: a constructor called `_`, a `values` method, and a `valueOf` method.
 class TestEnum extends EnumClass {
+  /// Example of how to make an [EnumClass] serializable.
+  ///
+  /// Declare a static final [Serializers] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static final Serializer<TestEnum> serializer = _$testEnumSerializer;
+
   static const TestEnum yes = _$yes;
   static const TestEnum no = _$no;
   static const TestEnum maybe = _$maybe;

--- a/example/lib/test_enum.g.dart
+++ b/example/lib/test_enum.g.dart
@@ -65,3 +65,22 @@ final BuiltSet<SecondTestEnum> _$vls = new BuiltSet<SecondTestEnum>(const [
   _$n,
   _$definitely,
 ]);
+
+Serializer<TestEnum> _$testEnumSerializer = new _$TestEnumSerializer();
+
+class _$TestEnumSerializer implements PrimitiveSerializer<TestEnum> {
+  final Iterable<Type> types = const [TestEnum];
+  final String wireName = 'TestEnum';
+
+  @override
+  Object serialize(Serializers serializers, TestEnum object,
+      {FullType specifiedType: FullType.unspecified}) {
+    return object.name;
+  }
+
+  @override
+  TestEnum deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    return TestEnum.valueOf(serialized);
+  }
+}

--- a/example/lib/validated_value.dart
+++ b/example/lib/validated_value.dart
@@ -5,6 +5,7 @@
 library validated_value;
 
 import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
 
 part 'validated_value.g.dart';
 
@@ -13,6 +14,14 @@ part 'validated_value.g.dart';
 /// Validation can be done in the constructor.
 abstract class ValidatedValue
     implements Built<ValidatedValue, ValidatedValueBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static final Serializer<ValidatedValue> serializer =
+      _$validatedValueSerializer;
+
   int get anInt;
   @nullable
   String get aString;

--- a/example/lib/validated_value.g.dart
+++ b/example/lib/validated_value.g.dart
@@ -4,6 +4,68 @@ part of validated_value;
 
 // **************************************************************************
 // Generator: BuiltValueGenerator
+// Target: library validated_value
+// **************************************************************************
+
+Serializer<ValidatedValue> _$validatedValueSerializer =
+    new _$ValidatedValueSerializer();
+
+class _$ValidatedValueSerializer
+    implements StructuredSerializer<ValidatedValue> {
+  final Iterable<Type> types = const [ValidatedValue, _$ValidatedValue];
+  final String wireName = 'ValidatedValue';
+
+  @override
+  Iterable serialize(Serializers serializers, ValidatedValue object,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = [
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+    if (object.aString != null) {
+      result.add('aString');
+      result.add(serializers.serialize(object.aString,
+          specifiedType: const FullType(String)));
+    }
+
+    return result;
+  }
+
+  @override
+  ValidatedValue deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) {
+    final result = new ValidatedValueBuilder();
+
+    var key;
+    var value;
+    var expectingKey = true;
+    for (final item in serialized) {
+      if (expectingKey) {
+        key = item;
+        expectingKey = false;
+      } else {
+        value = item;
+        expectingKey = true;
+
+        switch (key as String) {
+          case 'anInt':
+            result.anInt = serializers.deserialize(value,
+                specifiedType: const FullType(int));
+            break;
+          case 'aString':
+            result.aString = serializers.deserialize(value,
+                specifiedType: const FullType(String));
+            break;
+        }
+      }
+    }
+
+    return result.build();
+  }
+}
+
+// **************************************************************************
+// Generator: BuiltValueGenerator
 // Target: abstract class ValidatedValue
 // **************************************************************************
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,5 @@
 name: example
-version: 0.2.1
+version: 0.3.0
 description: >
   Just an example, not for publishing.
 authors:
@@ -11,12 +11,12 @@ environment:
 
 dependencies:
   built_collection: '^1.0.0'
-#  built_value: '^0.2.1'
+#  built_value: '^0.3.0'
   built_value:
     path: ../built_value
 
 dev_dependencies:
-#  built_value_generator: '^0.2.1'
+#  built_value_generator: '^0.3.0'
   built_value_generator:
     path: ../built_value_generator
   quiver: '>=0.21.0 <0.24.0'

--- a/example/test/collections_serializer_test.dart
+++ b/example/test/collections_serializer_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// TODO(davidmorgan): support serializing multimaps.
+void main() {}
+
+/*
+import 'package:example/collections.dart';
+import 'package:example/serializers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Collections', () {
+    final data = new Collections((b) => b
+      ..list.add(1)
+      ..set.add('two')
+      ..map['three'] = 4);
+    final serialized = [
+      'Collections',
+      'list',
+      [1],
+      'set',
+      ['two'],
+      'map',
+      ['three', 4],
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}
+*/

--- a/example/test/compound_value_serializer_test.dart
+++ b/example/test/compound_value_serializer_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// TODO(davidmorgan): fix deserialization for @nullable nested builder.
+// https://github.com/google/built_json.dart/issues/40
+void main() {}
+
+/*
+import 'package:example/compound_value.dart';
+import 'package:example/serializers.dart';
+import 'package:example/validated_value.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CompoundValue', () {
+    final data = new CompoundValue((b) => b
+      ..simpleValue.anInt = 1
+      ..simpleValue.aString = 'two'
+      ..validatedValue = new ValidatedValue((b) => b.anInt = 3).toBuilder());
+    final serialized = [
+      'CompoundValue',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'validatedValue',
+      [
+        'anInt',
+        3,
+      ],
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}
+*/

--- a/example/test/has_int_serializer_test.dart
+++ b/example/test/has_int_serializer_test.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:example/has_int.dart';
+import 'package:example/serializers.dart';
+import 'package:test/test.dart';
+import 'package:example/simple_value.dart';
+
+void main() {
+  group('HasInt', () {
+    final data = new BuiltList<HasInt>([
+      new ValueWithInt((b) => b
+        ..anInt = 2
+        ..note = 'two'),
+      EnumWithInt.one,
+    ]);
+    final serialized = [
+      'list',
+      ['ValueWithInt', 'anInt', 2, 'note', 'two'],
+      ['EnumWithInt', 'one'],
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/example/test/simple_value_serializer_test.dart
+++ b/example/test/simple_value_serializer_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:example/serializers.dart';
+import 'package:example/simple_value.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SimpleValue', () {
+    final data = new SimpleValue((b) => b
+      ..anInt = 1
+      ..aString = 'two');
+    final serialized = [
+      'SimpleValue',
+      'anInt',
+      1,
+      'aString',
+      'two',
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/example/test/test_enum_serializer_test.dart
+++ b/example/test/test_enum_serializer_test.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:example/serializers.dart';
+import 'package:example/test_enum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TestEnum', () {
+    final data = TestEnum.yes;
+    final serialized = ['TestEnum', 'yes'];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/libraries_for_object_oriented_dart.md
+++ b/libraries_for_object_oriented_dart.md
@@ -9,7 +9,7 @@ than it needs to be.
 
 ## Overview
 
-Libraries for Object Oriented Dart contains three powerful libraries that help
+Libraries for Object Oriented Dart contains two powerful libraries that help
 translate object oriented designs into implementations with minimum overhead,
 freeing developers to focus on the task at hand.
  
@@ -17,18 +17,14 @@ freeing developers to focus on the task at hand.
   provides immutable, type safe collections.
   
 * [built_value.dart](https://github.com/google/built_value.dart#built-values-for-dart)
-  provides immutable "value types" and classes with enum features.
+  provides immutable "value types", classes with enum features and
+  serialization.
 
 For those familiar with Java, these provide equivalent functionality to
 standard Java enums,
 [Immutable Collections](https://github.com/google/guava/wiki/ImmutableCollectionsExplained)
 and
 [AutoValues](https://github.com/google/auto/tree/master/value#autovalue).
-
-The third library provides something with no direct equivalent in Java:
-  
-* [built_json.dart](https://github.com/google/built_json.dart#built-json-for-dart)
-  provides dynamic, flexible JSON serialization for the other two libraries.
 
 To complete the package, we'll make the whole stack compatible with Java:
 
@@ -37,7 +33,6 @@ To complete the package, we'll make the whole stack compatible with Java:
   [Immutable Collections](https://github.com/google/guava/wiki/ImmutableCollectionsExplained)
   and Built Values to [AutoValues](https://github.com/google/auto/tree/master/value#autovalue).
 
-
   
 ## Current Status
  
@@ -45,9 +40,6 @@ To complete the package, we'll make the whole stack compatible with Java:
   is stable and production ready.
   
 * [built_value.dart](https://github.com/google/built_value.dart#built-values-for-dart)
-  is ready for use but may be missing features.
-  
-* [built_json.dart](https://github.com/google/built_json.dart#built-json-for-dart)
   is ready for use but may be missing features.
   
 * Built JSON for Java is not yet started.


### PR DESCRIPTION
As with the enum_class merge, this is mostly file moves and renames.

The changes are:

 - In built_value_generator.dart, to run the serializer generator if necessary and concatenate the output.
 - The "example" classes and tests are merged; there are a couple of TODOs so the serializer tests can work: adding support for multimaps and fixing deserialization for nested builders.
 - Rehashed the docs a bit to include information about serialization on the main page. I'll take another shot at the docs when I close the old github projects.

Note that built_json isn't used as a name anywhere. The import for the serializer is "built_value/serializer.dart", separate from built_value.dart, so people who don't want serialization don't pull in any of the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/56)
<!-- Reviewable:end -->
