### PR TITLE
Add ignored annotation for fields that should not be compared

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 #   Name/Organization <email address>
 
 David Morgan/Google Inc. <davidmorgan@google.com>
+Resul Alkan/MetGlobal <me@resulalkan.com>

--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -88,6 +88,11 @@ const String nullable = 'nullable';
 
 /// Memoized annotation for Built Value getters and methods.
 ///
+/// Fields marked with this annotation are not compared in the == operator.
+const String ignored = 'ignored';
+
+/// Memoized annotation for Built Value getters and methods.
+///
 /// Getters marked with this annotation are memoized: the result is calculated
 /// once on first access and stored in the instance.
 const String memoized = 'memoized';

--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -86,10 +86,13 @@ class BuiltValue {
 /// Fields marked with this annotation are allowed to be null.
 const String nullable = 'nullable';
 
-/// BuiltValueField annotation for Built Value fields.
-///
-/// Fields marked with this annotation are not compared in the == operator.
+/// Optionally, annotate a Built Value field with this to specify settings.
+/// This is only needed for advanced use.
 class BuiltValueField {
+  /// Whether the field is compared and hashed. Defaults to `true`.
+  ///
+  /// Set to `false` to ignore the field when calculating `hashCode` and when
+  /// comparing with `operator==`.
   final bool compare;
 
   const BuiltValueField({this.compare: true});

--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -86,10 +86,14 @@ class BuiltValue {
 /// Fields marked with this annotation are allowed to be null.
 const String nullable = 'nullable';
 
-/// Memoized annotation for Built Value getters and methods.
+/// BuiltValueField annotation for Built Value fields.
 ///
 /// Fields marked with this annotation are not compared in the == operator.
-const String ignored = 'ignored';
+class BuiltValueField {
+  final bool compare;
+
+  const BuiltValueField({this.compare: true});
+}
 
 /// Memoized annotation for Built Value getters and methods.
 ///

--- a/built_value_generator/lib/src/metadata.dart
+++ b/built_value_generator/lib/src/metadata.dart
@@ -3,16 +3,29 @@
 // license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:source_gen/source_gen.dart';
 
-/// Gets the `String` value of an annotation. Throws a descriptive
-/// [InvalidGenerationSourceError] if the annotation can't be resolved.
-String metadataToStringValue(ElementAnnotation annotation) {
+DartObject getConstantValueFromAnnotation(ElementAnnotation annotation) {
   final value = annotation.computeConstantValue();
   if (value == null) {
     throw new InvalidGenerationSourceError(
         'Can’t process annotation “${annotation.toSource()}” in '
         '“${annotation.librarySource.uri}”. Please check for a missing import.');
   }
+  return value;
+}
+
+/// Gets the `String` value of an annotation. Throws a descriptive
+/// [InvalidGenerationSourceError] if the annotation can't be resolved.
+String metadataToStringValue(ElementAnnotation annotation) {
+  final value = getConstantValueFromAnnotation(annotation);
   return value.toStringValue();
+}
+
+/// Gets a field from an annotation. Throws a descriptive
+/// [InvalidGenerationSourceError] if the annotation can't be resolved.
+DartObject getMetadataField(ElementAnnotation annotation, String name) {
+  final value = getConstantValueFromAnnotation(annotation);
+  return value.getField(name);
 }

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -380,11 +380,12 @@ abstract class ValueSourceClass
     result.writeln('bool operator==(dynamic other) {');
     result.writeln('  if (identical(other, this)) return true;');
     result.writeln('  if (other is! $name) return false;');
-    if (fields.length == 0) {
+    final comparedFields = fields.where((field) => !field.isIgnored);
+    if (comparedFields.length == 0) {
       result.writeln('return true;');
     } else {
       result.writeln('return');
-      result.writeln(fields
+      result.writeln(comparedFields
           .map((field) => '${field.name} == other.${field.name}')
           .join('&&'));
       result.writeln(';');

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -380,7 +380,8 @@ abstract class ValueSourceClass
     result.writeln('bool operator==(dynamic other) {');
     result.writeln('  if (identical(other, this)) return true;');
     result.writeln('  if (other is! $name) return false;');
-    final comparedFields = fields.where((field) => field.isCompared);
+    final comparedFields =
+        fields.where((field) => field.builtValueField.compare);
     if (comparedFields.length == 0) {
       result.writeln('return true;');
     } else {

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -380,7 +380,7 @@ abstract class ValueSourceClass
     result.writeln('bool operator==(dynamic other) {');
     result.writeln('  if (identical(other, this)) return true;');
     result.writeln('  if (other is! $name) return false;');
-    final comparedFields = fields.where((field) => !field.isIgnored);
+    final comparedFields = fields.where((field) => field.isCompared);
     if (comparedFields.length == 0) {
       result.writeln('return true;');
     } else {
@@ -395,13 +395,15 @@ abstract class ValueSourceClass
 
     result.writeln('@override');
     result.writeln('int get hashCode {');
-    if (fields.length == 0) {
+
+    if (comparedFields.length == 0) {
       result.writeln('return ${name.hashCode};');
     } else {
       result.writeln(r'return $jf(');
-      result.writeln(r'$jc(' * fields.length);
+      result.writeln(r'$jc(' * comparedFields.length);
       result.writeln('0, ');
-      result.write(fields.map((field) => '${field.name}.hashCode').join('), '));
+      result.write(
+          comparedFields.map((field) => '${field.name}.hashCode').join('), '));
       result.writeln('));');
     }
     result.writeln('}');

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -12,7 +12,7 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/dart_types.dart';
 import 'package:built_value_generator/src/fields.dart' show collectFields;
 import 'package:built_value_generator/src/metadata.dart'
-    show metadataToStringValue, getMetadataField;
+    show metadataToStringValue;
 
 part 'value_source_field.g.dart';
 
@@ -59,10 +59,15 @@ abstract class ValueSourceField
       .any((metadata) => metadataToStringValue(metadata) == 'nullable');
 
   @memoized
-  bool get isCompared => element.getter.metadata.every((metadata) =>
-      getMetadataField(metadata, 'compare') != null
-          ? getMetadataField(metadata, 'compare').toBoolValue()
-          : true);
+  BuiltValueField get builtValueField {
+    final annotations = element.getter.metadata
+        .map((annotation) => annotation.computeConstantValue())
+        .where((value) => value?.type?.displayName == 'BuiltValueField');
+    if (annotations.isEmpty) return const BuiltValueField();
+    final annotation = annotations.single;
+    return new BuiltValueField(
+        compare: annotation.getField('compare').toBoolValue());
+  }
 
   @memoized
   bool get builderFieldExists => builderElement != null;

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -12,7 +12,7 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/dart_types.dart';
 import 'package:built_value_generator/src/fields.dart' show collectFields;
 import 'package:built_value_generator/src/metadata.dart'
-    show metadataToStringValue;
+    show metadataToStringValue, getMetadataField;
 
 part 'value_source_field.g.dart';
 
@@ -59,8 +59,10 @@ abstract class ValueSourceField
       .any((metadata) => metadataToStringValue(metadata) == 'nullable');
 
   @memoized
-  bool get isIgnored => element.getter.metadata
-      .any((metadata) => metadataToStringValue(metadata) == 'ignored');
+  bool get isCompared => element.getter.metadata.every((metadata) =>
+      getMetadataField(metadata, 'compare') != null
+          ? getMetadataField(metadata, 'compare').toBoolValue()
+          : true);
 
   @memoized
   bool get builderFieldExists => builderElement != null;

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -59,6 +59,10 @@ abstract class ValueSourceField
       .any((metadata) => metadataToStringValue(metadata) == 'nullable');
 
   @memoized
+  bool get isIgnored => element.getter.metadata
+      .any((metadata) => metadataToStringValue(metadata) == 'ignored');
+
+  @memoized
   bool get builderFieldExists => builderElement != null;
 
   @memoized

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -26,7 +26,7 @@ class _$ValueSourceField extends ValueSourceField {
   String __typeWithPrefix;
   bool __isGetter;
   bool __isNullable;
-  bool __isCompared;
+  BuiltValueField __builtValueField;
   bool __builderFieldExists;
   bool __builderFieldIsNormalField;
   String __buildElementType;
@@ -58,7 +58,8 @@ class _$ValueSourceField extends ValueSourceField {
   bool get isNullable => __isNullable ??= super.isNullable;
 
   @override
-  bool get isCompared => __isCompared ??= super.isCompared;
+  BuiltValueField get builtValueField =>
+      __builtValueField ??= super.builtValueField;
 
   @override
   bool get builderFieldExists =>

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -26,7 +26,7 @@ class _$ValueSourceField extends ValueSourceField {
   String __typeWithPrefix;
   bool __isGetter;
   bool __isNullable;
-  bool __isIgnored;
+  bool __isCompared;
   bool __builderFieldExists;
   bool __builderFieldIsNormalField;
   String __buildElementType;
@@ -58,7 +58,7 @@ class _$ValueSourceField extends ValueSourceField {
   bool get isNullable => __isNullable ??= super.isNullable;
 
   @override
-  bool get isIgnored => __isIgnored ??= super.isIgnored;
+  bool get isCompared => __isCompared ??= super.isCompared;
 
   @override
   bool get builderFieldExists =>

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -26,6 +26,7 @@ class _$ValueSourceField extends ValueSourceField {
   String __typeWithPrefix;
   bool __isGetter;
   bool __isNullable;
+  bool __isIgnored;
   bool __builderFieldExists;
   bool __builderFieldIsNormalField;
   String __buildElementType;
@@ -55,6 +56,9 @@ class _$ValueSourceField extends ValueSourceField {
 
   @override
   bool get isNullable => __isNullable ??= super.isNullable;
+
+  @override
+  bool get isIgnored => __isIgnored ??= super.isIgnored;
 
   @override
   bool get builderFieldExists =>

--- a/built_value_test/test/matcher_test.dart
+++ b/built_value_test/test/matcher_test.dart
@@ -46,33 +46,33 @@ void main() {
       _expectMismatch(value, otherValue, 'is the wrong type');
     });
 
-    test('ignored value matcher', () {
-      final value = new IgnoredValue((b) => b
+    test('compared value matcher', () {
+      final value = new ComparedValue((b) => b
         ..name = 'foo'
         ..onChanged = () => 'Change happened!');
-      final otherValue = new IgnoredValue((b) => b
+      final otherValue = new ComparedValue((b) => b
         ..name = 'foo'
         ..onChanged = () => 'Change happened!');
 
       expect(value, otherValue);
     });
 
-    test('ignored value matcher with different onChanged outcomes', () {
-      final value = new IgnoredValue((b) => b
+    test('compared value matcher with different onChanged outcomes', () {
+      final value = new ComparedValue((b) => b
         ..name = 'foo'
         ..onChanged = () => 'Change happened!');
-      final otherValue = new IgnoredValue((b) => b
+      final otherValue = new ComparedValue((b) => b
         ..name = 'foo'
         ..onChanged = () => 'Change did not happen!');
 
       expect(value, otherValue);
     });
 
-    test('ignored value matcher with different names', () {
-      final value = new IgnoredValue((b) => b
+    test('compared value matcher with different names', () {
+      final value = new ComparedValue((b) => b
         ..name = 'foo'
         ..onChanged = () => 'Change happened!');
-      final otherValue = new IgnoredValue((b) => b
+      final otherValue = new ComparedValue((b) => b
         ..name = 'bar'
         ..onChanged = () => 'Change did not happen!');
 

--- a/built_value_test/test/matcher_test.dart
+++ b/built_value_test/test/matcher_test.dart
@@ -45,6 +45,39 @@ void main() {
 
       _expectMismatch(value, otherValue, 'is the wrong type');
     });
+
+    test('ignored value matcher', () {
+      final value = new IgnoredValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+      final otherValue = new IgnoredValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+
+      expect(value, otherValue);
+    });
+
+    test('ignored value matcher with different onChanged outcomes', () {
+      final value = new IgnoredValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+      final otherValue = new IgnoredValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change did not happen!');
+
+      expect(value, otherValue);
+    });
+
+    test('ignored value matcher with different names', () {
+      final value = new IgnoredValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+      final otherValue = new IgnoredValue((b) => b
+        ..name = 'bar'
+        ..onChanged = () => 'Change did not happen!');
+
+      _expectMismatch(value, otherValue, 'was \'foo\' instead of \'bar\'');
+    });
   });
 }
 

--- a/built_value_test/test/values.dart
+++ b/built_value_test/test/values.dart
@@ -26,3 +26,13 @@ abstract class CompoundValue
   factory CompoundValue([updates(CompoundValueBuilder b)]) = _$CompoundValue;
   CompoundValue._();
 }
+
+abstract class IgnoredValue
+    implements Built<IgnoredValue, IgnoredValueBuilder> {
+  String get name;
+  @ignored
+  Function get onChanged;
+
+  factory IgnoredValue([updates(IgnoredValueBuilder b)]) = _$IgnoredValue;
+  IgnoredValue._();
+}

--- a/built_value_test/test/values.dart
+++ b/built_value_test/test/values.dart
@@ -27,12 +27,13 @@ abstract class CompoundValue
   CompoundValue._();
 }
 
-abstract class IgnoredValue
-    implements Built<IgnoredValue, IgnoredValueBuilder> {
+abstract class ComparedValue
+    implements Built<ComparedValue, ComparedValueBuilder> {
   String get name;
-  @ignored
+
+  @BuiltValueField(compare: false)
   Function get onChanged;
 
-  factory IgnoredValue([updates(IgnoredValueBuilder b)]) = _$IgnoredValue;
-  IgnoredValue._();
+  factory ComparedValue([updates(ComparedValueBuilder b)]) = _$ComparedValue;
+  ComparedValue._();
 }

--- a/built_value_test/test/values.g.dart
+++ b/built_value_test/test/values.g.dart
@@ -185,3 +185,88 @@ class CompoundValueBuilder
     return _$result;
   }
 }
+
+class _$IgnoredValue extends IgnoredValue {
+  @override
+  final String name;
+  @override
+  final Function onChanged;
+
+  factory _$IgnoredValue([void updates(IgnoredValueBuilder b)]) =>
+      (new IgnoredValueBuilder()..update(updates)).build();
+
+  _$IgnoredValue._({this.name, this.onChanged}) : super._() {
+    if (name == null) throw new ArgumentError.notNull('name');
+    if (onChanged == null) throw new ArgumentError.notNull('onChanged');
+  }
+
+  @override
+  IgnoredValue rebuild(void updates(IgnoredValueBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  IgnoredValueBuilder toBuilder() => new IgnoredValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(other, this)) return true;
+    if (other is! IgnoredValue) return false;
+    return name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, name.hashCode), onChanged.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('IgnoredValue')
+          ..add('name', name)
+          ..add('onChanged', onChanged))
+        .toString();
+  }
+}
+
+class IgnoredValueBuilder
+    implements Builder<IgnoredValue, IgnoredValueBuilder> {
+  _$IgnoredValue _$v;
+
+  String _name;
+  String get name => _$this._name;
+  set name(String name) => _$this._name = name;
+
+  Function _onChanged;
+  Function get onChanged => _$this._onChanged;
+  set onChanged(Function onChanged) => _$this._onChanged = onChanged;
+
+  IgnoredValueBuilder();
+
+  IgnoredValueBuilder get _$this {
+    if (_$v != null) {
+      _name = _$v.name;
+      _onChanged = _$v.onChanged;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(IgnoredValue other) {
+    if (other == null) throw new ArgumentError.notNull('other');
+    _$v = other as _$IgnoredValue;
+  }
+
+  @override
+  void update(void updates(IgnoredValueBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$IgnoredValue build() {
+    final _$result =
+        _$v ?? new _$IgnoredValue._(name: name, onChanged: onChanged);
+    replace(_$result);
+    return _$result;
+  }
+}

--- a/built_value_test/test/values.g.dart
+++ b/built_value_test/test/values.g.dart
@@ -186,51 +186,51 @@ class CompoundValueBuilder
   }
 }
 
-class _$IgnoredValue extends IgnoredValue {
+class _$ComparedValue extends ComparedValue {
   @override
   final String name;
   @override
   final Function onChanged;
 
-  factory _$IgnoredValue([void updates(IgnoredValueBuilder b)]) =>
-      (new IgnoredValueBuilder()..update(updates)).build();
+  factory _$ComparedValue([void updates(ComparedValueBuilder b)]) =>
+      (new ComparedValueBuilder()..update(updates)).build();
 
-  _$IgnoredValue._({this.name, this.onChanged}) : super._() {
+  _$ComparedValue._({this.name, this.onChanged}) : super._() {
     if (name == null) throw new ArgumentError.notNull('name');
     if (onChanged == null) throw new ArgumentError.notNull('onChanged');
   }
 
   @override
-  IgnoredValue rebuild(void updates(IgnoredValueBuilder b)) =>
+  ComparedValue rebuild(void updates(ComparedValueBuilder b)) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  IgnoredValueBuilder toBuilder() => new IgnoredValueBuilder()..replace(this);
+  ComparedValueBuilder toBuilder() => new ComparedValueBuilder()..replace(this);
 
   @override
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
-    if (other is! IgnoredValue) return false;
+    if (other is! ComparedValue) return false;
     return name == other.name;
   }
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, name.hashCode), onChanged.hashCode));
+    return $jf($jc(0, name.hashCode));
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('IgnoredValue')
+    return (newBuiltValueToStringHelper('ComparedValue')
           ..add('name', name)
           ..add('onChanged', onChanged))
         .toString();
   }
 }
 
-class IgnoredValueBuilder
-    implements Builder<IgnoredValue, IgnoredValueBuilder> {
-  _$IgnoredValue _$v;
+class ComparedValueBuilder
+    implements Builder<ComparedValue, ComparedValueBuilder> {
+  _$ComparedValue _$v;
 
   String _name;
   String get name => _$this._name;
@@ -240,9 +240,9 @@ class IgnoredValueBuilder
   Function get onChanged => _$this._onChanged;
   set onChanged(Function onChanged) => _$this._onChanged = onChanged;
 
-  IgnoredValueBuilder();
+  ComparedValueBuilder();
 
-  IgnoredValueBuilder get _$this {
+  ComparedValueBuilder get _$this {
     if (_$v != null) {
       _name = _$v.name;
       _onChanged = _$v.onChanged;
@@ -252,20 +252,20 @@ class IgnoredValueBuilder
   }
 
   @override
-  void replace(IgnoredValue other) {
+  void replace(ComparedValue other) {
     if (other == null) throw new ArgumentError.notNull('other');
-    _$v = other as _$IgnoredValue;
+    _$v = other as _$ComparedValue;
   }
 
   @override
-  void update(void updates(IgnoredValueBuilder b)) {
+  void update(void updates(ComparedValueBuilder b)) {
     if (updates != null) updates(this);
   }
 
   @override
-  _$IgnoredValue build() {
+  _$ComparedValue build() {
     final _$result =
-        _$v ?? new _$IgnoredValue._(name: name, onChanged: onChanged);
+        _$v ?? new _$ComparedValue._(name: name, onChanged: onChanged);
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/test/to_string_test.dart
+++ b/end_to_end_test/test/to_string_test.dart
@@ -11,7 +11,9 @@ void main() {
     test('omits nulls', () {
       final value = new CompoundValue((b) => b..simpleValue.anInt = 1);
 
-      expect(value.toString(), '''CompoundValue {
+      expect(
+          value.toString(),
+          '''CompoundValue {
   simpleValue=SimpleValue {
     anInt=1,
   },

--- a/end_to_end_test/test/values_test.dart
+++ b/end_to_end_test/test/values_test.dart
@@ -106,7 +106,9 @@ void main() {
       final value1 = new SimpleValue((b) => b
         ..anInt = 0
         ..aString = '');
-      expect(value1.toString(), '''SimpleValue {
+      expect(
+          value1.toString(),
+          '''SimpleValue {
   anInt=0,
   aString=,
 }''');


### PR DESCRIPTION
I've had an issue with using flutter_redux and when creating a ViewModel for the store to pass on to the widget, I wasn't able to compare the old ViewModel instance with the new one every time a change happened. Since I had to pass a `String code` and a `Function onChange` (for dispatching actions) field in the ViewModel.

And when the field `code` is being compared it will return `true` however because the `onChange` field is a closure function, it always compares as `false` so the widget gets updated even when there is no direct change for this widget in the state.

```
(store) => new RoomTypeDropdownViewModel((b) => b
      ..code = store.state.roomTypeCode
      ..onChanged = (v) => store.dispatch({
        'type': SearchRoomTypeActions.Select,
        'room_type': v
      }));
```

I think we need a way to make `bool operator ==(other)` ignore specific fields.

With this PR we will be able to ignore certain fields in `bool operator ==(other)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/270)
<!-- Reviewable:end -->
