### PR TITLE
Fix builder getters to be available before set.

### DIFF
--- a/benchmark/lib/node.g.dart
+++ b/benchmark/lib/node.g.dart
@@ -52,20 +52,20 @@ class NodeBuilder implements Builder<Node, NodeBuilder> {
   Node _$v;
 
   String _label;
-  String get label => _label;
-  set label(String label) => _$writableBuilder._label = label;
+  String get label => _$this._label;
+  set label(String label) => _$this._label = label;
 
   NodeBuilder _left;
-  NodeBuilder get left => _$writableBuilder._left ??= new NodeBuilder();
-  set left(NodeBuilder left) => _$writableBuilder._left = left;
+  NodeBuilder get left => _$this._left ??= new NodeBuilder();
+  set left(NodeBuilder left) => _$this._left = left;
 
   NodeBuilder _right;
-  NodeBuilder get right => _$writableBuilder._right ??= new NodeBuilder();
-  set right(NodeBuilder right) => _$writableBuilder._right = right;
+  NodeBuilder get right => _$this._right ??= new NodeBuilder();
+  set right(NodeBuilder right) => _$this._right = right;
 
   NodeBuilder();
 
-  NodeBuilder get _$writableBuilder {
+  NodeBuilder get _$this {
     if (_$v != null) {
       _label = _$v.label;
       _left = _$v.left?.toBuilder();

--- a/benchmark/lib/simple_value.g.dart
+++ b/benchmark/lib/simple_value.g.dart
@@ -52,16 +52,16 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
   SimpleValue _$v;
 
   int _anInt;
-  int get anInt => _anInt;
-  set anInt(int anInt) => _$writableBuilder._anInt = anInt;
+  int get anInt => _$this._anInt;
+  set anInt(int anInt) => _$this._anInt = anInt;
 
   String _aString;
-  String get aString => _aString;
-  set aString(String aString) => _$writableBuilder._aString = aString;
+  String get aString => _$this._aString;
+  set aString(String aString) => _$this._aString = aString;
 
   SimpleValueBuilder();
 
-  SimpleValueBuilder get _$writableBuilder {
+  SimpleValueBuilder get _$this {
     if (_$v != null) {
       _anInt = _$v.anInt;
       _aString = _$v.aString;

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -12,11 +12,15 @@ environment:
 dependencies:
   browser: any
   built_collection: '^1.0.0'
-  built_value: ^0.4.2
+# built_value: ^0.4.2
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: '^0.4.0'
-  built_value_generator: ^0.4.2
+# built_value_generator: ^0.4.2
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'
   quiver: '>=0.21.0 <0.24.0'
   test: any

--- a/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_value_generator/lib/src/enum_source_class.g.dart
@@ -94,43 +94,42 @@ class EnumSourceClassBuilder
   EnumSourceClass _$v;
 
   String _name;
-  String get name => _name;
-  set name(String name) => _$writableBuilder._name = name;
+  String get name => _$this._name;
+  set name(String name) => _$this._name = name;
 
   ListBuilder<EnumSourceField> _fields;
   ListBuilder<EnumSourceField> get fields =>
-      _$writableBuilder._fields ??= new ListBuilder<EnumSourceField>();
-  set fields(ListBuilder<EnumSourceField> fields) =>
-      _$writableBuilder._fields = fields;
+      _$this._fields ??= new ListBuilder<EnumSourceField>();
+  set fields(ListBuilder<EnumSourceField> fields) => _$this._fields = fields;
 
   ListBuilder<String> _constructors;
   ListBuilder<String> get constructors =>
-      _$writableBuilder._constructors ??= new ListBuilder<String>();
+      _$this._constructors ??= new ListBuilder<String>();
   set constructors(ListBuilder<String> constructors) =>
-      _$writableBuilder._constructors = constructors;
+      _$this._constructors = constructors;
 
   String _valuesIdentifier;
-  String get valuesIdentifier => _valuesIdentifier;
+  String get valuesIdentifier => _$this._valuesIdentifier;
   set valuesIdentifier(String valuesIdentifier) =>
-      _$writableBuilder._valuesIdentifier = valuesIdentifier;
+      _$this._valuesIdentifier = valuesIdentifier;
 
   String _valueOfIdentifier;
-  String get valueOfIdentifier => _valueOfIdentifier;
+  String get valueOfIdentifier => _$this._valueOfIdentifier;
   set valueOfIdentifier(String valueOfIdentifier) =>
-      _$writableBuilder._valueOfIdentifier = valueOfIdentifier;
+      _$this._valueOfIdentifier = valueOfIdentifier;
 
   bool _usesMixin;
-  bool get usesMixin => _usesMixin;
-  set usesMixin(bool usesMixin) => _$writableBuilder._usesMixin = usesMixin;
+  bool get usesMixin => _$this._usesMixin;
+  set usesMixin(bool usesMixin) => _$this._usesMixin = usesMixin;
 
   String _mixinDeclaration;
-  String get mixinDeclaration => _mixinDeclaration;
+  String get mixinDeclaration => _$this._mixinDeclaration;
   set mixinDeclaration(String mixinDeclaration) =>
-      _$writableBuilder._mixinDeclaration = mixinDeclaration;
+      _$this._mixinDeclaration = mixinDeclaration;
 
   EnumSourceClassBuilder();
 
-  EnumSourceClassBuilder get _$writableBuilder {
+  EnumSourceClassBuilder get _$this {
     if (_$v != null) {
       _name = _$v.name;
       _fields = _$v.fields?.toBuilder();

--- a/built_value_generator/lib/src/enum_source_field.g.dart
+++ b/built_value_generator/lib/src/enum_source_field.g.dart
@@ -82,29 +82,29 @@ class EnumSourceFieldBuilder
   EnumSourceField _$v;
 
   String _name;
-  String get name => _name;
-  set name(String name) => _$writableBuilder._name = name;
+  String get name => _$this._name;
+  set name(String name) => _$this._name = name;
 
   String _type;
-  String get type => _type;
-  set type(String type) => _$writableBuilder._type = type;
+  String get type => _$this._type;
+  set type(String type) => _$this._type = type;
 
   String _generatedIdentifier;
-  String get generatedIdentifier => _generatedIdentifier;
+  String get generatedIdentifier => _$this._generatedIdentifier;
   set generatedIdentifier(String generatedIdentifier) =>
-      _$writableBuilder._generatedIdentifier = generatedIdentifier;
+      _$this._generatedIdentifier = generatedIdentifier;
 
   bool _isConst;
-  bool get isConst => _isConst;
-  set isConst(bool isConst) => _$writableBuilder._isConst = isConst;
+  bool get isConst => _$this._isConst;
+  set isConst(bool isConst) => _$this._isConst = isConst;
 
   bool _isStatic;
-  bool get isStatic => _isStatic;
-  set isStatic(bool isStatic) => _$writableBuilder._isStatic = isStatic;
+  bool get isStatic => _$this._isStatic;
+  set isStatic(bool isStatic) => _$this._isStatic = isStatic;
 
   EnumSourceFieldBuilder();
 
-  EnumSourceFieldBuilder get _$writableBuilder {
+  EnumSourceFieldBuilder get _$this {
     if (_$v != null) {
       _name = _$v.name;
       _type = _$v.type;

--- a/built_value_generator/lib/src/enum_source_library.g.dart
+++ b/built_value_generator/lib/src/enum_source_library.g.dart
@@ -68,26 +68,26 @@ class EnumSourceLibraryBuilder
   EnumSourceLibrary _$v;
 
   String _name;
-  String get name => _name;
-  set name(String name) => _$writableBuilder._name = name;
+  String get name => _$this._name;
+  set name(String name) => _$this._name = name;
 
   String _fileName;
-  String get fileName => _fileName;
-  set fileName(String fileName) => _$writableBuilder._fileName = fileName;
+  String get fileName => _$this._fileName;
+  set fileName(String fileName) => _$this._fileName = fileName;
 
   String _source;
-  String get source => _source;
-  set source(String source) => _$writableBuilder._source = source;
+  String get source => _$this._source;
+  set source(String source) => _$this._source = source;
 
   ListBuilder<EnumSourceClass> _classes;
   ListBuilder<EnumSourceClass> get classes =>
-      _$writableBuilder._classes ??= new ListBuilder<EnumSourceClass>();
+      _$this._classes ??= new ListBuilder<EnumSourceClass>();
   set classes(ListBuilder<EnumSourceClass> classes) =>
-      _$writableBuilder._classes = classes;
+      _$this._classes = classes;
 
   EnumSourceLibraryBuilder();
 
-  EnumSourceLibraryBuilder get _$writableBuilder {
+  EnumSourceLibraryBuilder get _$this {
     if (_$v != null) {
       _name = _$v.name;
       _fileName = _$v.fileName;

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -70,28 +70,26 @@ class SerializerSourceClassBuilder
   SerializerSourceClass _$v;
 
   String _name;
-  String get name => _name;
-  set name(String name) => _$writableBuilder._name = name;
+  String get name => _$this._name;
+  set name(String name) => _$this._name = name;
 
   bool _isBuiltValue;
-  bool get isBuiltValue => _isBuiltValue;
-  set isBuiltValue(bool isBuiltValue) =>
-      _$writableBuilder._isBuiltValue = isBuiltValue;
+  bool get isBuiltValue => _$this._isBuiltValue;
+  set isBuiltValue(bool isBuiltValue) => _$this._isBuiltValue = isBuiltValue;
 
   bool _isEnumClass;
-  bool get isEnumClass => _isEnumClass;
-  set isEnumClass(bool isEnumClass) =>
-      _$writableBuilder._isEnumClass = isEnumClass;
+  bool get isEnumClass => _$this._isEnumClass;
+  set isEnumClass(bool isEnumClass) => _$this._isEnumClass = isEnumClass;
 
   ListBuilder<SerializerSourceField> _fields;
   ListBuilder<SerializerSourceField> get fields =>
-      _$writableBuilder._fields ??= new ListBuilder<SerializerSourceField>();
+      _$this._fields ??= new ListBuilder<SerializerSourceField>();
   set fields(ListBuilder<SerializerSourceField> fields) =>
-      _$writableBuilder._fields = fields;
+      _$this._fields = fields;
 
   SerializerSourceClassBuilder();
 
-  SerializerSourceClassBuilder get _$writableBuilder {
+  SerializerSourceClassBuilder get _$this {
     if (_$v != null) {
       _name = _$v.name;
       _isBuiltValue = _$v.isBuiltValue;

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -82,48 +82,68 @@ class _$SerializerSourceFieldBuilder extends SerializerSourceFieldBuilder {
   SerializerSourceField _$v;
 
   @override
-  bool get isSerializable => super.isSerializable;
+  bool get isSerializable {
+    _$this;
+    return super.isSerializable;
+  }
+
   @override
   set isSerializable(bool isSerializable) {
-    _$writableBuilder;
+    _$this;
     super.isSerializable = isSerializable;
   }
 
   @override
-  bool get isNullable => super.isNullable;
+  bool get isNullable {
+    _$this;
+    return super.isNullable;
+  }
+
   @override
   set isNullable(bool isNullable) {
-    _$writableBuilder;
+    _$this;
     super.isNullable = isNullable;
   }
 
   @override
-  String get name => super.name;
+  String get name {
+    _$this;
+    return super.name;
+  }
+
   @override
   set name(String name) {
-    _$writableBuilder;
+    _$this;
     super.name = name;
   }
 
   @override
-  String get type => super.type;
+  String get type {
+    _$this;
+    return super.type;
+  }
+
   @override
   set type(String type) {
-    _$writableBuilder;
+    _$this;
     super.type = type;
   }
 
   @override
-  bool get builderFieldUsesNestedBuilder => super.builderFieldUsesNestedBuilder;
+  bool get builderFieldUsesNestedBuilder {
+    _$this;
+    return super.builderFieldUsesNestedBuilder;
+  }
+
   @override
   set builderFieldUsesNestedBuilder(bool builderFieldUsesNestedBuilder) {
-    _$writableBuilder;
+    _$this;
     super.builderFieldUsesNestedBuilder = builderFieldUsesNestedBuilder;
   }
 
   _$SerializerSourceFieldBuilder() : super._();
 
-  SerializerSourceFieldBuilder get _$writableBuilder {
+  SerializerSourceFieldBuilder get _$this {
     if (_$v != null) {
       super.isSerializable = _$v.isSerializable;
       super.isNullable = _$v.isNullable;

--- a/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -65,28 +65,32 @@ class _$SerializerSourceLibraryBuilder extends SerializerSourceLibraryBuilder {
   SerializerSourceLibrary _$v;
 
   @override
-  bool get hasSerializers => super.hasSerializers;
+  bool get hasSerializers {
+    _$this;
+    return super.hasSerializers;
+  }
+
   @override
   set hasSerializers(bool hasSerializers) {
-    _$writableBuilder;
+    _$this;
     super.hasSerializers = hasSerializers;
   }
 
   @override
   SetBuilder<SerializerSourceClass> get sourceClasses {
-    _$writableBuilder;
+    _$this;
     return super.sourceClasses ??= new SetBuilder<SerializerSourceClass>();
   }
 
   @override
   set sourceClasses(SetBuilder<SerializerSourceClass> sourceClasses) {
-    _$writableBuilder;
+    _$this;
     super.sourceClasses = sourceClasses;
   }
 
   @override
   SetBuilder<SerializerSourceClass> get transitiveSourceClasses {
-    _$writableBuilder;
+    _$this;
     return super.transitiveSourceClasses ??=
         new SetBuilder<SerializerSourceClass>();
   }
@@ -94,13 +98,13 @@ class _$SerializerSourceLibraryBuilder extends SerializerSourceLibraryBuilder {
   @override
   set transitiveSourceClasses(
       SetBuilder<SerializerSourceClass> transitiveSourceClasses) {
-    _$writableBuilder;
+    _$this;
     super.transitiveSourceClasses = transitiveSourceClasses;
   }
 
   _$SerializerSourceLibraryBuilder() : super._();
 
-  SerializerSourceLibraryBuilder get _$writableBuilder {
+  SerializerSourceLibraryBuilder get _$this {
     if (_$v != null) {
       super.hasSerializers = _$v.hasSerializers;
       super.sourceClasses = _$v.sourceClasses?.toBuilder();

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -316,20 +316,23 @@ abstract class ValueSourceClass
         if (field.isNestedBuilder) {
           result.writeln('@override');
           result.writeln('$typeInBuilder get $name {'
-              '_\$writableBuilder;'
+              '_\$this;'
               'return super.$name ??= new $typeInBuilder();'
               '}');
           result.writeln('@override');
           result.writeln('set $name($typeInBuilder $name) {'
-              '_\$writableBuilder;'
+              '_\$this;'
               'super.$name = $name;'
               '}');
         } else {
           result.writeln('@override');
-          result.writeln('$type get $name => super.$name;');
+          result.writeln('$typeInBuilder get $name {'
+              '_\$this;'
+              'return super.$name;'
+              '}');
           result.writeln('@override');
           result.writeln('set $name($type $name) {'
-              '_\$writableBuilder;'
+              '_\$this;'
               'super.$name = $name;'
               '}');
         }
@@ -344,14 +347,14 @@ abstract class ValueSourceClass
         if (field.isNestedBuilder) {
           result.writeln('$typeInBuilder _$name;');
           result.writeln('$typeInBuilder get $name =>'
-              '_\$writableBuilder._$name ??= new $typeInBuilder();');
+              '_\$this._$name ??= new $typeInBuilder();');
           result.writeln('set $name($typeInBuilder $name) =>'
-              '_\$writableBuilder._$name = $name;');
+              '_\$this._$name = $name;');
         } else {
           result.writeln('$type _$name;');
-          result.writeln('$type get $name => _$name;');
+          result.writeln('$type get $name => _\$this._$name;');
           result.writeln('set $name($type $name) =>'
-              '_\$writableBuilder._$name = $name;');
+              '_\$this._$name = $name;');
         }
         result.writeln();
       }
@@ -366,7 +369,7 @@ abstract class ValueSourceClass
     result.writeln();
 
     // Getter for "this" that does lazy copying if needed.
-    result.writeln('${name}Builder get _\$writableBuilder {');
+    result.writeln('${name}Builder get _\$this {');
     result.writeln('if (_\$v != null) {');
     for (final field in fields) {
       final name = field.name;

--- a/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_value_generator/lib/src/value_source_class.g.dart
@@ -155,132 +155,164 @@ class _$ValueSourceClassBuilder extends ValueSourceClassBuilder {
   ValueSourceClass _$v;
 
   @override
-  String get name => super.name;
+  String get name {
+    _$this;
+    return super.name;
+  }
+
   @override
   set name(String name) {
-    _$writableBuilder;
+    _$this;
     super.name = name;
   }
 
   @override
-  String get builtParameters => super.builtParameters;
+  String get builtParameters {
+    _$this;
+    return super.builtParameters;
+  }
+
   @override
   set builtParameters(String builtParameters) {
-    _$writableBuilder;
+    _$this;
     super.builtParameters = builtParameters;
   }
 
   @override
-  bool get hasBuilder => super.hasBuilder;
+  bool get hasBuilder {
+    _$this;
+    return super.hasBuilder;
+  }
+
   @override
   set hasBuilder(bool hasBuilder) {
-    _$writableBuilder;
+    _$this;
     super.hasBuilder = hasBuilder;
   }
 
   @override
-  String get builderParameters => super.builderParameters;
+  String get builderParameters {
+    _$this;
+    return super.builderParameters;
+  }
+
   @override
   set builderParameters(String builderParameters) {
-    _$writableBuilder;
+    _$this;
     super.builderParameters = builderParameters;
   }
 
   @override
   ListBuilder<ValueSourceField> get fields {
-    _$writableBuilder;
+    _$this;
     return super.fields ??= new ListBuilder<ValueSourceField>();
   }
 
   @override
   set fields(ListBuilder<ValueSourceField> fields) {
-    _$writableBuilder;
+    _$this;
     super.fields = fields;
   }
 
   @override
-  String get partStatement => super.partStatement;
+  String get partStatement {
+    _$this;
+    return super.partStatement;
+  }
+
   @override
   set partStatement(String partStatement) {
-    _$writableBuilder;
+    _$this;
     super.partStatement = partStatement;
   }
 
   @override
-  bool get hasPartStatement => super.hasPartStatement;
+  bool get hasPartStatement {
+    _$this;
+    return super.hasPartStatement;
+  }
+
   @override
   set hasPartStatement(bool hasPartStatement) {
-    _$writableBuilder;
+    _$this;
     super.hasPartStatement = hasPartStatement;
   }
 
   @override
-  bool get valueClassIsAbstract => super.valueClassIsAbstract;
+  bool get valueClassIsAbstract {
+    _$this;
+    return super.valueClassIsAbstract;
+  }
+
   @override
   set valueClassIsAbstract(bool valueClassIsAbstract) {
-    _$writableBuilder;
+    _$this;
     super.valueClassIsAbstract = valueClassIsAbstract;
   }
 
   @override
   ListBuilder<String> get valueClassConstructors {
-    _$writableBuilder;
+    _$this;
     return super.valueClassConstructors ??= new ListBuilder<String>();
   }
 
   @override
   set valueClassConstructors(ListBuilder<String> valueClassConstructors) {
-    _$writableBuilder;
+    _$this;
     super.valueClassConstructors = valueClassConstructors;
   }
 
   @override
   ListBuilder<String> get valueClassFactories {
-    _$writableBuilder;
+    _$this;
     return super.valueClassFactories ??= new ListBuilder<String>();
   }
 
   @override
   set valueClassFactories(ListBuilder<String> valueClassFactories) {
-    _$writableBuilder;
+    _$this;
     super.valueClassFactories = valueClassFactories;
   }
 
   @override
-  bool get builderClassIsAbstract => super.builderClassIsAbstract;
+  bool get builderClassIsAbstract {
+    _$this;
+    return super.builderClassIsAbstract;
+  }
+
   @override
   set builderClassIsAbstract(bool builderClassIsAbstract) {
-    _$writableBuilder;
+    _$this;
     super.builderClassIsAbstract = builderClassIsAbstract;
   }
 
   @override
   ListBuilder<String> get builderClassConstructors {
-    _$writableBuilder;
+    _$this;
     return super.builderClassConstructors ??= new ListBuilder<String>();
   }
 
   @override
   set builderClassConstructors(ListBuilder<String> builderClassConstructors) {
-    _$writableBuilder;
+    _$this;
     super.builderClassConstructors = builderClassConstructors;
   }
 
   @override
   ListBuilder<String> get builderClassFactories {
-    _$writableBuilder;
+    _$this;
     return super.builderClassFactories ??= new ListBuilder<String>();
   }
 
   @override
   set builderClassFactories(ListBuilder<String> builderClassFactories) {
-    _$writableBuilder;
+    _$this;
     super.builderClassFactories = builderClassFactories;
   }
 
   _$ValueSourceClassBuilder() : super._();
 
-  ValueSourceClassBuilder get _$writableBuilder {
+  ValueSourceClassBuilder get _$this {
     if (_$v != null) {
       super.name = _$v.name;
       super.builtParameters = _$v.builtParameters;

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -108,44 +108,44 @@ class ValueSourceFieldBuilder
   ValueSourceField _$v;
 
   String _name;
-  String get name => _name;
-  set name(String name) => _$writableBuilder._name = name;
+  String get name => _$this._name;
+  set name(String name) => _$this._name = name;
 
   String _type;
-  String get type => _type;
-  set type(String type) => _$writableBuilder._type = type;
+  String get type => _$this._type;
+  set type(String type) => _$this._type = type;
 
   bool _isGetter;
-  bool get isGetter => _isGetter;
-  set isGetter(bool isGetter) => _$writableBuilder._isGetter = isGetter;
+  bool get isGetter => _$this._isGetter;
+  set isGetter(bool isGetter) => _$this._isGetter = isGetter;
 
   bool _isNullable;
-  bool get isNullable => _isNullable;
-  set isNullable(bool isNullable) => _$writableBuilder._isNullable = isNullable;
+  bool get isNullable => _$this._isNullable;
+  set isNullable(bool isNullable) => _$this._isNullable = isNullable;
 
   bool _builderFieldExists;
-  bool get builderFieldExists => _builderFieldExists;
+  bool get builderFieldExists => _$this._builderFieldExists;
   set builderFieldExists(bool builderFieldExists) =>
-      _$writableBuilder._builderFieldExists = builderFieldExists;
+      _$this._builderFieldExists = builderFieldExists;
 
   bool _builderFieldIsNormalField;
-  bool get builderFieldIsNormalField => _builderFieldIsNormalField;
+  bool get builderFieldIsNormalField => _$this._builderFieldIsNormalField;
   set builderFieldIsNormalField(bool builderFieldIsNormalField) =>
-      _$writableBuilder._builderFieldIsNormalField = builderFieldIsNormalField;
+      _$this._builderFieldIsNormalField = builderFieldIsNormalField;
 
   String _typeInBuilder;
-  String get typeInBuilder => _typeInBuilder;
+  String get typeInBuilder => _$this._typeInBuilder;
   set typeInBuilder(String typeInBuilder) =>
-      _$writableBuilder._typeInBuilder = typeInBuilder;
+      _$this._typeInBuilder = typeInBuilder;
 
   bool _isNestedBuilder;
-  bool get isNestedBuilder => _isNestedBuilder;
+  bool get isNestedBuilder => _$this._isNestedBuilder;
   set isNestedBuilder(bool isNestedBuilder) =>
-      _$writableBuilder._isNestedBuilder = isNestedBuilder;
+      _$this._isNestedBuilder = isNestedBuilder;
 
   ValueSourceFieldBuilder();
 
-  ValueSourceFieldBuilder get _$writableBuilder {
+  ValueSourceFieldBuilder get _$this {
     if (_$v != null) {
       _name = _$v.name;
       _type = _$v.type;

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -14,7 +14,9 @@ dependencies:
   analyzer: '>=0.28.0 <0.29.0'
   build: '^0.4.1'
   built_collection: '^1.0.0'
-  built_value: ^0.4.2
+# built_value: ^0.4.2
+  built_value:
+    path: ../built_value
   meta: '^1.0.4'
   source_gen: '>=0.5.0+03 <0.6.0'
   quiver: '>=0.21.0 <0.24.0'

--- a/chat_example/lib/data_model/data_model.g.dart
+++ b/chat_example/lib/data_model/data_model.g.dart
@@ -531,18 +531,17 @@ class ChatBuilder implements Builder<Chat, ChatBuilder> {
   Chat _$v;
 
   String _text;
-  String get text => _text;
-  set text(String text) => _$writableBuilder._text = text;
+  String get text => _$this._text;
+  set text(String text) => _$this._text = text;
 
   SetBuilder<String> _targets;
   SetBuilder<String> get targets =>
-      _$writableBuilder._targets ??= new SetBuilder<String>();
-  set targets(SetBuilder<String> targets) =>
-      _$writableBuilder._targets = targets;
+      _$this._targets ??= new SetBuilder<String>();
+  set targets(SetBuilder<String> targets) => _$this._targets = targets;
 
   ChatBuilder();
 
-  ChatBuilder get _$writableBuilder {
+  ChatBuilder get _$this {
     if (_$v != null) {
       _text = _$v.text;
       _targets = _$v.targets?.toBuilder();
@@ -619,16 +618,16 @@ class LoginBuilder implements Builder<Login, LoginBuilder> {
   Login _$v;
 
   String _username;
-  String get username => _username;
-  set username(String username) => _$writableBuilder._username = username;
+  String get username => _$this._username;
+  set username(String username) => _$this._username = username;
 
   String _password;
-  String get password => _password;
-  set password(String password) => _$writableBuilder._password = password;
+  String get password => _$this._password;
+  set password(String password) => _$this._password = password;
 
   LoginBuilder();
 
-  LoginBuilder get _$writableBuilder {
+  LoginBuilder get _$this {
     if (_$v != null) {
       _username = _$v.username;
       _password = _$v.password;
@@ -705,16 +704,16 @@ class StatusBuilder implements Builder<Status, StatusBuilder> {
   Status _$v;
 
   String _message;
-  String get message => _message;
-  set message(String message) => _$writableBuilder._message = message;
+  String get message => _$this._message;
+  set message(String message) => _$this._message = message;
 
   StatusType _type;
-  StatusType get type => _type;
-  set type(StatusType type) => _$writableBuilder._type = type;
+  StatusType get type => _$this._type;
+  set type(StatusType type) => _$this._type = type;
 
   StatusBuilder();
 
-  StatusBuilder get _$writableBuilder {
+  StatusBuilder get _$this {
     if (_$v != null) {
       _message = _$v.message;
       _type = _$v.type;
@@ -788,13 +787,13 @@ class ListUsersBuilder implements Builder<ListUsers, ListUsersBuilder> {
 
   SetBuilder<StatusType> _statusTypes;
   SetBuilder<StatusType> get statusTypes =>
-      _$writableBuilder._statusTypes ??= new SetBuilder<StatusType>();
+      _$this._statusTypes ??= new SetBuilder<StatusType>();
   set statusTypes(SetBuilder<StatusType> statusTypes) =>
-      _$writableBuilder._statusTypes = statusTypes;
+      _$this._statusTypes = statusTypes;
 
   ListUsersBuilder();
 
-  ListUsersBuilder get _$writableBuilder {
+  ListUsersBuilder get _$this {
     if (_$v != null) {
       _statusTypes = _$v.statusTypes?.toBuilder();
       _$v = null;
@@ -877,20 +876,20 @@ class ShowChatBuilder implements Builder<ShowChat, ShowChatBuilder> {
   ShowChat _$v;
 
   String _username;
-  String get username => _username;
-  set username(String username) => _$writableBuilder._username = username;
+  String get username => _$this._username;
+  set username(String username) => _$this._username = username;
 
   bool _private;
-  bool get private => _private;
-  set private(bool private) => _$writableBuilder._private = private;
+  bool get private => _$this._private;
+  set private(bool private) => _$this._private = private;
 
   String _text;
-  String get text => _text;
-  set text(String text) => _$writableBuilder._text = text;
+  String get text => _$this._text;
+  set text(String text) => _$this._text = text;
 
   ShowChatBuilder();
 
-  ShowChatBuilder get _$writableBuilder {
+  ShowChatBuilder get _$this {
     if (_$v != null) {
       _username = _$v.username;
       _private = _$v.private;
@@ -969,17 +968,16 @@ class WelcomeBuilder implements Builder<Welcome, WelcomeBuilder> {
   Welcome _$v;
 
   ListBuilder<Response> _log;
-  ListBuilder<Response> get log =>
-      _$writableBuilder._log ??= new ListBuilder<Response>();
-  set log(ListBuilder<Response> log) => _$writableBuilder._log = log;
+  ListBuilder<Response> get log => _$this._log ??= new ListBuilder<Response>();
+  set log(ListBuilder<Response> log) => _$this._log = log;
 
   String _message;
-  String get message => _message;
-  set message(String message) => _$writableBuilder._message = message;
+  String get message => _$this._message;
+  set message(String message) => _$this._message = message;
 
   WelcomeBuilder();
 
-  WelcomeBuilder get _$writableBuilder {
+  WelcomeBuilder get _$this {
     if (_$v != null) {
       _log = _$v.log?.toBuilder();
       _message = _$v.message;
@@ -1055,13 +1053,13 @@ class ListUsersResponseBuilder
 
   MapBuilder<String, Status> _statuses;
   MapBuilder<String, Status> get statuses =>
-      _$writableBuilder._statuses ??= new MapBuilder<String, Status>();
+      _$this._statuses ??= new MapBuilder<String, Status>();
   set statuses(MapBuilder<String, Status> statuses) =>
-      _$writableBuilder._statuses = statuses;
+      _$this._statuses = statuses;
 
   ListUsersResponseBuilder();
 
-  ListUsersResponseBuilder get _$writableBuilder {
+  ListUsersResponseBuilder get _$this {
     if (_$v != null) {
       _statuses = _$v.statuses?.toBuilder();
       _$v = null;

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -11,12 +11,16 @@ environment:
 
 dependencies:
   built_collection: '^1.0.0'
-  built_value: ^0.4.2
+# built_value: ^0.4.2
+  built_value:
+    path: ../built_value
   package_resolver: ^1.0.0
   route: '>=0.4.6'
 
 dev_dependencies:
   build: '^0.4.0'
-  built_value_generator: ^0.4.2
+# built_value_generator: ^0.4.2
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'
   test: any

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -261,69 +261,65 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
   Collections _$v;
 
   ListBuilder<int> _list;
-  ListBuilder<int> get list =>
-      _$writableBuilder._list ??= new ListBuilder<int>();
-  set list(ListBuilder<int> list) => _$writableBuilder._list = list;
+  ListBuilder<int> get list => _$this._list ??= new ListBuilder<int>();
+  set list(ListBuilder<int> list) => _$this._list = list;
 
   SetBuilder<String> _set;
-  SetBuilder<String> get set =>
-      _$writableBuilder._set ??= new SetBuilder<String>();
-  set set(SetBuilder<String> set) => _$writableBuilder._set = set;
+  SetBuilder<String> get set => _$this._set ??= new SetBuilder<String>();
+  set set(SetBuilder<String> set) => _$this._set = set;
 
   MapBuilder<String, int> _map;
   MapBuilder<String, int> get map =>
-      _$writableBuilder._map ??= new MapBuilder<String, int>();
-  set map(MapBuilder<String, int> map) => _$writableBuilder._map = map;
+      _$this._map ??= new MapBuilder<String, int>();
+  set map(MapBuilder<String, int> map) => _$this._map = map;
 
   ListMultimapBuilder<int, bool> _listMultimap;
   ListMultimapBuilder<int, bool> get listMultimap =>
-      _$writableBuilder._listMultimap ??= new ListMultimapBuilder<int, bool>();
+      _$this._listMultimap ??= new ListMultimapBuilder<int, bool>();
   set listMultimap(ListMultimapBuilder<int, bool> listMultimap) =>
-      _$writableBuilder._listMultimap = listMultimap;
+      _$this._listMultimap = listMultimap;
 
   SetMultimapBuilder<String, bool> _setMultimap;
   SetMultimapBuilder<String, bool> get setMultimap =>
-      _$writableBuilder._setMultimap ??= new SetMultimapBuilder<String, bool>();
+      _$this._setMultimap ??= new SetMultimapBuilder<String, bool>();
   set setMultimap(SetMultimapBuilder<String, bool> setMultimap) =>
-      _$writableBuilder._setMultimap = setMultimap;
+      _$this._setMultimap = setMultimap;
 
   ListBuilder<int> _nullableList;
   ListBuilder<int> get nullableList =>
-      _$writableBuilder._nullableList ??= new ListBuilder<int>();
+      _$this._nullableList ??= new ListBuilder<int>();
   set nullableList(ListBuilder<int> nullableList) =>
-      _$writableBuilder._nullableList = nullableList;
+      _$this._nullableList = nullableList;
 
   SetBuilder<String> _nullableSet;
   SetBuilder<String> get nullableSet =>
-      _$writableBuilder._nullableSet ??= new SetBuilder<String>();
+      _$this._nullableSet ??= new SetBuilder<String>();
   set nullableSet(SetBuilder<String> nullableSet) =>
-      _$writableBuilder._nullableSet = nullableSet;
+      _$this._nullableSet = nullableSet;
 
   MapBuilder<String, int> _nullableMap;
   MapBuilder<String, int> get nullableMap =>
-      _$writableBuilder._nullableMap ??= new MapBuilder<String, int>();
+      _$this._nullableMap ??= new MapBuilder<String, int>();
   set nullableMap(MapBuilder<String, int> nullableMap) =>
-      _$writableBuilder._nullableMap = nullableMap;
+      _$this._nullableMap = nullableMap;
 
   ListMultimapBuilder<int, bool> _nullableListMultimap;
   ListMultimapBuilder<int, bool> get nullableListMultimap =>
-      _$writableBuilder._nullableListMultimap ??=
-          new ListMultimapBuilder<int, bool>();
+      _$this._nullableListMultimap ??= new ListMultimapBuilder<int, bool>();
   set nullableListMultimap(
           ListMultimapBuilder<int, bool> nullableListMultimap) =>
-      _$writableBuilder._nullableListMultimap = nullableListMultimap;
+      _$this._nullableListMultimap = nullableListMultimap;
 
   SetMultimapBuilder<String, bool> _nullableSetMultimap;
   SetMultimapBuilder<String, bool> get nullableSetMultimap =>
-      _$writableBuilder._nullableSetMultimap ??=
-          new SetMultimapBuilder<String, bool>();
+      _$this._nullableSetMultimap ??= new SetMultimapBuilder<String, bool>();
   set nullableSetMultimap(
           SetMultimapBuilder<String, bool> nullableSetMultimap) =>
-      _$writableBuilder._nullableSetMultimap = nullableSetMultimap;
+      _$this._nullableSetMultimap = nullableSetMultimap;
 
   CollectionsBuilder();
 
-  CollectionsBuilder get _$writableBuilder {
+  CollectionsBuilder get _$this {
     if (_$v != null) {
       _list = _$v.list?.toBuilder();
       _set = _$v.set?.toBuilder();

--- a/example/lib/compound_value.g.dart
+++ b/example/lib/compound_value.g.dart
@@ -118,19 +118,19 @@ class CompoundValueBuilder
 
   SimpleValueBuilder _simpleValue;
   SimpleValueBuilder get simpleValue =>
-      _$writableBuilder._simpleValue ??= new SimpleValueBuilder();
+      _$this._simpleValue ??= new SimpleValueBuilder();
   set simpleValue(SimpleValueBuilder simpleValue) =>
-      _$writableBuilder._simpleValue = simpleValue;
+      _$this._simpleValue = simpleValue;
 
   ValidatedValueBuilder _validatedValue;
   ValidatedValueBuilder get validatedValue =>
-      _$writableBuilder._validatedValue ??= new ValidatedValueBuilder();
+      _$this._validatedValue ??= new ValidatedValueBuilder();
   set validatedValue(ValidatedValueBuilder validatedValue) =>
-      _$writableBuilder._validatedValue = validatedValue;
+      _$this._validatedValue = validatedValue;
 
   CompoundValueBuilder();
 
-  CompoundValueBuilder get _$writableBuilder {
+  CompoundValueBuilder get _$this {
     if (_$v != null) {
       _simpleValue = _$v.simpleValue?.toBuilder();
       _validatedValue = _$v.validatedValue?.toBuilder();

--- a/example/lib/has_int.g.dart
+++ b/example/lib/has_int.g.dart
@@ -156,24 +156,32 @@ class _$ValueWithIntBuilder extends ValueWithIntBuilder {
   ValueWithInt _$v;
 
   @override
-  int get anInt => super.anInt;
+  int get anInt {
+    _$this;
+    return super.anInt;
+  }
+
   @override
   set anInt(int anInt) {
-    _$writableBuilder;
+    _$this;
     super.anInt = anInt;
   }
 
   @override
-  String get note => super.note;
+  String get note {
+    _$this;
+    return super.note;
+  }
+
   @override
   set note(String note) {
-    _$writableBuilder;
+    _$this;
     super.note = note;
   }
 
   _$ValueWithIntBuilder() : super._();
 
-  ValueWithIntBuilder get _$writableBuilder {
+  ValueWithIntBuilder get _$this {
     if (_$v != null) {
       super.anInt = _$v.anInt;
       super.note = _$v.note;

--- a/example/lib/simple_value.g.dart
+++ b/example/lib/simple_value.g.dart
@@ -113,16 +113,16 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
   SimpleValue _$v;
 
   int _anInt;
-  int get anInt => _anInt;
-  set anInt(int anInt) => _$writableBuilder._anInt = anInt;
+  int get anInt => _$this._anInt;
+  set anInt(int anInt) => _$this._anInt = anInt;
 
   String _aString;
-  String get aString => _aString;
-  set aString(String aString) => _$writableBuilder._aString = aString;
+  String get aString => _$this._aString;
+  set aString(String aString) => _$this._aString = aString;
 
   SimpleValueBuilder();
 
-  SimpleValueBuilder get _$writableBuilder {
+  SimpleValueBuilder get _$this {
     if (_$v != null) {
       _anInt = _$v.anInt;
       _aString = _$v.aString;

--- a/example/lib/validated_value.g.dart
+++ b/example/lib/validated_value.g.dart
@@ -117,16 +117,16 @@ class ValidatedValueBuilder
   ValidatedValue _$v;
 
   int _anInt;
-  int get anInt => _anInt;
-  set anInt(int anInt) => _$writableBuilder._anInt = anInt;
+  int get anInt => _$this._anInt;
+  set anInt(int anInt) => _$this._anInt = anInt;
 
   String _aString;
-  String get aString => _aString;
-  set aString(String aString) => _$writableBuilder._aString = aString;
+  String get aString => _$this._aString;
+  set aString(String aString) => _$this._aString = aString;
 
   ValidatedValueBuilder();
 
-  ValidatedValueBuilder get _$writableBuilder {
+  ValidatedValueBuilder get _$this {
     if (_$v != null) {
       _anInt = _$v.anInt;
       _aString = _$v.aString;

--- a/example/lib/value_with_code.g.dart
+++ b/example/lib/value_with_code.g.dart
@@ -52,16 +52,16 @@ class ValueWithCodeBuilder
   ValueWithCode _$v;
 
   int _anInt;
-  int get anInt => _anInt;
-  set anInt(int anInt) => _$writableBuilder._anInt = anInt;
+  int get anInt => _$this._anInt;
+  set anInt(int anInt) => _$this._anInt = anInt;
 
   String _aString;
-  String get aString => _aString;
-  set aString(String aString) => _$writableBuilder._aString = aString;
+  String get aString => _$this._aString;
+  set aString(String aString) => _$this._aString = aString;
 
   ValueWithCodeBuilder();
 
-  ValueWithCodeBuilder get _$writableBuilder {
+  ValueWithCodeBuilder get _$this {
     if (_$v != null) {
       _anInt = _$v.anInt;
       _aString = _$v.aString;

--- a/example/lib/value_with_defaults.g.dart
+++ b/example/lib/value_with_defaults.g.dart
@@ -52,24 +52,32 @@ class _$ValueWithDefaultsBuilder extends ValueWithDefaultsBuilder {
   ValueWithDefaults _$v;
 
   @override
-  int get anInt => super.anInt;
+  int get anInt {
+    _$this;
+    return super.anInt;
+  }
+
   @override
   set anInt(int anInt) {
-    _$writableBuilder;
+    _$this;
     super.anInt = anInt;
   }
 
   @override
-  String get aString => super.aString;
+  String get aString {
+    _$this;
+    return super.aString;
+  }
+
   @override
   set aString(String aString) {
-    _$writableBuilder;
+    _$this;
     super.aString = aString;
   }
 
   _$ValueWithDefaultsBuilder() : super._();
 
-  ValueWithDefaultsBuilder get _$writableBuilder {
+  ValueWithDefaultsBuilder get _$this {
     if (_$v != null) {
       super.anInt = _$v.anInt;
       super.aString = _$v.aString;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,11 +12,15 @@ environment:
 dependencies:
   meta: '^1.0.4'
   built_collection: '^1.0.0'
-  built_value: ^0.4.2
+# built_value: ^0.4.2
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: '^0.4.0'
-  built_value_generator: ^0.4.2
+# built_value_generator: ^0.4.2
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'
   quiver: '>=0.21.0 <0.24.0'
   test: any

--- a/example/test/simple_value_test.dart
+++ b/example/test/simple_value_test.dart
@@ -38,6 +38,13 @@ void main() {
       new SimpleValueBuilder();
     });
 
+    test('builder exposes values via getters', () {
+      final builder = new SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '').toBuilder();
+      expect(builder.anInt, 0);
+    });
+
     test('compares equal when equal', () {
       final value1 = new SimpleValue((b) => b
         ..anInt = 0

--- a/example/test/value_with_defaults_test.dart
+++ b/example/test/value_with_defaults_test.dart
@@ -10,5 +10,10 @@ void main() {
     test('has defaults', () {
       expect(new ValueWithDefaults().anInt, 7);
     });
+
+    test('builder exposes values via getters', () {
+      final builder = new ValueWithDefaults((b) => b..anInt = 12).toBuilder();
+      expect(builder.anInt, 12);
+    });
   });
 }


### PR DESCRIPTION
Renamed "_$writableBuilder" to "_$this", since

 - it's now used for all the setters and getters in the builder, not just setters (which is why it was "writable")
 - a longer name didn't seem to add much, and we might as well keep the generated code a bit shorter

Fixes #80 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/81)
<!-- Reviewable:end -->
