### PR TITLE
Allow "updates" in value type factory to have explicit void return type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.2
+
+- Fix lints.
+- Allow "updates" in value type factory to have explicit void return type.
+
 ## 0.4.1
 
 - Fix some analyzer hints.

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -146,7 +146,10 @@ abstract class ValueSourceClass
 
     final expectedFactory =
         'factory $name([updates(${name}Builder b)]) = _\$$name;';
-    if (!valueClassFactories.any((factory) => factory == expectedFactory)) {
+    final alternativeExpectedFactory =
+        'factory $name([void updates(${name}Builder b)]) = _\$$name;';
+    if (!valueClassFactories.any((factory) =>
+        factory == expectedFactory || factory == alternativeExpectedFactory)) {
       result.add('Make class have factory: $expectedFactory');
     }
 

--- a/built_value_generator/test/built_value_generator_test.dart
+++ b/built_value_generator/test/built_value_generator_test.dart
@@ -83,6 +83,16 @@ abstract class Value implements Built<Value, ValueBuilder>, Object {
 }'''), isNot(contains('1.')));
     });
 
+    test('allows updates to have return type', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder>, Object {
+  Value._();
+  factory Value([void updates(ValueBuilder b)]) = _\$Value;
+}'''), isNot(contains('1.')));
+    });
+
     test('handles unresolved Built type parameters', () async {
       expect(await generate('''library value;
 import 'package:built_value/built_value.dart';


### PR DESCRIPTION
Fixes #71

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/77)
<!-- Reviewable:end -->
