### PR TITLE
Fix function types in generated builders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.4.2
+
+- Fix generated builder when fields hold function types.
+
 ## 4.4.1
 
 - Use build 0.11.1 and build_runner 0.6.0.

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -12,12 +12,16 @@ environment:
 dependencies:
   browser: any
   built_collection: ^2.0.0
-  built_value: ^4.4.1
+# built_value: ^4.4.1
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.11.1
   build_runner: ^0.6.0
-  built_value_generator: ^4.4.1
+# built_value_generator: ^4.4.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.26.0'
   test: any

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -97,7 +97,7 @@ abstract class ValueSourceField
   @memoized
   String get typeInBuilder => builderFieldExists
       ? buildElementType
-      : _toBuilderType(element.getter.returnType);
+      : _toBuilderType(element.getter.returnType, typeWithPrefix);
 
   @memoized
   bool get isNestedBuilder => builderFieldExists
@@ -121,17 +121,17 @@ abstract class ValueSourceField
     return result.build();
   }
 
-  static String _toBuilderType(DartType type) {
+  static String _toBuilderType(DartType type, String displayName) {
     if (DartTypes.isBuiltCollection(type)) {
-      return type.displayName
+      return displayName
           .replaceFirst('Built', '')
           .replaceFirst('<', 'Builder<');
     } else if (DartTypes.isInstantiableBuiltValue(type)) {
-      return type.displayName.contains('<')
-          ? type.displayName.replaceFirst('<', 'Builder<')
+      return displayName.contains('<')
+          ? displayName.replaceFirst('<', 'Builder<')
           : '${type}Builder';
     } else {
-      return type.displayName;
+      return displayName;
     }
   }
 

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -14,7 +14,9 @@ dependencies:
   analyzer: '>=0.29.0 <0.31.0'
   build: ^0.11.1
   built_collection: ^2.0.0
-  built_value: ^4.4.1
+# built_value: ^4.4.1
+  built_value:
+    path: ../built_value
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.27.0'
 

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -11,7 +11,9 @@ environment:
   sdk: '>=1.8.0 <2.0.0'
 
 dependencies:
-  built_value: ^4.4.1
+# built_value: ^4.4.1
+  built_value:
+    path: ../built_value
   built_collection: ^2.0.0
   collection: ^1.0.0
   quiver: '>=0.21.0 <0.27.0'
@@ -20,5 +22,7 @@ dependencies:
 dev_dependencies:
   build: ^0.11.1
   build_runner: ^0.6.0
-  built_value_generator: ^4.4.1
+# built_value_generator: ^4.4.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -12,7 +12,9 @@ environment:
 dependencies:
   browser: ^0.10.0
   built_collection: ^2.0.0
-  built_value: ^4.4.1
+# built_value: ^4.4.1
+  built_value:
+    path: ../built_value
   shelf: ^0.6.0
   shelf_proxy: ^0.1.0
   shelf_web_socket: ^0.2.1
@@ -21,6 +23,8 @@ dependencies:
 dev_dependencies:
   build: ^0.11.1
   build_runner: ^0.6.0
-  built_value_generator: ^4.4.1
+# built_value_generator: ^4.4.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0
   test: any

--- a/end_to_end_test/lib/values.dart
+++ b/end_to_end_test/lib/values.dart
@@ -178,6 +178,27 @@ abstract class PrimitivesValue
   PrimitivesValue._();
 }
 
+typedef MyFunctionType = int Function<String>();
+
+abstract class FunctionValue
+    implements Built<FunctionValue, FunctionValueBuilder> {
+  MyFunctionType get function;
+
+  factory FunctionValue([updates(FunctionValueBuilder b)]) = _$FunctionValue;
+
+  FunctionValue._();
+}
+
+abstract class ListOfFunctionValue
+    implements Built<ListOfFunctionValue, ListOfFunctionValueBuilder> {
+  BuiltList<MyFunctionType> get functions;
+
+  factory ListOfFunctionValue([updates(ListOfFunctionValueBuilder b)]) =
+      _$ListOfFunctionValue;
+
+  ListOfFunctionValue._();
+}
+
 abstract class NamedFactoryValue
     implements Built<NamedFactoryValue, NamedFactoryValueBuilder> {
   static Serializer<NamedFactoryValue> get serializer =>

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -1548,6 +1548,160 @@ class PrimitivesValueBuilder
   }
 }
 
+class _$FunctionValue extends FunctionValue {
+  @override
+  final MyFunctionType function;
+
+  factory _$FunctionValue([void updates(FunctionValueBuilder b)]) =>
+      (new FunctionValueBuilder()..update(updates)).build();
+
+  _$FunctionValue._({this.function}) : super._() {
+    if (function == null) throw new ArgumentError.notNull('function');
+  }
+
+  @override
+  FunctionValue rebuild(void updates(FunctionValueBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  FunctionValueBuilder toBuilder() => new FunctionValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(other, this)) return true;
+    if (other is! FunctionValue) return false;
+    return function == other.function;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, function.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('FunctionValue')
+          ..add('function', function))
+        .toString();
+  }
+}
+
+class FunctionValueBuilder
+    implements Builder<FunctionValue, FunctionValueBuilder> {
+  _$FunctionValue _$v;
+
+  MyFunctionType _function;
+  MyFunctionType get function => _$this._function;
+  set function(MyFunctionType function) => _$this._function = function;
+
+  FunctionValueBuilder();
+
+  FunctionValueBuilder get _$this {
+    if (_$v != null) {
+      _function = _$v.function;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(FunctionValue other) {
+    if (other == null) throw new ArgumentError.notNull('other');
+    _$v = other as _$FunctionValue;
+  }
+
+  @override
+  void update(void updates(FunctionValueBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$FunctionValue build() {
+    final _$result = _$v ?? new _$FunctionValue._(function: function);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ListOfFunctionValue extends ListOfFunctionValue {
+  @override
+  final BuiltList<MyFunctionType> functions;
+
+  factory _$ListOfFunctionValue([void updates(ListOfFunctionValueBuilder b)]) =>
+      (new ListOfFunctionValueBuilder()..update(updates)).build();
+
+  _$ListOfFunctionValue._({this.functions}) : super._() {
+    if (functions == null) throw new ArgumentError.notNull('functions');
+  }
+
+  @override
+  ListOfFunctionValue rebuild(void updates(ListOfFunctionValueBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ListOfFunctionValueBuilder toBuilder() =>
+      new ListOfFunctionValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(other, this)) return true;
+    if (other is! ListOfFunctionValue) return false;
+    return functions == other.functions;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, functions.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('ListOfFunctionValue')
+          ..add('functions', functions))
+        .toString();
+  }
+}
+
+class ListOfFunctionValueBuilder
+    implements Builder<ListOfFunctionValue, ListOfFunctionValueBuilder> {
+  _$ListOfFunctionValue _$v;
+
+  ListBuilder<MyFunctionType> _functions;
+  ListBuilder<MyFunctionType> get functions =>
+      _$this._functions ??= new ListBuilder<MyFunctionType>();
+  set functions(ListBuilder<MyFunctionType> functions) =>
+      _$this._functions = functions;
+
+  ListOfFunctionValueBuilder();
+
+  ListOfFunctionValueBuilder get _$this {
+    if (_$v != null) {
+      _functions = _$v.functions?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ListOfFunctionValue other) {
+    if (other == null) throw new ArgumentError.notNull('other');
+    _$v = other as _$ListOfFunctionValue;
+  }
+
+  @override
+  void update(void updates(ListOfFunctionValueBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$ListOfFunctionValue build() {
+    final _$result =
+        _$v ?? new _$ListOfFunctionValue._(functions: functions?.build());
+    replace(_$result);
+    return _$result;
+  }
+}
+
 class _$NamedFactoryValue extends NamedFactoryValue {
   @override
   final int value;

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -11,12 +11,16 @@ environment:
 
 dependencies:
   built_collection: ^2.0.0
-  built_value: ^4.4.1
+# built_value: ^4.4.1
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.11.1
   build_runner: ^0.6.0
-  built_value_generator: ^4.4.1
+# built_value_generator: ^4.4.1
+  built_value_generator:
+    path: ../built_value_generator
   fixnum: ^0.10.0
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.26.0'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,12 +12,16 @@ environment:
 dependencies:
   meta: ^1.0.4
   built_collection: ^2.0.0
-  built_value: ^4.4.1
+# built_value: ^4.4.1
+  built_value:
+    path: ../built_value
 
 dev_dependencies:
   build: ^0.11.1
   build_runner: ^0.6.0
-  built_value_generator: ^4.4.1
+# built_value_generator: ^4.4.1
+  built_value_generator:
+    path: ../built_value_generator
   source_gen: ^0.7.0
   quiver: '>=0.21.0 <0.26.0'
   test: any


### PR DESCRIPTION
Fixes #281 

We were getting the field names via a different codepath for builders, and this didn't work for functions; use the same codepath.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/284)
<!-- Reviewable:end -->
