### PR TITLE
Fix for built_collection 2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.4
+
+- Fix for built_collection 2.0.0.
+
 ## 4.3.3
 
 - Allow quiver 0.26.

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -11,13 +11,17 @@ environment:
 
 dependencies:
   browser: any
-  built_collection: ^1.0.0
-  built_value: ^4.3.3
+  built_collection: ^2.0.0
+# built_value: ^4.3.3
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.10.0
   build_runner: ^0.4.0
-  built_value_generator: ^4.3.3
+# built_value_generator: ^4.3.3
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.26.0'
   test: any

--- a/built_value/lib/src/built_list_multimap_serializer.dart
+++ b/built_value/lib/src/built_list_multimap_serializer.dart
@@ -9,7 +9,8 @@ class BuiltListMultimapSerializer
     implements StructuredSerializer<BuiltListMultimap> {
   final bool structured = true;
   @override
-  final Iterable<Type> types = new BuiltList<Type>([BuiltListMultimap]);
+  final Iterable<Type> types = new BuiltList<Type>(
+      [BuiltListMultimap, new BuiltListMultimap<Object, Object>().runtimeType]);
   @override
   final String wireName = 'listMultimap';
 

--- a/built_value/lib/src/built_list_serializer.dart
+++ b/built_value/lib/src/built_list_serializer.dart
@@ -8,7 +8,8 @@ import 'package:built_value/serializer.dart';
 class BuiltListSerializer implements StructuredSerializer<BuiltList> {
   final bool structured = true;
   @override
-  final Iterable<Type> types = new BuiltList<Type>([BuiltList]);
+  final Iterable<Type> types =
+      new BuiltList<Type>([BuiltList, new BuiltList<Object>().runtimeType]);
   @override
   final String wireName = 'list';
 

--- a/built_value/lib/src/built_map_serializer.dart
+++ b/built_value/lib/src/built_map_serializer.dart
@@ -8,7 +8,8 @@ import 'package:built_value/serializer.dart';
 class BuiltMapSerializer implements StructuredSerializer<BuiltMap> {
   final bool structured = true;
   @override
-  final Iterable<Type> types = new BuiltList<Type>([BuiltMap]);
+  final Iterable<Type> types = new BuiltList<Type>(
+      [BuiltMap, new BuiltMap<Object, Object>().runtimeType]);
   @override
   final String wireName = 'map';
 

--- a/built_value/lib/src/built_set_serializer.dart
+++ b/built_value/lib/src/built_set_serializer.dart
@@ -8,7 +8,8 @@ import 'package:built_value/serializer.dart';
 class BuiltSetSerializer implements StructuredSerializer<BuiltSet> {
   final bool structured = true;
   @override
-  final Iterable<Type> types = new BuiltList<Type>([BuiltSet]);
+  final Iterable<Type> types =
+      new BuiltList<Type>([BuiltSet, new BuiltSet<Object>().runtimeType]);
   @override
   final String wireName = 'set';
 

--- a/built_value/pubspec.yaml
+++ b/built_value/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=1.21.0 <2.0.0'
 
 dependencies:
-  built_collection: ^1.0.0
+  built_collection: ^2.0.0
   collection: ^1.0.0
   fixnum: ^0.10.0
   quiver: '>=0.21.0 <0.27.0'

--- a/built_value/test/built_list_multimap_serializer_test.dart
+++ b/built_value/test/built_list_multimap_serializer_test.dart
@@ -42,9 +42,8 @@ void main() {
       expect(
           serializers
               .deserialize(serialized, specifiedType: specifiedType)
-              .runtimeType
-              .toString(),
-          'BuiltListMultimap<int, String>');
+              .runtimeType,
+          new BuiltListMultimap<int, String>().runtimeType);
     });
   });
 }

--- a/built_value/test/built_list_serializer_test.dart
+++ b/built_value/test/built_list_serializer_test.dart
@@ -50,9 +50,8 @@ void main() {
       expect(
           serializers
               .deserialize(serialized, specifiedType: specifiedType)
-              .runtimeType
-              .toString(),
-          'BuiltList<int>');
+              .runtimeType,
+          new BuiltList<int>().runtimeType);
     });
   });
 

--- a/built_value/test/built_map_serializer_test.dart
+++ b/built_value/test/built_map_serializer_test.dart
@@ -51,9 +51,8 @@ void main() {
       expect(
           serializers
               .deserialize(serialized, specifiedType: specifiedType)
-              .runtimeType
-              .toString(),
-          'BuiltMap<int, String>');
+              .runtimeType,
+          new BuiltMap<int, String>().runtimeType);
     });
   });
 
@@ -178,9 +177,9 @@ void main() {
       expect(
           genericSerializer
               .deserialize(serialized, specifiedType: specifiedType)
-              .runtimeType
-              .toString(),
-          'BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>');
+              .runtimeType,
+          new BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>()
+              .runtimeType);
     });
   });
 

--- a/built_value/test/built_set_multimap_serializer_test.dart
+++ b/built_value/test/built_set_multimap_serializer_test.dart
@@ -42,9 +42,8 @@ void main() {
       expect(
           serializers
               .deserialize(serialized, specifiedType: specifiedType)
-              .runtimeType
-              .toString(),
-          'BuiltSetMultimap<int, String>');
+              .runtimeType,
+          new BuiltSetMultimap<int, String>().runtimeType);
     });
   });
 }

--- a/built_value/test/built_set_serializer_test.dart
+++ b/built_value/test/built_set_serializer_test.dart
@@ -51,9 +51,8 @@ void main() {
       expect(
           serializers
               .deserialize(serialized, specifiedType: specifiedType)
-              .runtimeType
-              .toString(),
-          'BuiltSet<int>');
+              .runtimeType,
+          new BuiltSet<int>().runtimeType);
     });
   });
 

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -13,8 +13,10 @@ environment:
 dependencies:
   analyzer: '>=0.29.0 <0.31.0'
   build: ^0.10.0
-  built_collection: ^1.0.0
-  built_value: ^4.3.3
+  built_collection: ^2.0.0
+# built_value: ^4.3.3
+  built_value:
+    path: ../built_value
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.27.0'
 

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -11,8 +11,10 @@ environment:
   sdk: '>=1.8.0 <2.0.0'
 
 dependencies:
-  built_value: ^4.3.3
-  built_collection: ^1.0.0
+# built_value: ^4.3.3
+  built_value:
+    path: ../built_value
+  built_collection: ^2.0.0
   collection: ^1.0.0
   quiver: '>=0.21.0 <0.27.0'
   test: any
@@ -20,5 +22,7 @@ dependencies:
 dev_dependencies:
   build: ^0.10.0
   build_runner: ^0.4.0
-  built_value_generator: ^4.3.3
+# built_value_generator: ^4.3.3
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -11,8 +11,10 @@ environment:
 
 dependencies:
   browser: ^0.10.0
-  built_collection: ^1.0.0
-  built_value: ^4.3.3
+  built_collection: ^2.0.0
+# built_value: ^4.3.3
+  built_value:
+    path: ../built_value
   shelf: ^0.6.0
   shelf_proxy: ^0.1.0
   shelf_web_socket: ^0.2.1
@@ -21,6 +23,8 @@ dependencies:
 dev_dependencies:
   build: ^0.10.0
   build_runner: ^0.4.0
-  built_value_generator: ^4.3.3
+# built_value_generator: ^4.3.3
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0
   test: any

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -10,13 +10,17 @@ environment:
   sdk: '>=1.8.0 <2.0.0'
 
 dependencies:
-  built_collection: ^1.0.0
-  built_value: ^4.3.3
+  built_collection: ^2.0.0
+# built_value: ^4.3.3
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.10.0
   build_runner: ^0.4.0
-  built_value_generator: ^4.3.3
+# built_value_generator: ^4.3.3
+  built_value_generator:
+    path: ../built_value_generator
   fixnum: ^0.10.0
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.26.0'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,13 +11,17 @@ environment:
 
 dependencies:
   meta: ^1.0.4
-  built_collection: ^1.0.0
-  built_value: ^4.3.3
+  built_collection: ^2.0.0
+# built_value: ^4.3.3
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.10.0
   build_runner: ^0.4.0
-  built_value_generator: ^4.3.3
+# built_value_generator: ^4.3.3
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.26.0'
   test: any


### PR DESCRIPTION
 - Get the actual `runtimeType` of collections for serialization, instead of assuming we know it.
 - Stop using strings for `runtimeType` in tests and use actual values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/264)
<!-- Reviewable:end -->
