### PR TITLE
Add BuiltListAsyncDeserializer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 - Add support for polymorphism to `StandardJsonPlugin`. It will now specify
   type names as needed via a `discriminator` field, which by defualt is
   called `$`. This can be changed in the `StandardJsonPlugin` constructor.
+- Add `BuiltListAsyncDeserializer`. It provides a way to deserialize large
+  responses without blocking, provided the top level serialized type is
+  `BuiltList`.
 
 ## 4.4.1
 

--- a/built_value/lib/async_serializer.dart
+++ b/built_value/lib/async_serializer.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:built_value/serializer.dart';
+
+/// Deserializer for `BuiltList` that runs asynchronously.
+///
+/// If you need to deserialize large payloads without blocking, arrange that
+/// the top level serialized object is a `BuiltList`. Then use this class to
+/// deserialize to a [Stream] of objects.
+class BuiltListAsyncDeserializer {
+  Stream<Object> deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType: FullType.unspecified}) async* {
+    final elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    for (final item in serialized) {
+      yield serializers.deserialize(item, specifiedType: elementType);
+    }
+  }
+}

--- a/built_value/test/built_list_async_deserializer_test.dart
+++ b/built_value/test/built_list_async_deserializer_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/async_serializer.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltList', () {
+    final data = new BuiltList<int>([1, 2, 3]);
+    final specifiedType =
+        const FullType(BuiltList, const [const FullType(int)]);
+    final serializers = (new Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => new ListBuilder<int>()))
+        .build();
+    final serialized = [1, 2, 3];
+
+    test('can be deserialized asynchronously', () async {
+      final deserialized = await new BuiltListAsyncDeserializer()
+          .deserialize(serializers, serialized, specifiedType: specifiedType)
+          .toList();
+
+      expect(deserialized, data);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #105 

This seems a much simper approach than the ones discussed on that issue; we just provide support for asynchronously deserializing a top level list.

This approach could be expanded to asynchronously deserializing other types--but you will in general only need to do this for the top level type in the payload, to split the work into chunks. This PR ought to be enough to show the concept works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/297)
<!-- Reviewable:end -->
