### PR TITLE
Significantly improve build performance by using @memoized instead of precomputed fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2
+
+- Significantly improve build performance by using @memoized instead of precomputed fields.
+
 ## 1.1.1
 
 - Update analyzer and build dependencies.

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -12,12 +12,16 @@ environment:
 dependencies:
   browser: any
   built_collection: ^1.0.0
-  built_value: ^1.1.1
+# built_value: ^1.1.1
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.9.0
   build_runner: ^0.3.2
-  built_value_generator: ^1.1.1
+# built_value_generator: ^1.1.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'
   quiver: '>=0.21.0 <0.26.0'
   test: any

--- a/built_value_generator/lib/built_value_generator.dart
+++ b/built_value_generator/lib/built_value_generator.dart
@@ -18,13 +18,11 @@ class BuiltValueGenerator extends Generator {
   @override
   Future<String> generate(Element element, BuildStep buildStep) async {
     if (element is ClassElement && ValueSourceClass.needsBuiltValue(element)) {
-      return new ValueSourceClass.fromClassElement(element).generateCode();
+      return new ValueSourceClass(element).generateCode();
     } else if (element is LibraryElement) {
-      final enumCode =
-          new EnumSourceLibrary.fromLibraryElement(element).generateCode();
+      final enumCode = new EnumSourceLibrary(element).generateCode();
 
-      final serializerSourceLibrary =
-          SerializerSourceLibrary.fromLibraryElement(element);
+      final serializerSourceLibrary = new SerializerSourceLibrary(element);
       if (serializerSourceLibrary.needsBuiltJson ||
           serializerSourceLibrary.hasSerializers) {
         return (enumCode ?? '') + '\n' + serializerSourceLibrary.generateCode();

--- a/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_value_generator/lib/src/enum_source_class.g.dart
@@ -9,41 +9,51 @@ part of built_value_generator.enum_source_class;
 
 class _$EnumSourceClass extends EnumSourceClass {
   @override
-  final String name;
-  @override
-  final bool isAbstract;
-  @override
-  final BuiltList<EnumSourceField> fields;
-  @override
-  final BuiltList<String> constructors;
-  @override
-  final String valuesIdentifier;
-  @override
-  final String valueOfIdentifier;
-  @override
-  final bool usesMixin;
-  @override
-  final String mixinDeclaration;
+  final ClassElement element;
+  String __name;
+  bool __isAbstract;
+  BuiltList<EnumSourceField> __fields;
+  BuiltList<String> __constructors;
+  String __valuesIdentifier;
+  String __valueOfIdentifier;
+  bool __usesMixin;
+  String __mixinDeclaration;
+  Iterable<String> __identifiers;
 
   factory _$EnumSourceClass([void updates(EnumSourceClassBuilder b)]) =>
       (new EnumSourceClassBuilder()..update(updates)).build();
 
-  _$EnumSourceClass._(
-      {this.name,
-      this.isAbstract,
-      this.fields,
-      this.constructors,
-      this.valuesIdentifier,
-      this.valueOfIdentifier,
-      this.usesMixin,
-      this.mixinDeclaration})
-      : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (isAbstract == null) throw new ArgumentError.notNull('isAbstract');
-    if (fields == null) throw new ArgumentError.notNull('fields');
-    if (constructors == null) throw new ArgumentError.notNull('constructors');
-    if (usesMixin == null) throw new ArgumentError.notNull('usesMixin');
+  _$EnumSourceClass._({this.element}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  bool get isAbstract => __isAbstract ??= super.isAbstract;
+
+  @override
+  BuiltList<EnumSourceField> get fields => __fields ??= super.fields;
+
+  @override
+  BuiltList<String> get constructors => __constructors ??= super.constructors;
+
+  @override
+  String get valuesIdentifier => __valuesIdentifier ??= super.valuesIdentifier;
+
+  @override
+  String get valueOfIdentifier =>
+      __valueOfIdentifier ??= super.valueOfIdentifier;
+
+  @override
+  bool get usesMixin => __usesMixin ??= super.usesMixin;
+
+  @override
+  String get mixinDeclaration => __mixinDeclaration ??= super.mixinDeclaration;
+
+  @override
+  Iterable<String> get identifiers => __identifiers ??= super.identifiers;
 
   @override
   EnumSourceClass rebuild(void updates(EnumSourceClassBuilder b)) =>
@@ -57,43 +67,18 @@ class _$EnumSourceClass extends EnumSourceClass {
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! EnumSourceClass) return false;
-    return name == other.name &&
-        isAbstract == other.isAbstract &&
-        fields == other.fields &&
-        constructors == other.constructors &&
-        valuesIdentifier == other.valuesIdentifier &&
-        valueOfIdentifier == other.valueOfIdentifier &&
-        usesMixin == other.usesMixin &&
-        mixinDeclaration == other.mixinDeclaration;
+    return element == other.element;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc($jc($jc(0, name.hashCode), isAbstract.hashCode),
-                            fields.hashCode),
-                        constructors.hashCode),
-                    valuesIdentifier.hashCode),
-                valueOfIdentifier.hashCode),
-            usesMixin.hashCode),
-        mixinDeclaration.hashCode));
+    return $jf($jc(0, element.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('EnumSourceClass')
-          ..add('name', name)
-          ..add('isAbstract', isAbstract)
-          ..add('fields', fields)
-          ..add('constructors', constructors)
-          ..add('valuesIdentifier', valuesIdentifier)
-          ..add('valueOfIdentifier', valueOfIdentifier)
-          ..add('usesMixin', usesMixin)
-          ..add('mixinDeclaration', mixinDeclaration))
+          ..add('element', element))
         .toString();
   }
 }
@@ -102,56 +87,15 @@ class EnumSourceClassBuilder
     implements Builder<EnumSourceClass, EnumSourceClassBuilder> {
   _$EnumSourceClass _$v;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
-
-  bool _isAbstract;
-  bool get isAbstract => _$this._isAbstract;
-  set isAbstract(bool isAbstract) => _$this._isAbstract = isAbstract;
-
-  ListBuilder<EnumSourceField> _fields;
-  ListBuilder<EnumSourceField> get fields =>
-      _$this._fields ??= new ListBuilder<EnumSourceField>();
-  set fields(ListBuilder<EnumSourceField> fields) => _$this._fields = fields;
-
-  ListBuilder<String> _constructors;
-  ListBuilder<String> get constructors =>
-      _$this._constructors ??= new ListBuilder<String>();
-  set constructors(ListBuilder<String> constructors) =>
-      _$this._constructors = constructors;
-
-  String _valuesIdentifier;
-  String get valuesIdentifier => _$this._valuesIdentifier;
-  set valuesIdentifier(String valuesIdentifier) =>
-      _$this._valuesIdentifier = valuesIdentifier;
-
-  String _valueOfIdentifier;
-  String get valueOfIdentifier => _$this._valueOfIdentifier;
-  set valueOfIdentifier(String valueOfIdentifier) =>
-      _$this._valueOfIdentifier = valueOfIdentifier;
-
-  bool _usesMixin;
-  bool get usesMixin => _$this._usesMixin;
-  set usesMixin(bool usesMixin) => _$this._usesMixin = usesMixin;
-
-  String _mixinDeclaration;
-  String get mixinDeclaration => _$this._mixinDeclaration;
-  set mixinDeclaration(String mixinDeclaration) =>
-      _$this._mixinDeclaration = mixinDeclaration;
+  ClassElement _element;
+  ClassElement get element => _$this._element;
+  set element(ClassElement element) => _$this._element = element;
 
   EnumSourceClassBuilder();
 
   EnumSourceClassBuilder get _$this {
     if (_$v != null) {
-      _name = _$v.name;
-      _isAbstract = _$v.isAbstract;
-      _fields = _$v.fields?.toBuilder();
-      _constructors = _$v.constructors?.toBuilder();
-      _valuesIdentifier = _$v.valuesIdentifier;
-      _valueOfIdentifier = _$v.valueOfIdentifier;
-      _usesMixin = _$v.usesMixin;
-      _mixinDeclaration = _$v.mixinDeclaration;
+      _element = _$v.element;
       _$v = null;
     }
     return this;
@@ -170,16 +114,7 @@ class EnumSourceClassBuilder
 
   @override
   _$EnumSourceClass build() {
-    final result = _$v ??
-        new _$EnumSourceClass._(
-            name: name,
-            isAbstract: isAbstract,
-            fields: fields?.build(),
-            constructors: constructors?.build(),
-            valuesIdentifier: valuesIdentifier,
-            valueOfIdentifier: valueOfIdentifier,
-            usesMixin: usesMixin,
-            mixinDeclaration: mixinDeclaration);
+    final result = _$v ?? new _$EnumSourceClass._(element: element);
     replace(result);
     return result;
   }

--- a/built_value_generator/lib/src/enum_source_field.dart
+++ b/built_value_generator/lib/src/enum_source_field.dart
@@ -12,29 +12,29 @@ part 'enum_source_field.g.dart';
 
 abstract class EnumSourceField
     implements Built<EnumSourceField, EnumSourceFieldBuilder> {
-  String get name;
-  String get type;
-  String get generatedIdentifier;
-  bool get isConst;
-  bool get isStatic;
+  FieldElement get element;
 
-  factory EnumSourceField([updates(EnumSourceFieldBuilder b)]) =
-      _$EnumSourceField;
+  factory EnumSourceField(FieldElement element) =>
+      new _$EnumSourceField._(element: element);
   EnumSourceField._();
 
-  factory EnumSourceField.fromFieldElement(FieldElement fieldElement) {
-    return new EnumSourceField((b) => b
-      ..name = fieldElement.displayName
-      ..type = fieldElement.getter.returnType.displayName
-      ..generatedIdentifier = _getGeneratedIdentifier(fieldElement)
-      ..isConst = fieldElement.isConst
-      ..isStatic = fieldElement.isStatic);
+  @memoized
+  String get name => element.displayName;
+
+  @memoized
+  String get type => element.getter.returnType.displayName;
+
+  @memoized
+  String get generatedIdentifier {
+    final fieldName = element.displayName;
+    return element.computeNode().toString().substring('$fieldName = '.length);
   }
 
-  static String _getGeneratedIdentifier(FieldElement field) {
-    final fieldName = field.displayName;
-    return field.computeNode().toString().substring('$fieldName = '.length);
-  }
+  @memoized
+  bool get isConst => element.isConst;
+
+  @memoized
+  bool get isStatic => element.isStatic;
 
   static BuiltList<EnumSourceField> fromClassElement(
       ClassElement classElement) {
@@ -45,7 +45,7 @@ abstract class EnumSourceField
       final type = fieldElement.getter.returnType.displayName;
       if (!fieldElement.isSynthetic &&
           (type == enumName || type == 'dynamic')) {
-        result.add(new EnumSourceField.fromFieldElement(fieldElement));
+        result.add(new EnumSourceField(fieldElement));
       }
     }
 

--- a/built_value_generator/lib/src/enum_source_field.g.dart
+++ b/built_value_generator/lib/src/enum_source_field.g.dart
@@ -9,33 +9,35 @@ part of built_value_generator.enum_source_field;
 
 class _$EnumSourceField extends EnumSourceField {
   @override
-  final String name;
-  @override
-  final String type;
-  @override
-  final String generatedIdentifier;
-  @override
-  final bool isConst;
-  @override
-  final bool isStatic;
+  final FieldElement element;
+  String __name;
+  String __type;
+  String __generatedIdentifier;
+  bool __isConst;
+  bool __isStatic;
 
   factory _$EnumSourceField([void updates(EnumSourceFieldBuilder b)]) =>
       (new EnumSourceFieldBuilder()..update(updates)).build();
 
-  _$EnumSourceField._(
-      {this.name,
-      this.type,
-      this.generatedIdentifier,
-      this.isConst,
-      this.isStatic})
-      : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (type == null) throw new ArgumentError.notNull('type');
-    if (generatedIdentifier == null)
-      throw new ArgumentError.notNull('generatedIdentifier');
-    if (isConst == null) throw new ArgumentError.notNull('isConst');
-    if (isStatic == null) throw new ArgumentError.notNull('isStatic');
+  _$EnumSourceField._({this.element}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get type => __type ??= super.type;
+
+  @override
+  String get generatedIdentifier =>
+      __generatedIdentifier ??= super.generatedIdentifier;
+
+  @override
+  bool get isConst => __isConst ??= super.isConst;
+
+  @override
+  bool get isStatic => __isStatic ??= super.isStatic;
 
   @override
   EnumSourceField rebuild(void updates(EnumSourceFieldBuilder b)) =>
@@ -49,31 +51,18 @@ class _$EnumSourceField extends EnumSourceField {
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! EnumSourceField) return false;
-    return name == other.name &&
-        type == other.type &&
-        generatedIdentifier == other.generatedIdentifier &&
-        isConst == other.isConst &&
-        isStatic == other.isStatic;
+    return element == other.element;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc($jc($jc(0, name.hashCode), type.hashCode),
-                generatedIdentifier.hashCode),
-            isConst.hashCode),
-        isStatic.hashCode));
+    return $jf($jc(0, element.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('EnumSourceField')
-          ..add('name', name)
-          ..add('type', type)
-          ..add('generatedIdentifier', generatedIdentifier)
-          ..add('isConst', isConst)
-          ..add('isStatic', isStatic))
+          ..add('element', element))
         .toString();
   }
 }
@@ -82,36 +71,15 @@ class EnumSourceFieldBuilder
     implements Builder<EnumSourceField, EnumSourceFieldBuilder> {
   _$EnumSourceField _$v;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
-
-  String _type;
-  String get type => _$this._type;
-  set type(String type) => _$this._type = type;
-
-  String _generatedIdentifier;
-  String get generatedIdentifier => _$this._generatedIdentifier;
-  set generatedIdentifier(String generatedIdentifier) =>
-      _$this._generatedIdentifier = generatedIdentifier;
-
-  bool _isConst;
-  bool get isConst => _$this._isConst;
-  set isConst(bool isConst) => _$this._isConst = isConst;
-
-  bool _isStatic;
-  bool get isStatic => _$this._isStatic;
-  set isStatic(bool isStatic) => _$this._isStatic = isStatic;
+  FieldElement _element;
+  FieldElement get element => _$this._element;
+  set element(FieldElement element) => _$this._element = element;
 
   EnumSourceFieldBuilder();
 
   EnumSourceFieldBuilder get _$this {
     if (_$v != null) {
-      _name = _$v.name;
-      _type = _$v.type;
-      _generatedIdentifier = _$v.generatedIdentifier;
-      _isConst = _$v.isConst;
-      _isStatic = _$v.isStatic;
+      _element = _$v.element;
       _$v = null;
     }
     return this;
@@ -130,13 +98,7 @@ class EnumSourceFieldBuilder
 
   @override
   _$EnumSourceField build() {
-    final result = _$v ??
-        new _$EnumSourceField._(
-            name: name,
-            type: type,
-            generatedIdentifier: generatedIdentifier,
-            isConst: isConst,
-            isStatic: isStatic);
+    final result = _$v ?? new _$EnumSourceField._(element: element);
     replace(result);
     return result;
   }

--- a/built_value_generator/lib/src/enum_source_library.dart
+++ b/built_value_generator/lib/src/enum_source_library.dart
@@ -16,29 +16,32 @@ part 'enum_source_library.g.dart';
 
 abstract class EnumSourceLibrary
     implements Built<EnumSourceLibrary, EnumSourceLibraryBuilder> {
-  String get name;
-  String get fileName;
-  String get source;
-  BuiltList<EnumSourceClass> get classes;
+  LibraryElement get element;
 
-  factory EnumSourceLibrary([updates(EnumSourceLibraryBuilder b)]) =
-      _$EnumSourceLibrary;
+  factory EnumSourceLibrary(LibraryElement element) =>
+      new _$EnumSourceLibrary._(element: element);
   EnumSourceLibrary._();
 
-  factory EnumSourceLibrary.fromLibraryElement(LibraryElement libraryElement) {
-    final result = new EnumSourceLibraryBuilder()
-      ..name = libraryElement.name
-      ..fileName = libraryElement.source.shortName.replaceAll('.dart', '')
-      ..source = libraryElement.source.contents.data;
+  @memoized
+  String get name => element.name;
 
-    for (final classElement
-        in LibraryElements.getClassElements(libraryElement)) {
+  @memoized
+  String get fileName => element.source.shortName.replaceAll('.dart', '');
+
+  @memoized
+  String get source => element.source.contents.data;
+
+  @memoized
+  BuiltList<EnumSourceClass> get classes {
+    final result = new ListBuilder<EnumSourceClass>();
+
+    for (final classElement in LibraryElements.getClassElements(element)) {
       if (EnumSourceClass.isMissingImportFor(classElement)) {
         throw _makeError([
           "Import EnumClass: import 'package:built_value/built_value.dart';"
         ]);
       } else if (EnumSourceClass.needsEnumClass(classElement)) {
-        result.classes.add(new EnumSourceClass.fromClassElement(classElement));
+        result.add(new EnumSourceClass(classElement));
       }
     }
     return result.build();

--- a/built_value_generator/lib/src/enum_source_library.g.dart
+++ b/built_value_generator/lib/src/enum_source_library.g.dart
@@ -9,24 +9,30 @@ part of built_value_generator.enum_source_library;
 
 class _$EnumSourceLibrary extends EnumSourceLibrary {
   @override
-  final String name;
-  @override
-  final String fileName;
-  @override
-  final String source;
-  @override
-  final BuiltList<EnumSourceClass> classes;
+  final LibraryElement element;
+  String __name;
+  String __fileName;
+  String __source;
+  BuiltList<EnumSourceClass> __classes;
 
   factory _$EnumSourceLibrary([void updates(EnumSourceLibraryBuilder b)]) =>
       (new EnumSourceLibraryBuilder()..update(updates)).build();
 
-  _$EnumSourceLibrary._({this.name, this.fileName, this.source, this.classes})
-      : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (fileName == null) throw new ArgumentError.notNull('fileName');
-    if (source == null) throw new ArgumentError.notNull('source');
-    if (classes == null) throw new ArgumentError.notNull('classes');
+  _$EnumSourceLibrary._({this.element}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get fileName => __fileName ??= super.fileName;
+
+  @override
+  String get source => __source ??= super.source;
+
+  @override
+  BuiltList<EnumSourceClass> get classes => __classes ??= super.classes;
 
   @override
   EnumSourceLibrary rebuild(void updates(EnumSourceLibraryBuilder b)) =>
@@ -40,26 +46,18 @@ class _$EnumSourceLibrary extends EnumSourceLibrary {
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! EnumSourceLibrary) return false;
-    return name == other.name &&
-        fileName == other.fileName &&
-        source == other.source &&
-        classes == other.classes;
+    return element == other.element;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, name.hashCode), fileName.hashCode), source.hashCode),
-        classes.hashCode));
+    return $jf($jc(0, element.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('EnumSourceLibrary')
-          ..add('name', name)
-          ..add('fileName', fileName)
-          ..add('source', source)
-          ..add('classes', classes))
+          ..add('element', element))
         .toString();
   }
 }
@@ -68,32 +66,15 @@ class EnumSourceLibraryBuilder
     implements Builder<EnumSourceLibrary, EnumSourceLibraryBuilder> {
   _$EnumSourceLibrary _$v;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
-
-  String _fileName;
-  String get fileName => _$this._fileName;
-  set fileName(String fileName) => _$this._fileName = fileName;
-
-  String _source;
-  String get source => _$this._source;
-  set source(String source) => _$this._source = source;
-
-  ListBuilder<EnumSourceClass> _classes;
-  ListBuilder<EnumSourceClass> get classes =>
-      _$this._classes ??= new ListBuilder<EnumSourceClass>();
-  set classes(ListBuilder<EnumSourceClass> classes) =>
-      _$this._classes = classes;
+  LibraryElement _element;
+  LibraryElement get element => _$this._element;
+  set element(LibraryElement element) => _$this._element = element;
 
   EnumSourceLibraryBuilder();
 
   EnumSourceLibraryBuilder get _$this {
     if (_$v != null) {
-      _name = _$v.name;
-      _fileName = _$v.fileName;
-      _source = _$v.source;
-      _classes = _$v.classes?.toBuilder();
+      _element = _$v.element;
       _$v = null;
     }
     return this;
@@ -112,12 +93,7 @@ class EnumSourceLibraryBuilder
 
   @override
   _$EnumSourceLibrary build() {
-    final result = _$v ??
-        new _$EnumSourceLibrary._(
-            name: name,
-            fileName: fileName,
-            source: source,
-            classes: classes?.build());
+    final result = _$v ?? new _$EnumSourceLibrary._(element: element);
     replace(result);
     return result;
   }

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -9,43 +9,48 @@ part of built_value_generator.source_class;
 
 class _$SerializerSourceClass extends SerializerSourceClass {
   @override
-  final String name;
+  final ClassElement element;
   @override
-  final String serializerDeclaration;
-  @override
-  final BuiltList<String> genericParameters;
-  @override
-  final BuiltList<String> genericBounds;
-  @override
-  final bool isBuiltValue;
-  @override
-  final bool isEnumClass;
-  @override
-  final BuiltList<SerializerSourceField> fields;
+  final ClassElement builderElement;
+  String __name;
+  String __serializerDeclaration;
+  BuiltList<String> __genericParameters;
+  BuiltList<String> __genericBounds;
+  bool __isBuiltValue;
+  bool __isEnumClass;
+  BuiltList<SerializerSourceField> __fields;
 
   factory _$SerializerSourceClass(
           [void updates(SerializerSourceClassBuilder b)]) =>
       (new SerializerSourceClassBuilder()..update(updates)).build();
 
-  _$SerializerSourceClass._(
-      {this.name,
-      this.serializerDeclaration,
-      this.genericParameters,
-      this.genericBounds,
-      this.isBuiltValue,
-      this.isEnumClass,
-      this.fields})
-      : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (serializerDeclaration == null)
-      throw new ArgumentError.notNull('serializerDeclaration');
-    if (genericParameters == null)
-      throw new ArgumentError.notNull('genericParameters');
-    if (genericBounds == null) throw new ArgumentError.notNull('genericBounds');
-    if (isBuiltValue == null) throw new ArgumentError.notNull('isBuiltValue');
-    if (isEnumClass == null) throw new ArgumentError.notNull('isEnumClass');
-    if (fields == null) throw new ArgumentError.notNull('fields');
+  _$SerializerSourceClass._({this.element, this.builderElement}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get serializerDeclaration =>
+      __serializerDeclaration ??= super.serializerDeclaration;
+
+  @override
+  BuiltList<String> get genericParameters =>
+      __genericParameters ??= super.genericParameters;
+
+  @override
+  BuiltList<String> get genericBounds =>
+      __genericBounds ??= super.genericBounds;
+
+  @override
+  bool get isBuiltValue => __isBuiltValue ??= super.isBuiltValue;
+
+  @override
+  bool get isEnumClass => __isEnumClass ??= super.isEnumClass;
+
+  @override
+  BuiltList<SerializerSourceField> get fields => __fields ??= super.fields;
 
   @override
   SerializerSourceClass rebuild(void updates(SerializerSourceClassBuilder b)) =>
@@ -59,41 +64,19 @@ class _$SerializerSourceClass extends SerializerSourceClass {
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! SerializerSourceClass) return false;
-    return name == other.name &&
-        serializerDeclaration == other.serializerDeclaration &&
-        genericParameters == other.genericParameters &&
-        genericBounds == other.genericBounds &&
-        isBuiltValue == other.isBuiltValue &&
-        isEnumClass == other.isEnumClass &&
-        fields == other.fields;
+    return element == other.element && builderElement == other.builderElement;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc($jc(0, name.hashCode),
-                            serializerDeclaration.hashCode),
-                        genericParameters.hashCode),
-                    genericBounds.hashCode),
-                isBuiltValue.hashCode),
-            isEnumClass.hashCode),
-        fields.hashCode));
+    return $jf($jc($jc(0, element.hashCode), builderElement.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('SerializerSourceClass')
-          ..add('name', name)
-          ..add('serializerDeclaration', serializerDeclaration)
-          ..add('genericParameters', genericParameters)
-          ..add('genericBounds', genericBounds)
-          ..add('isBuiltValue', isBuiltValue)
-          ..add('isEnumClass', isEnumClass)
-          ..add('fields', fields))
+          ..add('element', element)
+          ..add('builderElement', builderElement))
         .toString();
   }
 }
@@ -102,52 +85,21 @@ class SerializerSourceClassBuilder
     implements Builder<SerializerSourceClass, SerializerSourceClassBuilder> {
   _$SerializerSourceClass _$v;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  ClassElement _element;
+  ClassElement get element => _$this._element;
+  set element(ClassElement element) => _$this._element = element;
 
-  String _serializerDeclaration;
-  String get serializerDeclaration => _$this._serializerDeclaration;
-  set serializerDeclaration(String serializerDeclaration) =>
-      _$this._serializerDeclaration = serializerDeclaration;
-
-  ListBuilder<String> _genericParameters;
-  ListBuilder<String> get genericParameters =>
-      _$this._genericParameters ??= new ListBuilder<String>();
-  set genericParameters(ListBuilder<String> genericParameters) =>
-      _$this._genericParameters = genericParameters;
-
-  ListBuilder<String> _genericBounds;
-  ListBuilder<String> get genericBounds =>
-      _$this._genericBounds ??= new ListBuilder<String>();
-  set genericBounds(ListBuilder<String> genericBounds) =>
-      _$this._genericBounds = genericBounds;
-
-  bool _isBuiltValue;
-  bool get isBuiltValue => _$this._isBuiltValue;
-  set isBuiltValue(bool isBuiltValue) => _$this._isBuiltValue = isBuiltValue;
-
-  bool _isEnumClass;
-  bool get isEnumClass => _$this._isEnumClass;
-  set isEnumClass(bool isEnumClass) => _$this._isEnumClass = isEnumClass;
-
-  ListBuilder<SerializerSourceField> _fields;
-  ListBuilder<SerializerSourceField> get fields =>
-      _$this._fields ??= new ListBuilder<SerializerSourceField>();
-  set fields(ListBuilder<SerializerSourceField> fields) =>
-      _$this._fields = fields;
+  ClassElement _builderElement;
+  ClassElement get builderElement => _$this._builderElement;
+  set builderElement(ClassElement builderElement) =>
+      _$this._builderElement = builderElement;
 
   SerializerSourceClassBuilder();
 
   SerializerSourceClassBuilder get _$this {
     if (_$v != null) {
-      _name = _$v.name;
-      _serializerDeclaration = _$v.serializerDeclaration;
-      _genericParameters = _$v.genericParameters?.toBuilder();
-      _genericBounds = _$v.genericBounds?.toBuilder();
-      _isBuiltValue = _$v.isBuiltValue;
-      _isEnumClass = _$v.isEnumClass;
-      _fields = _$v.fields?.toBuilder();
+      _element = _$v.element;
+      _builderElement = _$v.builderElement;
       _$v = null;
     }
     return this;
@@ -168,13 +120,7 @@ class SerializerSourceClassBuilder
   _$SerializerSourceClass build() {
     final result = _$v ??
         new _$SerializerSourceClass._(
-            name: name,
-            serializerDeclaration: serializerDeclaration,
-            genericParameters: genericParameters?.build(),
-            genericBounds: genericBounds?.build(),
-            isBuiltValue: isBuiltValue,
-            isEnumClass: isEnumClass,
-            fields: fields?.build());
+            element: element, builderElement: builderElement);
     replace(result);
     return result;
   }

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -9,150 +9,91 @@ part of built_value_generator.source_field;
 
 class _$SerializerSourceField extends SerializerSourceField {
   @override
-  final bool isSerializable;
+  final FieldElement element;
   @override
-  final bool isNullable;
-  @override
-  final String name;
-  @override
-  final String type;
-  @override
-  final bool builderFieldUsesNestedBuilder;
+  final FieldElement builderElement;
+  bool __isSerializable;
+  bool __isNullable;
+  String __name;
+  String __type;
+  bool __builderFieldUsesNestedBuilder;
+  String __rawType;
 
   factory _$SerializerSourceField(
           [void updates(SerializerSourceFieldBuilder b)]) =>
-      (new SerializerSourceFieldBuilder()..update(updates)).build()
-          as _$SerializerSourceField;
+      (new SerializerSourceFieldBuilder()..update(updates)).build();
 
-  _$SerializerSourceField._(
-      {this.isSerializable,
-      this.isNullable,
-      this.name,
-      this.type,
-      this.builderFieldUsesNestedBuilder})
-      : super._() {
-    if (isSerializable == null)
-      throw new ArgumentError.notNull('isSerializable');
-    if (isNullable == null) throw new ArgumentError.notNull('isNullable');
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (type == null) throw new ArgumentError.notNull('type');
-    if (builderFieldUsesNestedBuilder == null)
-      throw new ArgumentError.notNull('builderFieldUsesNestedBuilder');
+  _$SerializerSourceField._({this.element, this.builderElement}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  bool get isSerializable => __isSerializable ??= super.isSerializable;
+
+  @override
+  bool get isNullable => __isNullable ??= super.isNullable;
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get type => __type ??= super.type;
+
+  @override
+  bool get builderFieldUsesNestedBuilder =>
+      __builderFieldUsesNestedBuilder ??= super.builderFieldUsesNestedBuilder;
+
+  @override
+  String get rawType => __rawType ??= super.rawType;
 
   @override
   SerializerSourceField rebuild(void updates(SerializerSourceFieldBuilder b)) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  _$SerializerSourceFieldBuilder toBuilder() =>
-      new _$SerializerSourceFieldBuilder()..replace(this);
+  SerializerSourceFieldBuilder toBuilder() =>
+      new SerializerSourceFieldBuilder()..replace(this);
 
   @override
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! SerializerSourceField) return false;
-    return isSerializable == other.isSerializable &&
-        isNullable == other.isNullable &&
-        name == other.name &&
-        type == other.type &&
-        builderFieldUsesNestedBuilder == other.builderFieldUsesNestedBuilder;
+    return element == other.element && builderElement == other.builderElement;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc($jc($jc(0, isSerializable.hashCode), isNullable.hashCode),
-                name.hashCode),
-            type.hashCode),
-        builderFieldUsesNestedBuilder.hashCode));
+    return $jf($jc($jc(0, element.hashCode), builderElement.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('SerializerSourceField')
-          ..add('isSerializable', isSerializable)
-          ..add('isNullable', isNullable)
-          ..add('name', name)
-          ..add('type', type)
-          ..add('builderFieldUsesNestedBuilder', builderFieldUsesNestedBuilder))
+          ..add('element', element)
+          ..add('builderElement', builderElement))
         .toString();
   }
 }
 
-class _$SerializerSourceFieldBuilder extends SerializerSourceFieldBuilder {
+class SerializerSourceFieldBuilder
+    implements Builder<SerializerSourceField, SerializerSourceFieldBuilder> {
   _$SerializerSourceField _$v;
 
-  @override
-  bool get isSerializable {
-    _$this;
-    return super.isSerializable;
-  }
+  FieldElement _element;
+  FieldElement get element => _$this._element;
+  set element(FieldElement element) => _$this._element = element;
 
-  @override
-  set isSerializable(bool isSerializable) {
-    _$this;
-    super.isSerializable = isSerializable;
-  }
+  FieldElement _builderElement;
+  FieldElement get builderElement => _$this._builderElement;
+  set builderElement(FieldElement builderElement) =>
+      _$this._builderElement = builderElement;
 
-  @override
-  bool get isNullable {
-    _$this;
-    return super.isNullable;
-  }
-
-  @override
-  set isNullable(bool isNullable) {
-    _$this;
-    super.isNullable = isNullable;
-  }
-
-  @override
-  String get name {
-    _$this;
-    return super.name;
-  }
-
-  @override
-  set name(String name) {
-    _$this;
-    super.name = name;
-  }
-
-  @override
-  String get type {
-    _$this;
-    return super.type;
-  }
-
-  @override
-  set type(String type) {
-    _$this;
-    super.type = type;
-  }
-
-  @override
-  bool get builderFieldUsesNestedBuilder {
-    _$this;
-    return super.builderFieldUsesNestedBuilder;
-  }
-
-  @override
-  set builderFieldUsesNestedBuilder(bool builderFieldUsesNestedBuilder) {
-    _$this;
-    super.builderFieldUsesNestedBuilder = builderFieldUsesNestedBuilder;
-  }
-
-  _$SerializerSourceFieldBuilder() : super._();
+  SerializerSourceFieldBuilder();
 
   SerializerSourceFieldBuilder get _$this {
     if (_$v != null) {
-      super.isSerializable = _$v.isSerializable;
-      super.isNullable = _$v.isNullable;
-      super.name = _$v.name;
-      super.type = _$v.type;
-      super.builderFieldUsesNestedBuilder = _$v.builderFieldUsesNestedBuilder;
+      _element = _$v.element;
+      _builderElement = _$v.builderElement;
       _$v = null;
     }
     return this;
@@ -173,11 +114,7 @@ class _$SerializerSourceFieldBuilder extends SerializerSourceFieldBuilder {
   _$SerializerSourceField build() {
     final result = _$v ??
         new _$SerializerSourceField._(
-            isSerializable: isSerializable,
-            isNullable: isNullable,
-            name: name,
-            type: type,
-            builderFieldUsesNestedBuilder: builderFieldUsesNestedBuilder);
+            element: element, builderElement: builderElement);
     replace(result);
     return result;
   }

--- a/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -9,26 +9,29 @@ part of built_value_generator.source_library;
 
 class _$SerializerSourceLibrary extends SerializerSourceLibrary {
   @override
-  final bool hasSerializers;
-  @override
-  final BuiltSet<SerializerSourceClass> sourceClasses;
-  @override
-  final BuiltSet<SerializerSourceClass> transitiveSourceClasses;
+  final LibraryElement element;
+  bool __hasSerializers;
+  BuiltSet<SerializerSourceClass> __sourceClasses;
+  BuiltSet<SerializerSourceClass> __transitiveSourceClasses;
 
   factory _$SerializerSourceLibrary(
           [void updates(SerializerSourceLibraryBuilder b)]) =>
-      (new SerializerSourceLibraryBuilder()..update(updates)).build()
-          as _$SerializerSourceLibrary;
+      (new SerializerSourceLibraryBuilder()..update(updates)).build();
 
-  _$SerializerSourceLibrary._(
-      {this.hasSerializers, this.sourceClasses, this.transitiveSourceClasses})
-      : super._() {
-    if (hasSerializers == null)
-      throw new ArgumentError.notNull('hasSerializers');
-    if (sourceClasses == null) throw new ArgumentError.notNull('sourceClasses');
-    if (transitiveSourceClasses == null)
-      throw new ArgumentError.notNull('transitiveSourceClasses');
+  _$SerializerSourceLibrary._({this.element}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  bool get hasSerializers => __hasSerializers ??= super.hasSerializers;
+
+  @override
+  BuiltSet<SerializerSourceClass> get sourceClasses =>
+      __sourceClasses ??= super.sourceClasses;
+
+  @override
+  BuiltSet<SerializerSourceClass> get transitiveSourceClasses =>
+      __transitiveSourceClasses ??= super.transitiveSourceClasses;
 
   @override
   SerializerSourceLibrary rebuild(
@@ -36,82 +39,43 @@ class _$SerializerSourceLibrary extends SerializerSourceLibrary {
       (toBuilder()..update(updates)).build();
 
   @override
-  _$SerializerSourceLibraryBuilder toBuilder() =>
-      new _$SerializerSourceLibraryBuilder()..replace(this);
+  SerializerSourceLibraryBuilder toBuilder() =>
+      new SerializerSourceLibraryBuilder()..replace(this);
 
   @override
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! SerializerSourceLibrary) return false;
-    return hasSerializers == other.hasSerializers &&
-        sourceClasses == other.sourceClasses &&
-        transitiveSourceClasses == other.transitiveSourceClasses;
+    return element == other.element;
   }
 
   @override
   int get hashCode {
-    return $jf($jc($jc($jc(0, hasSerializers.hashCode), sourceClasses.hashCode),
-        transitiveSourceClasses.hashCode));
+    return $jf($jc(0, element.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('SerializerSourceLibrary')
-          ..add('hasSerializers', hasSerializers)
-          ..add('sourceClasses', sourceClasses)
-          ..add('transitiveSourceClasses', transitiveSourceClasses))
+          ..add('element', element))
         .toString();
   }
 }
 
-class _$SerializerSourceLibraryBuilder extends SerializerSourceLibraryBuilder {
+class SerializerSourceLibraryBuilder
+    implements
+        Builder<SerializerSourceLibrary, SerializerSourceLibraryBuilder> {
   _$SerializerSourceLibrary _$v;
 
-  @override
-  bool get hasSerializers {
-    _$this;
-    return super.hasSerializers;
-  }
+  LibraryElement _element;
+  LibraryElement get element => _$this._element;
+  set element(LibraryElement element) => _$this._element = element;
 
-  @override
-  set hasSerializers(bool hasSerializers) {
-    _$this;
-    super.hasSerializers = hasSerializers;
-  }
-
-  @override
-  SetBuilder<SerializerSourceClass> get sourceClasses {
-    _$this;
-    return super.sourceClasses ??= new SetBuilder<SerializerSourceClass>();
-  }
-
-  @override
-  set sourceClasses(SetBuilder<SerializerSourceClass> sourceClasses) {
-    _$this;
-    super.sourceClasses = sourceClasses;
-  }
-
-  @override
-  SetBuilder<SerializerSourceClass> get transitiveSourceClasses {
-    _$this;
-    return super.transitiveSourceClasses ??=
-        new SetBuilder<SerializerSourceClass>();
-  }
-
-  @override
-  set transitiveSourceClasses(
-      SetBuilder<SerializerSourceClass> transitiveSourceClasses) {
-    _$this;
-    super.transitiveSourceClasses = transitiveSourceClasses;
-  }
-
-  _$SerializerSourceLibraryBuilder() : super._();
+  SerializerSourceLibraryBuilder();
 
   SerializerSourceLibraryBuilder get _$this {
     if (_$v != null) {
-      super.hasSerializers = _$v.hasSerializers;
-      super.sourceClasses = _$v.sourceClasses?.toBuilder();
-      super.transitiveSourceClasses = _$v.transitiveSourceClasses?.toBuilder();
+      _element = _$v.element;
       _$v = null;
     }
     return this;
@@ -130,11 +94,7 @@ class _$SerializerSourceLibraryBuilder extends SerializerSourceLibraryBuilder {
 
   @override
   _$SerializerSourceLibrary build() {
-    final result = _$v ??
-        new _$SerializerSourceLibrary._(
-            hasSerializers: hasSerializers,
-            sourceClasses: sourceClasses?.build(),
-            transitiveSourceClasses: transitiveSourceClasses?.build());
+    final result = _$v ?? new _$SerializerSourceLibrary._(element: element);
     replace(result);
     return result;
   }

--- a/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_value_generator/lib/src/value_source_class.g.dart
@@ -9,399 +9,134 @@ part of built_value_generator.source_class;
 
 class _$ValueSourceClass extends ValueSourceClass {
   @override
-  final String name;
-  @override
-  final BuiltList<String> genericParameters;
-  @override
-  final BuiltList<String> genericBounds;
-  @override
-  final String builtParameters;
-  @override
-  final bool hasBuilder;
-  @override
-  final String builderParameters;
-  @override
-  final BuiltList<ValueSourceField> fields;
-  @override
-  final String partStatement;
-  @override
-  final bool hasPartStatement;
-  @override
-  final bool valueClassIsAbstract;
-  @override
-  final BuiltList<String> valueClassConstructors;
-  @override
-  final BuiltList<String> valueClassFactories;
-  @override
-  final bool builderClassIsAbstract;
-  @override
-  final BuiltList<String> builderClassConstructors;
-  @override
-  final BuiltList<String> builderClassFactories;
-  @override
-  final BuiltList<MemoizedGetter> memoizedGetters;
+  final ClassElement element;
+  String __name;
+  ClassElement __builderElement;
+  BuiltList<String> __genericParameters;
+  BuiltList<String> __genericBounds;
+  String __builtParameters;
+  bool __hasBuilder;
+  String __builderParameters;
+  BuiltList<ValueSourceField> __fields;
+  String __partStatement;
+  bool __hasPartStatement;
+  bool __valueClassIsAbstract;
+  BuiltList<String> __valueClassConstructors;
+  BuiltList<String> __valueClassFactories;
+  bool __builderClassIsAbstract;
+  BuiltList<String> __builderClassConstructors;
+  BuiltList<String> __builderClassFactories;
+  BuiltList<MemoizedGetter> __memoizedGetters;
 
   factory _$ValueSourceClass([void updates(ValueSourceClassBuilder b)]) =>
-      (new ValueSourceClassBuilder()..update(updates)).build()
-          as _$ValueSourceClass;
+      (new ValueSourceClassBuilder()..update(updates)).build();
 
-  _$ValueSourceClass._(
-      {this.name,
-      this.genericParameters,
-      this.genericBounds,
-      this.builtParameters,
-      this.hasBuilder,
-      this.builderParameters,
-      this.fields,
-      this.partStatement,
-      this.hasPartStatement,
-      this.valueClassIsAbstract,
-      this.valueClassConstructors,
-      this.valueClassFactories,
-      this.builderClassIsAbstract,
-      this.builderClassConstructors,
-      this.builderClassFactories,
-      this.memoizedGetters})
-      : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (genericParameters == null)
-      throw new ArgumentError.notNull('genericParameters');
-    if (genericBounds == null) throw new ArgumentError.notNull('genericBounds');
-    if (builtParameters == null)
-      throw new ArgumentError.notNull('builtParameters');
-    if (hasBuilder == null) throw new ArgumentError.notNull('hasBuilder');
-    if (builderParameters == null)
-      throw new ArgumentError.notNull('builderParameters');
-    if (fields == null) throw new ArgumentError.notNull('fields');
-    if (partStatement == null) throw new ArgumentError.notNull('partStatement');
-    if (hasPartStatement == null)
-      throw new ArgumentError.notNull('hasPartStatement');
-    if (valueClassIsAbstract == null)
-      throw new ArgumentError.notNull('valueClassIsAbstract');
-    if (valueClassConstructors == null)
-      throw new ArgumentError.notNull('valueClassConstructors');
-    if (valueClassFactories == null)
-      throw new ArgumentError.notNull('valueClassFactories');
-    if (builderClassIsAbstract == null)
-      throw new ArgumentError.notNull('builderClassIsAbstract');
-    if (builderClassConstructors == null)
-      throw new ArgumentError.notNull('builderClassConstructors');
-    if (builderClassFactories == null)
-      throw new ArgumentError.notNull('builderClassFactories');
-    if (memoizedGetters == null)
-      throw new ArgumentError.notNull('memoizedGetters');
+  _$ValueSourceClass._({this.element}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  ClassElement get builderElement => __builderElement ??= super.builderElement;
+
+  @override
+  BuiltList<String> get genericParameters =>
+      __genericParameters ??= super.genericParameters;
+
+  @override
+  BuiltList<String> get genericBounds =>
+      __genericBounds ??= super.genericBounds;
+
+  @override
+  String get builtParameters => __builtParameters ??= super.builtParameters;
+
+  @override
+  bool get hasBuilder => __hasBuilder ??= super.hasBuilder;
+
+  @override
+  String get builderParameters =>
+      __builderParameters ??= super.builderParameters;
+
+  @override
+  BuiltList<ValueSourceField> get fields => __fields ??= super.fields;
+
+  @override
+  String get partStatement => __partStatement ??= super.partStatement;
+
+  @override
+  bool get hasPartStatement => __hasPartStatement ??= super.hasPartStatement;
+
+  @override
+  bool get valueClassIsAbstract =>
+      __valueClassIsAbstract ??= super.valueClassIsAbstract;
+
+  @override
+  BuiltList<String> get valueClassConstructors =>
+      __valueClassConstructors ??= super.valueClassConstructors;
+
+  @override
+  BuiltList<String> get valueClassFactories =>
+      __valueClassFactories ??= super.valueClassFactories;
+
+  @override
+  bool get builderClassIsAbstract =>
+      __builderClassIsAbstract ??= super.builderClassIsAbstract;
+
+  @override
+  BuiltList<String> get builderClassConstructors =>
+      __builderClassConstructors ??= super.builderClassConstructors;
+
+  @override
+  BuiltList<String> get builderClassFactories =>
+      __builderClassFactories ??= super.builderClassFactories;
+
+  @override
+  BuiltList<MemoizedGetter> get memoizedGetters =>
+      __memoizedGetters ??= super.memoizedGetters;
 
   @override
   ValueSourceClass rebuild(void updates(ValueSourceClassBuilder b)) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  _$ValueSourceClassBuilder toBuilder() =>
-      new _$ValueSourceClassBuilder()..replace(this);
+  ValueSourceClassBuilder toBuilder() =>
+      new ValueSourceClassBuilder()..replace(this);
 
   @override
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! ValueSourceClass) return false;
-    return name == other.name &&
-        genericParameters == other.genericParameters &&
-        genericBounds == other.genericBounds &&
-        builtParameters == other.builtParameters &&
-        hasBuilder == other.hasBuilder &&
-        builderParameters == other.builderParameters &&
-        fields == other.fields &&
-        partStatement == other.partStatement &&
-        hasPartStatement == other.hasPartStatement &&
-        valueClassIsAbstract == other.valueClassIsAbstract &&
-        valueClassConstructors == other.valueClassConstructors &&
-        valueClassFactories == other.valueClassFactories &&
-        builderClassIsAbstract == other.builderClassIsAbstract &&
-        builderClassConstructors == other.builderClassConstructors &&
-        builderClassFactories == other.builderClassFactories &&
-        memoizedGetters == other.memoizedGetters;
+    return element == other.element;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc(
-                                $jc(
-                                    $jc(
-                                        $jc(
-                                            $jc(
-                                                $jc(
-                                                    $jc(
-                                                        $jc(
-                                                            $jc(
-                                                                $jc(
-                                                                    0,
-                                                                    name
-                                                                        .hashCode),
-                                                                genericParameters
-                                                                    .hashCode),
-                                                            genericBounds
-                                                                .hashCode),
-                                                        builtParameters
-                                                            .hashCode),
-                                                    hasBuilder.hashCode),
-                                                builderParameters.hashCode),
-                                            fields.hashCode),
-                                        partStatement.hashCode),
-                                    hasPartStatement.hashCode),
-                                valueClassIsAbstract.hashCode),
-                            valueClassConstructors.hashCode),
-                        valueClassFactories.hashCode),
-                    builderClassIsAbstract.hashCode),
-                builderClassConstructors.hashCode),
-            builderClassFactories.hashCode),
-        memoizedGetters.hashCode));
+    return $jf($jc(0, element.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('ValueSourceClass')
-          ..add('name', name)
-          ..add('genericParameters', genericParameters)
-          ..add('genericBounds', genericBounds)
-          ..add('builtParameters', builtParameters)
-          ..add('hasBuilder', hasBuilder)
-          ..add('builderParameters', builderParameters)
-          ..add('fields', fields)
-          ..add('partStatement', partStatement)
-          ..add('hasPartStatement', hasPartStatement)
-          ..add('valueClassIsAbstract', valueClassIsAbstract)
-          ..add('valueClassConstructors', valueClassConstructors)
-          ..add('valueClassFactories', valueClassFactories)
-          ..add('builderClassIsAbstract', builderClassIsAbstract)
-          ..add('builderClassConstructors', builderClassConstructors)
-          ..add('builderClassFactories', builderClassFactories)
-          ..add('memoizedGetters', memoizedGetters))
+          ..add('element', element))
         .toString();
   }
 }
 
-class _$ValueSourceClassBuilder extends ValueSourceClassBuilder {
+class ValueSourceClassBuilder
+    implements Builder<ValueSourceClass, ValueSourceClassBuilder> {
   _$ValueSourceClass _$v;
 
-  @override
-  String get name {
-    _$this;
-    return super.name;
-  }
+  ClassElement _element;
+  ClassElement get element => _$this._element;
+  set element(ClassElement element) => _$this._element = element;
 
-  @override
-  set name(String name) {
-    _$this;
-    super.name = name;
-  }
-
-  @override
-  ListBuilder<String> get genericParameters {
-    _$this;
-    return super.genericParameters ??= new ListBuilder<String>();
-  }
-
-  @override
-  set genericParameters(ListBuilder<String> genericParameters) {
-    _$this;
-    super.genericParameters = genericParameters;
-  }
-
-  @override
-  ListBuilder<String> get genericBounds {
-    _$this;
-    return super.genericBounds ??= new ListBuilder<String>();
-  }
-
-  @override
-  set genericBounds(ListBuilder<String> genericBounds) {
-    _$this;
-    super.genericBounds = genericBounds;
-  }
-
-  @override
-  String get builtParameters {
-    _$this;
-    return super.builtParameters;
-  }
-
-  @override
-  set builtParameters(String builtParameters) {
-    _$this;
-    super.builtParameters = builtParameters;
-  }
-
-  @override
-  bool get hasBuilder {
-    _$this;
-    return super.hasBuilder;
-  }
-
-  @override
-  set hasBuilder(bool hasBuilder) {
-    _$this;
-    super.hasBuilder = hasBuilder;
-  }
-
-  @override
-  String get builderParameters {
-    _$this;
-    return super.builderParameters;
-  }
-
-  @override
-  set builderParameters(String builderParameters) {
-    _$this;
-    super.builderParameters = builderParameters;
-  }
-
-  @override
-  ListBuilder<ValueSourceField> get fields {
-    _$this;
-    return super.fields ??= new ListBuilder<ValueSourceField>();
-  }
-
-  @override
-  set fields(ListBuilder<ValueSourceField> fields) {
-    _$this;
-    super.fields = fields;
-  }
-
-  @override
-  String get partStatement {
-    _$this;
-    return super.partStatement;
-  }
-
-  @override
-  set partStatement(String partStatement) {
-    _$this;
-    super.partStatement = partStatement;
-  }
-
-  @override
-  bool get hasPartStatement {
-    _$this;
-    return super.hasPartStatement;
-  }
-
-  @override
-  set hasPartStatement(bool hasPartStatement) {
-    _$this;
-    super.hasPartStatement = hasPartStatement;
-  }
-
-  @override
-  bool get valueClassIsAbstract {
-    _$this;
-    return super.valueClassIsAbstract;
-  }
-
-  @override
-  set valueClassIsAbstract(bool valueClassIsAbstract) {
-    _$this;
-    super.valueClassIsAbstract = valueClassIsAbstract;
-  }
-
-  @override
-  ListBuilder<String> get valueClassConstructors {
-    _$this;
-    return super.valueClassConstructors ??= new ListBuilder<String>();
-  }
-
-  @override
-  set valueClassConstructors(ListBuilder<String> valueClassConstructors) {
-    _$this;
-    super.valueClassConstructors = valueClassConstructors;
-  }
-
-  @override
-  ListBuilder<String> get valueClassFactories {
-    _$this;
-    return super.valueClassFactories ??= new ListBuilder<String>();
-  }
-
-  @override
-  set valueClassFactories(ListBuilder<String> valueClassFactories) {
-    _$this;
-    super.valueClassFactories = valueClassFactories;
-  }
-
-  @override
-  bool get builderClassIsAbstract {
-    _$this;
-    return super.builderClassIsAbstract;
-  }
-
-  @override
-  set builderClassIsAbstract(bool builderClassIsAbstract) {
-    _$this;
-    super.builderClassIsAbstract = builderClassIsAbstract;
-  }
-
-  @override
-  ListBuilder<String> get builderClassConstructors {
-    _$this;
-    return super.builderClassConstructors ??= new ListBuilder<String>();
-  }
-
-  @override
-  set builderClassConstructors(ListBuilder<String> builderClassConstructors) {
-    _$this;
-    super.builderClassConstructors = builderClassConstructors;
-  }
-
-  @override
-  ListBuilder<String> get builderClassFactories {
-    _$this;
-    return super.builderClassFactories ??= new ListBuilder<String>();
-  }
-
-  @override
-  set builderClassFactories(ListBuilder<String> builderClassFactories) {
-    _$this;
-    super.builderClassFactories = builderClassFactories;
-  }
-
-  @override
-  ListBuilder<MemoizedGetter> get memoizedGetters {
-    _$this;
-    return super.memoizedGetters ??= new ListBuilder<MemoizedGetter>();
-  }
-
-  @override
-  set memoizedGetters(ListBuilder<MemoizedGetter> memoizedGetters) {
-    _$this;
-    super.memoizedGetters = memoizedGetters;
-  }
-
-  _$ValueSourceClassBuilder() : super._();
+  ValueSourceClassBuilder();
 
   ValueSourceClassBuilder get _$this {
     if (_$v != null) {
-      super.name = _$v.name;
-      super.genericParameters = _$v.genericParameters?.toBuilder();
-      super.genericBounds = _$v.genericBounds?.toBuilder();
-      super.builtParameters = _$v.builtParameters;
-      super.hasBuilder = _$v.hasBuilder;
-      super.builderParameters = _$v.builderParameters;
-      super.fields = _$v.fields?.toBuilder();
-      super.partStatement = _$v.partStatement;
-      super.hasPartStatement = _$v.hasPartStatement;
-      super.valueClassIsAbstract = _$v.valueClassIsAbstract;
-      super.valueClassConstructors = _$v.valueClassConstructors?.toBuilder();
-      super.valueClassFactories = _$v.valueClassFactories?.toBuilder();
-      super.builderClassIsAbstract = _$v.builderClassIsAbstract;
-      super.builderClassConstructors =
-          _$v.builderClassConstructors?.toBuilder();
-      super.builderClassFactories = _$v.builderClassFactories?.toBuilder();
-      super.memoizedGetters = _$v.memoizedGetters?.toBuilder();
+      _element = _$v.element;
       _$v = null;
     }
     return this;
@@ -420,24 +155,7 @@ class _$ValueSourceClassBuilder extends ValueSourceClassBuilder {
 
   @override
   _$ValueSourceClass build() {
-    final result = _$v ??
-        new _$ValueSourceClass._(
-            name: name,
-            genericParameters: genericParameters?.build(),
-            genericBounds: genericBounds?.build(),
-            builtParameters: builtParameters,
-            hasBuilder: hasBuilder,
-            builderParameters: builderParameters,
-            fields: fields?.build(),
-            partStatement: partStatement,
-            hasPartStatement: hasPartStatement,
-            valueClassIsAbstract: valueClassIsAbstract,
-            valueClassConstructors: valueClassConstructors?.build(),
-            valueClassFactories: valueClassFactories?.build(),
-            builderClassIsAbstract: builderClassIsAbstract,
-            builderClassConstructors: builderClassConstructors?.build(),
-            builderClassFactories: builderClassFactories?.build(),
-            memoizedGetters: memoizedGetters?.build());
+    final result = _$v ?? new _$ValueSourceClass._(element: element);
     replace(result);
     return result;
   }

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -9,47 +9,50 @@ part of built_value_generator.source_field;
 
 class _$ValueSourceField extends ValueSourceField {
   @override
-  final String name;
+  final FieldElement element;
   @override
-  final String type;
-  @override
-  final bool isGetter;
-  @override
-  final bool isNullable;
-  @override
-  final bool builderFieldExists;
-  @override
-  final bool builderFieldIsNormalField;
-  @override
-  final String typeInBuilder;
-  @override
-  final bool isNestedBuilder;
+  final FieldElement builderElement;
+  String __name;
+  String __type;
+  bool __isGetter;
+  bool __isNullable;
+  bool __builderFieldExists;
+  bool __builderFieldIsNormalField;
+  String __typeInBuilder;
+  bool __isNestedBuilder;
 
   factory _$ValueSourceField([void updates(ValueSourceFieldBuilder b)]) =>
       (new ValueSourceFieldBuilder()..update(updates)).build();
 
-  _$ValueSourceField._(
-      {this.name,
-      this.type,
-      this.isGetter,
-      this.isNullable,
-      this.builderFieldExists,
-      this.builderFieldIsNormalField,
-      this.typeInBuilder,
-      this.isNestedBuilder})
-      : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (type == null) throw new ArgumentError.notNull('type');
-    if (isGetter == null) throw new ArgumentError.notNull('isGetter');
-    if (isNullable == null) throw new ArgumentError.notNull('isNullable');
-    if (builderFieldExists == null)
-      throw new ArgumentError.notNull('builderFieldExists');
-    if (builderFieldIsNormalField == null)
-      throw new ArgumentError.notNull('builderFieldIsNormalField');
-    if (typeInBuilder == null) throw new ArgumentError.notNull('typeInBuilder');
-    if (isNestedBuilder == null)
-      throw new ArgumentError.notNull('isNestedBuilder');
+  _$ValueSourceField._({this.element, this.builderElement}) : super._() {
+    if (element == null) throw new ArgumentError.notNull('element');
   }
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get type => __type ??= super.type;
+
+  @override
+  bool get isGetter => __isGetter ??= super.isGetter;
+
+  @override
+  bool get isNullable => __isNullable ??= super.isNullable;
+
+  @override
+  bool get builderFieldExists =>
+      __builderFieldExists ??= super.builderFieldExists;
+
+  @override
+  bool get builderFieldIsNormalField =>
+      __builderFieldIsNormalField ??= super.builderFieldIsNormalField;
+
+  @override
+  String get typeInBuilder => __typeInBuilder ??= super.typeInBuilder;
+
+  @override
+  bool get isNestedBuilder => __isNestedBuilder ??= super.isNestedBuilder;
 
   @override
   ValueSourceField rebuild(void updates(ValueSourceFieldBuilder b)) =>
@@ -63,43 +66,19 @@ class _$ValueSourceField extends ValueSourceField {
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! ValueSourceField) return false;
-    return name == other.name &&
-        type == other.type &&
-        isGetter == other.isGetter &&
-        isNullable == other.isNullable &&
-        builderFieldExists == other.builderFieldExists &&
-        builderFieldIsNormalField == other.builderFieldIsNormalField &&
-        typeInBuilder == other.typeInBuilder &&
-        isNestedBuilder == other.isNestedBuilder;
+    return element == other.element && builderElement == other.builderElement;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc($jc($jc(0, name.hashCode), type.hashCode),
-                            isGetter.hashCode),
-                        isNullable.hashCode),
-                    builderFieldExists.hashCode),
-                builderFieldIsNormalField.hashCode),
-            typeInBuilder.hashCode),
-        isNestedBuilder.hashCode));
+    return $jf($jc($jc(0, element.hashCode), builderElement.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('ValueSourceField')
-          ..add('name', name)
-          ..add('type', type)
-          ..add('isGetter', isGetter)
-          ..add('isNullable', isNullable)
-          ..add('builderFieldExists', builderFieldExists)
-          ..add('builderFieldIsNormalField', builderFieldIsNormalField)
-          ..add('typeInBuilder', typeInBuilder)
-          ..add('isNestedBuilder', isNestedBuilder))
+          ..add('element', element)
+          ..add('builderElement', builderElement))
         .toString();
   }
 }
@@ -108,54 +87,21 @@ class ValueSourceFieldBuilder
     implements Builder<ValueSourceField, ValueSourceFieldBuilder> {
   _$ValueSourceField _$v;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  FieldElement _element;
+  FieldElement get element => _$this._element;
+  set element(FieldElement element) => _$this._element = element;
 
-  String _type;
-  String get type => _$this._type;
-  set type(String type) => _$this._type = type;
-
-  bool _isGetter;
-  bool get isGetter => _$this._isGetter;
-  set isGetter(bool isGetter) => _$this._isGetter = isGetter;
-
-  bool _isNullable;
-  bool get isNullable => _$this._isNullable;
-  set isNullable(bool isNullable) => _$this._isNullable = isNullable;
-
-  bool _builderFieldExists;
-  bool get builderFieldExists => _$this._builderFieldExists;
-  set builderFieldExists(bool builderFieldExists) =>
-      _$this._builderFieldExists = builderFieldExists;
-
-  bool _builderFieldIsNormalField;
-  bool get builderFieldIsNormalField => _$this._builderFieldIsNormalField;
-  set builderFieldIsNormalField(bool builderFieldIsNormalField) =>
-      _$this._builderFieldIsNormalField = builderFieldIsNormalField;
-
-  String _typeInBuilder;
-  String get typeInBuilder => _$this._typeInBuilder;
-  set typeInBuilder(String typeInBuilder) =>
-      _$this._typeInBuilder = typeInBuilder;
-
-  bool _isNestedBuilder;
-  bool get isNestedBuilder => _$this._isNestedBuilder;
-  set isNestedBuilder(bool isNestedBuilder) =>
-      _$this._isNestedBuilder = isNestedBuilder;
+  FieldElement _builderElement;
+  FieldElement get builderElement => _$this._builderElement;
+  set builderElement(FieldElement builderElement) =>
+      _$this._builderElement = builderElement;
 
   ValueSourceFieldBuilder();
 
   ValueSourceFieldBuilder get _$this {
     if (_$v != null) {
-      _name = _$v.name;
-      _type = _$v.type;
-      _isGetter = _$v.isGetter;
-      _isNullable = _$v.isNullable;
-      _builderFieldExists = _$v.builderFieldExists;
-      _builderFieldIsNormalField = _$v.builderFieldIsNormalField;
-      _typeInBuilder = _$v.typeInBuilder;
-      _isNestedBuilder = _$v.isNestedBuilder;
+      _element = _$v.element;
+      _builderElement = _$v.builderElement;
       _$v = null;
     }
     return this;
@@ -176,14 +122,7 @@ class ValueSourceFieldBuilder
   _$ValueSourceField build() {
     final result = _$v ??
         new _$ValueSourceField._(
-            name: name,
-            type: type,
-            isGetter: isGetter,
-            isNullable: isNullable,
-            builderFieldExists: builderFieldExists,
-            builderFieldIsNormalField: builderFieldIsNormalField,
-            typeInBuilder: typeInBuilder,
-            isNestedBuilder: isNestedBuilder);
+            element: element, builderElement: builderElement);
     replace(result);
     return result;
   }

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -14,7 +14,9 @@ dependencies:
   analyzer: '>=0.29.0 <0.31.0'
   build: ^0.9.0
   built_collection: ^1.0.0
-  built_value: ^1.1.1
+# built_value: ^1.1.1
+  built_value:
+    path: ../built_value
   meta: ^1.0.4
   source_gen: '>=0.5.0+03 <0.6.0'
   quiver: '>=0.21.0 <0.26.0'

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -11,7 +11,9 @@ environment:
   sdk: '>=1.8.0 <2.0.0'
 
 dependencies:
-  built_value: ^1.1.1
+# built_value: ^1.1.1
+  built_value:
+    path: ../built_value
   built_collection: ^1.0.0
   collection: ^1.0.0
   quiver: '>=0.21.0 <0.26.0'
@@ -20,5 +22,7 @@ dependencies:
 dev_dependencies:
   build: ^0.9.0
   build_runner: ^0.3.2
-  built_value_generator: ^1.1.1
+# built_value_generator: ^1.1.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -12,7 +12,9 @@ environment:
 dependencies:
   browser: ^0.10.0
   built_collection: ^1.0.0
-  built_value: ^1.1.1
+# built_value: ^1.1.1
+  built_value:
+    path: ../built_value
   shelf: ^0.6.0
   shelf_proxy: ^0.1.0
   shelf_web_socket: ^0.2.1
@@ -21,6 +23,8 @@ dependencies:
 dev_dependencies:
   build: ^0.9.0
   build_runner: ^0.3.2
-  built_value_generator: ^1.1.1
+# built_value_generator: ^1.1.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'
   test: any

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -12,12 +12,16 @@ environment:
 dependencies:
   meta: ^1.0.4
   built_collection: ^1.0.0
-  built_value: ^1.1.1
+# built_value: ^1.1.1
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.9.0
   build_runner: ^0.3.2
-  built_value_generator: ^1.1.1
+# built_value_generator: ^1.1.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'
   quiver: '>=0.21.0 <0.26.0'
   test: any

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,12 +12,16 @@ environment:
 dependencies:
   meta: ^1.0.4
   built_collection: ^1.0.0
-  built_value: ^1.1.1
+# built_value: ^1.1.1
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.9.0
   build_runner: ^0.3.2
-  built_value_generator: ^1.1.1
+# built_value_generator: ^1.1.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: '>=0.5.0+03 <0.6.0'
   quiver: '>=0.21.0 <0.26.0'
   test: any


### PR DESCRIPTION
Straightforward refactor with no change to functionality or tests: instead of precomputing everything in e.g. ValueSourceClass constructor, store analyzer elements and do computation on them only in @memoized getters.

Significantly faster at build time when there is irrelevant code visible to the analyzer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/168)
<!-- Reviewable:end -->
