### PR TITLE
Improve annotation handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.0.1 (unreleased)
 
-- Make generator robust against invalid annotations.
+- Improved annotation handling for corner cases.
 
 ## 4.0.0
 

--- a/built_value_generator/lib/src/memoized_getter.dart
+++ b/built_value_generator/lib/src/memoized_getter.dart
@@ -2,6 +2,8 @@ library built_value_generator.memoized_getter;
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/metadata.dart'
+    show metadataToStringValue;
 
 part 'memoized_getter.g.dart';
 
@@ -18,8 +20,8 @@ abstract class MemoizedGetter
         .where((field) =>
             field.getter != null &&
             !field.getter.isAbstract &&
-            field.getter.metadata.any((metadata) =>
-                metadata.constantValue?.toStringValue() == 'memoized'))
+            field.getter.metadata.any(
+                (metadata) => metadataToStringValue(metadata) == 'memoized'))
         .map((field) => new MemoizedGetter((b) => b
           ..returnType = field.getter.returnType.toString()
           ..name = field.displayName))

--- a/built_value_generator/lib/src/metadata.dart
+++ b/built_value_generator/lib/src/metadata.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:source_gen/source_gen.dart';
+
+/// Gets the `String` value of an annotation. Throws a descriptive
+/// [InvalidGenerationSourceError] if the annotation can't be resolved.
+String metadataToStringValue(ElementAnnotation annotation) {
+  final value = annotation.computeConstantValue();
+  if (value == null) {
+    throw new InvalidGenerationSourceError(
+        'Can’t process annotation “${annotation.toSource()}” in '
+        '“${annotation.librarySource.uri}”. Please check for a missing import.');
+  }
+  return value.toStringValue();
+}

--- a/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_value_generator/lib/src/serializer_source_field.dart
@@ -9,6 +9,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/dart_types.dart';
+import 'package:built_value_generator/src/metadata.dart'
+    show metadataToStringValue;
 
 part 'serializer_source_field.g.dart';
 
@@ -47,7 +49,7 @@ abstract class SerializerSourceField
 
   @memoized
   bool get isNullable => element.getter.metadata
-      .any((metadata) => metadata.constantValue?.toStringValue() == 'nullable');
+      .any((metadata) => metadataToStringValue(metadata) == 'nullable');
 
   @memoized
   String get name => element.displayName;

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -11,6 +11,8 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/dart_types.dart';
 import 'package:built_value_generator/src/fields.dart' show collectFields;
+import 'package:built_value_generator/src/metadata.dart'
+    show metadataToStringValue;
 
 part 'value_source_field.g.dart';
 
@@ -43,7 +45,7 @@ abstract class ValueSourceField
 
   @memoized
   bool get isNullable => element.getter.metadata
-      .any((metadata) => metadata.constantValue?.toStringValue() == 'nullable');
+      .any((metadata) => metadataToStringValue(metadata) == 'nullable');
 
   @memoized
   bool get builderFieldExists => builderElement != null;


### PR DESCRIPTION
Fixes #220 

For real this time :)

The problem was that the "constantValue" getter is allowed to sometimes return null. What I really wanted was "computeConstantValue". This PR also improves handling if there is a missing import.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/222)
<!-- Reviewable:end -->
