### PR TITLE
Add a recipe for boilerplate generation in IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ the same for Dart. The boilerplate is generated for you, leaving you to
 specify which fields you need and to add code for the behaviour of the
 class.
 
+### Generating boilerplate for Value Types
+
+Value types require a bit of boilerplate in order to connect it to generated
+code. Luckily, even this bit of boilerplate can be got automated using code
+snippets support in your favourite text editor. For example, in IntelliJ you
+can use following live template:
+
+```
+abstract class $CLASS_NAME$ implements Built<$CLASS_NAME$, $CLASS_NAME$Builder> {
+  $CLASS_NAME$._();
+  factory $CLASS_NAME$([updates($CLASS_NAME$Builder b)]) = _$$$CLASS_NAME$;
+}
+```
+
+Using this template you would only have to manually enter a name of your data
+class name which is something that can't be automated.
+
 ## Enum Class
 
 Enum Classes provide classes with enum features.


### PR DESCRIPTION
I've added a live template for generating bits of boilerplate required to use built_value and decided to share it in the docs. Not sure whether README.md is the best place for that but there doesn't seem to be other places to put docs to?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/268)
<!-- Reviewable:end -->
