### PR TITLE
Better null messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## 4.5.3
+## 4.6.0
 
+- Add custom `Error` classes: `BuiltValueNullFieldError`,
+  `BuiltValueMissingGenericsError` and `BuiltValueNestedFieldError`. These
+  provide clearer error messages on failure. In particular, errors in nested
+  builders now report the enclosing class and field name, making them much
+  more useful.
 - Fix serialization when using polymorphism with StandardJsonPlugin.
 
 ## 4.5.2

--- a/benchmark/lib/node.g.dart
+++ b/benchmark/lib/node.g.dart
@@ -96,9 +96,24 @@ class NodeBuilder implements Builder<Node, NodeBuilder> {
 
   @override
   _$Node build() {
-    final _$result = _$v ??
-        new _$Node._(
-            label: label, left: _left?.build(), right: _right?.build());
+    _$Node _$result;
+    try {
+      _$result = _$v ??
+          new _$Node._(
+              label: label, left: _left?.build(), right: _right?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'left';
+        _left?.build();
+        _$failedField = 'right';
+        _right?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Node', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/benchmark/lib/simple_value.g.dart
+++ b/benchmark/lib/simple_value.g.dart
@@ -24,8 +24,10 @@ class _$SimpleValue extends SimpleValue {
       (new SimpleValueBuilder()..update(updates)).build();
 
   _$SimpleValue._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
-    if (aString == null) throw new ArgumentError.notNull('aString');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('SimpleValue', 'anInt');
+    if (aString == null)
+      throw new BuiltValueNullFieldError('SimpleValue', 'aString');
   }
 
   @override

--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -283,3 +283,18 @@ class BuiltValueMissingGenericsError extends Error {
       'Tried to construct class "$type" with missing or dynamic '
       'type argument "$parameter". All type arguments must be specified.';
 }
+
+/// [Error] indicating that a built_value `build` method failed because a
+/// nested field builder failed.
+class BuiltValueNestedFieldError extends Error {
+  final String type;
+  final String field;
+  final String error;
+
+  BuiltValueNestedFieldError(this.type, this.field, this.error);
+
+  @override
+  String toString() =>
+      'Tried to build class "$type" but nested builder for field "$field" '
+      'threw: $error';
+}

--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -255,3 +255,31 @@ class FlatBuiltValueToStringHelper implements BuiltValueToStringHelper {
     return stringResult;
   }
 }
+
+/// [Error] indicating that a built_value class constructor was called with
+/// a `null` value for a field not marked `@nullable`.
+class BuiltValueNullFieldError extends Error {
+  final String type;
+  final String field;
+
+  BuiltValueNullFieldError(this.type, this.field);
+
+  @override
+  String toString() =>
+      'Tried to construct class "$type" with null field "$field". '
+      'This is forbidden; to allow it, mark "$field" with @nullable.';
+}
+
+/// [Error] indicating that a built_value class constructor was called with
+/// a missing or `dynamic` type parameter.
+class BuiltValueMissingGenericsError extends Error {
+  final String type;
+  final String parameter;
+
+  BuiltValueMissingGenericsError(this.type, this.parameter);
+
+  @override
+  String toString() =>
+      'Tried to construct class "$type" with missing or dynamic '
+      'type argument "$parameter". All type arguments must be specified.';
+}

--- a/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_value_generator/lib/src/enum_source_class.g.dart
@@ -33,7 +33,8 @@ class _$EnumSourceClass extends EnumSourceClass {
       (new EnumSourceClassBuilder()..update(updates)).build();
 
   _$EnumSourceClass._({this.element}) : super._() {
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (element == null)
+      throw new BuiltValueNullFieldError('EnumSourceClass', 'element');
   }
 
   @override

--- a/built_value_generator/lib/src/enum_source_field.g.dart
+++ b/built_value_generator/lib/src/enum_source_field.g.dart
@@ -28,7 +28,8 @@ class _$EnumSourceField extends EnumSourceField {
       (new EnumSourceFieldBuilder()..update(updates)).build();
 
   _$EnumSourceField._({this.element}) : super._() {
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (element == null)
+      throw new BuiltValueNullFieldError('EnumSourceField', 'element');
   }
 
   @override

--- a/built_value_generator/lib/src/enum_source_library.g.dart
+++ b/built_value_generator/lib/src/enum_source_library.g.dart
@@ -26,7 +26,8 @@ class _$EnumSourceLibrary extends EnumSourceLibrary {
       (new EnumSourceLibraryBuilder()..update(updates)).build();
 
   _$EnumSourceLibrary._({this.element}) : super._() {
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (element == null)
+      throw new BuiltValueNullFieldError('EnumSourceLibrary', 'element');
   }
 
   @override

--- a/built_value_generator/lib/src/memoized_getter.g.dart
+++ b/built_value_generator/lib/src/memoized_getter.g.dart
@@ -24,8 +24,10 @@ class _$MemoizedGetter extends MemoizedGetter {
       (new MemoizedGetterBuilder()..update(updates)).build();
 
   _$MemoizedGetter._({this.returnType, this.name}) : super._() {
-    if (returnType == null) throw new ArgumentError.notNull('returnType');
-    if (name == null) throw new ArgumentError.notNull('name');
+    if (returnType == null)
+      throw new BuiltValueNullFieldError('MemoizedGetter', 'returnType');
+    if (name == null)
+      throw new BuiltValueNullFieldError('MemoizedGetter', 'name');
   }
 
   @override

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -37,7 +37,8 @@ class _$SerializerSourceClass extends SerializerSourceClass {
       (new SerializerSourceClassBuilder()..update(updates)).build();
 
   _$SerializerSourceClass._({this.element, this.builderElement}) : super._() {
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (element == null)
+      throw new BuiltValueNullFieldError('SerializerSourceClass', 'element');
   }
 
   @override

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -38,8 +38,10 @@ class _$SerializerSourceField extends SerializerSourceField {
 
   _$SerializerSourceField._({this.settings, this.element, this.builderElement})
       : super._() {
-    if (settings == null) throw new ArgumentError.notNull('settings');
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (settings == null)
+      throw new BuiltValueNullFieldError('SerializerSourceField', 'settings');
+    if (element == null)
+      throw new BuiltValueNullFieldError('SerializerSourceField', 'element');
   }
 
   @override

--- a/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -29,7 +29,8 @@ class _$SerializerSourceLibrary extends SerializerSourceLibrary {
       (new SerializerSourceLibraryBuilder()..update(updates)).build();
 
   _$SerializerSourceLibrary._({this.element}) : super._() {
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (element == null)
+      throw new BuiltValueNullFieldError('SerializerSourceLibrary', 'element');
   }
 
   @override

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -356,7 +356,7 @@ abstract class ValueSourceClass
       result.writeln('{');
       for (final field in requiredFields) {
         result.writeln("if (${field.name} == null) "
-            "throw new ArgumentError.notNull('${field.name}');");
+            "throw new BuiltValueNullFieldError('${name}', '${field.name}');");
       }
       result.writeln('}');
     }
@@ -523,10 +523,9 @@ abstract class ValueSourceClass
     } else {
       result.writeln('{');
       for (final genericParameter in genericParameters) {
-        result.writeln(
-            'if ($genericParameter == dynamic) throw new ArgumentError.value('
-            "'dynamic', '$genericParameter', "
-            "'All type arguments must be specified');");
+        result.writeln('if ($genericParameter == dynamic) '
+            'throw new BuiltValueMissingGenericsError('
+            "'$name', '$genericParameter');");
       }
       result.writeln('}');
     }

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -572,21 +572,68 @@ abstract class ValueSourceClass
 
     result.writeln('@override');
     result.writeln('$implName$_generics build() {');
-    result.writeln('final _\$result = _\$v ?? ');
-    result.writeln('new $implName$_generics._(');
-    result.write(fields.map((field) {
+
+    // Construct a map from field to how it's built. If it's a normal field,
+    // this is just the field name; if it's a nested builder, this is an
+    // invocation of the nested builder taking into account nullability.
+    final fieldBuilders = <String, String>{};
+    fields.forEach((field) {
       final name = field.name;
-      if (!field.isNestedBuilder) return '$name: $name';
-      // If not nullable, go via the public accessor, which instantiates
-      // if needed.
-      if (!field.isNullable) return '$name: $name?.build()';
-      // Otherwise access the private field: in super if there's a manually
-      // maintaned builder, otherwise here.
-      return hasBuilder
-          ? '$name: super.$name?.build()'
-          : '$name: _$name?.build()';
-    }).join(', '));
+      if (!field.isNestedBuilder) {
+        fieldBuilders[name] = name;
+      } else if (!field.isNullable) {
+        // If not nullable, go via the public accessor, which instantiates
+        // if needed.
+        fieldBuilders[name] = '$name.build()';
+      } else if (hasBuilder) {
+        // Otherwise access the private field: in super if there's a manually
+        // maintained builder.
+        fieldBuilders[name] = 'super.$name?.build()';
+      } else {
+        // Or, directly if there is no manually maintained builder.
+        fieldBuilders[name] = '_$name?.build()';
+      }
+    });
+
+    // If there are nested builders then wrap the build in a try/catch so we
+    // can add information should a nested builder fail.
+    final needsTryCatchOnBuild =
+        fieldBuilders.keys.any((field) => fieldBuilders[field] != field);
+
+    if (needsTryCatchOnBuild) {
+      result.writeln('$implName$_generics _\$result;');
+      result.writeln('try {');
+    } else {
+      result.write('final ');
+    }
+    result.writeln('_\$result = _\$v ?? ');
+    result.writeln('new $implName$_generics._(');
+    result.write(fieldBuilders.keys
+        .map((field) => '$field: ${fieldBuilders[field]}')
+        .join(','));
     result.writeln(');');
+
+    if (needsTryCatchOnBuild) {
+      // Handle errors by re-running all nested builders; if there's an error
+      // in a nested builder then throw with more information. Otherwise,
+      // just rethrow.
+      result.writeln('} catch (_) {');
+      result.writeln('String _\$failedField;');
+      result.writeln('try {');
+      result.write(fieldBuilders.keys.map((field) {
+        final fieldBuilder = fieldBuilders[field];
+        if (fieldBuilder == field) return '';
+        return "_\$failedField = '$field'; $fieldBuilder;";
+      }).join('\n'));
+
+      result.writeln('} catch (e) {');
+      result.writeln('throw new BuiltValueNestedFieldError('
+          "'$name', _\$failedField, e.toString());");
+      result.writeln('}');
+      result.writeln('rethrow;');
+      result.writeln('}');
+    }
+
     // Set _$v to the built value, so it will be lazily copied if needed.
     result.writeln('replace(_\$result);');
     result.writeln('return _\$result;');

--- a/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_value_generator/lib/src/value_source_class.g.dart
@@ -47,7 +47,8 @@ class _$ValueSourceClass extends ValueSourceClass {
       (new ValueSourceClassBuilder()..update(updates)).build();
 
   _$ValueSourceClass._({this.element}) : super._() {
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (element == null)
+      throw new BuiltValueNullFieldError('ValueSourceClass', 'element');
   }
 
   @override

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -37,8 +37,10 @@ class _$ValueSourceField extends ValueSourceField {
 
   _$ValueSourceField._({this.settings, this.element, this.builderElement})
       : super._() {
-    if (settings == null) throw new ArgumentError.notNull('settings');
-    if (element == null) throw new ArgumentError.notNull('element');
+    if (settings == null)
+      throw new BuiltValueNullFieldError('ValueSourceField', 'settings');
+    if (element == null)
+      throw new BuiltValueNullFieldError('ValueSourceField', 'element');
   }
 
   @override

--- a/built_value_test/test/values.g.dart
+++ b/built_value_test/test/values.g.dart
@@ -93,8 +93,20 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
 
   @override
   _$SimpleValue build() {
-    final _$result =
-        _$v ?? new _$SimpleValue._(anInt: anInt, map: map?.build());
+    _$SimpleValue _$result;
+    try {
+      _$result = _$v ?? new _$SimpleValue._(anInt: anInt, map: map.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'map';
+        map.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'SimpleValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -180,9 +192,22 @@ class CompoundValueBuilder
 
   @override
   _$CompoundValue build() {
-    final _$result = _$v ??
-        new _$CompoundValue._(
-            simpleValue: simpleValue?.build(), string: string);
+    _$CompoundValue _$result;
+    try {
+      _$result = _$v ??
+          new _$CompoundValue._(
+              simpleValue: simpleValue.build(), string: string);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'CompoundValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/built_value_test/test/values.g.dart
+++ b/built_value_test/test/values.g.dart
@@ -24,8 +24,9 @@ class _$SimpleValue extends SimpleValue {
       (new SimpleValueBuilder()..update(updates)).build();
 
   _$SimpleValue._({this.anInt, this.map}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
-    if (map == null) throw new ArgumentError.notNull('map');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('SimpleValue', 'anInt');
+    if (map == null) throw new BuiltValueNullFieldError('SimpleValue', 'map');
   }
 
   @override
@@ -109,7 +110,8 @@ class _$CompoundValue extends CompoundValue {
       (new CompoundValueBuilder()..update(updates)).build();
 
   _$CompoundValue._({this.simpleValue, this.string}) : super._() {
-    if (simpleValue == null) throw new ArgumentError.notNull('simpleValue');
+    if (simpleValue == null)
+      throw new BuiltValueNullFieldError('CompoundValue', 'simpleValue');
   }
 
   @override
@@ -196,8 +198,10 @@ class _$ComparedValue extends ComparedValue {
       (new ComparedValueBuilder()..update(updates)).build();
 
   _$ComparedValue._({this.name, this.onChanged}) : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (onChanged == null) throw new ArgumentError.notNull('onChanged');
+    if (name == null)
+      throw new BuiltValueNullFieldError('ComparedValue', 'name');
+    if (onChanged == null)
+      throw new BuiltValueNullFieldError('ComparedValue', 'onChanged');
   }
 
   @override

--- a/chat_example/lib/data_model/data_model.g.dart
+++ b/chat_example/lib/data_model/data_model.g.dart
@@ -452,8 +452,8 @@ class _$Chat extends Chat {
       (new ChatBuilder()..update(updates)).build();
 
   _$Chat._({this.text, this.targets}) : super._() {
-    if (text == null) throw new ArgumentError.notNull('text');
-    if (targets == null) throw new ArgumentError.notNull('targets');
+    if (text == null) throw new BuiltValueNullFieldError('Chat', 'text');
+    if (targets == null) throw new BuiltValueNullFieldError('Chat', 'targets');
   }
 
   @override
@@ -536,8 +536,10 @@ class _$Login extends Login {
       (new LoginBuilder()..update(updates)).build();
 
   _$Login._({this.username, this.password}) : super._() {
-    if (username == null) throw new ArgumentError.notNull('username');
-    if (password == null) throw new ArgumentError.notNull('password');
+    if (username == null)
+      throw new BuiltValueNullFieldError('Login', 'username');
+    if (password == null)
+      throw new BuiltValueNullFieldError('Login', 'password');
   }
 
   @override
@@ -620,8 +622,9 @@ class _$Status extends Status {
       (new StatusBuilder()..update(updates)).build();
 
   _$Status._({this.message, this.type}) : super._() {
-    if (message == null) throw new ArgumentError.notNull('message');
-    if (type == null) throw new ArgumentError.notNull('type');
+    if (message == null)
+      throw new BuiltValueNullFieldError('Status', 'message');
+    if (type == null) throw new BuiltValueNullFieldError('Status', 'type');
   }
 
   @override
@@ -701,7 +704,8 @@ class _$ListUsers extends ListUsers {
       (new ListUsersBuilder()..update(updates)).build();
 
   _$ListUsers._({this.statusTypes}) : super._() {
-    if (statusTypes == null) throw new ArgumentError.notNull('statusTypes');
+    if (statusTypes == null)
+      throw new BuiltValueNullFieldError('ListUsers', 'statusTypes');
   }
 
   @override
@@ -782,9 +786,11 @@ class _$ShowChat extends ShowChat {
       (new ShowChatBuilder()..update(updates)).build();
 
   _$ShowChat._({this.username, this.private, this.text}) : super._() {
-    if (username == null) throw new ArgumentError.notNull('username');
-    if (private == null) throw new ArgumentError.notNull('private');
-    if (text == null) throw new ArgumentError.notNull('text');
+    if (username == null)
+      throw new BuiltValueNullFieldError('ShowChat', 'username');
+    if (private == null)
+      throw new BuiltValueNullFieldError('ShowChat', 'private');
+    if (text == null) throw new BuiltValueNullFieldError('ShowChat', 'text');
   }
 
   @override
@@ -876,8 +882,9 @@ class _$Welcome extends Welcome {
       (new WelcomeBuilder()..update(updates)).build();
 
   _$Welcome._({this.log, this.message}) : super._() {
-    if (log == null) throw new ArgumentError.notNull('log');
-    if (message == null) throw new ArgumentError.notNull('message');
+    if (log == null) throw new BuiltValueNullFieldError('Welcome', 'log');
+    if (message == null)
+      throw new BuiltValueNullFieldError('Welcome', 'message');
   }
 
   @override
@@ -958,7 +965,8 @@ class _$ListUsersResponse extends ListUsersResponse {
       (new ListUsersResponseBuilder()..update(updates)).build();
 
   _$ListUsersResponse._({this.statuses}) : super._() {
-    if (statuses == null) throw new ArgumentError.notNull('statuses');
+    if (statuses == null)
+      throw new BuiltValueNullFieldError('ListUsersResponse', 'statuses');
   }
 
   @override

--- a/chat_example/lib/data_model/data_model.g.dart
+++ b/chat_example/lib/data_model/data_model.g.dart
@@ -520,7 +520,20 @@ class ChatBuilder implements Builder<Chat, ChatBuilder> {
 
   @override
   _$Chat build() {
-    final _$result = _$v ?? new _$Chat._(text: text, targets: targets?.build());
+    _$Chat _$result;
+    try {
+      _$result = _$v ?? new _$Chat._(text: text, targets: targets.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'targets';
+        targets.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Chat', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -767,8 +780,20 @@ class ListUsersBuilder implements Builder<ListUsers, ListUsersBuilder> {
 
   @override
   _$ListUsers build() {
-    final _$result =
-        _$v ?? new _$ListUsers._(statusTypes: statusTypes?.build());
+    _$ListUsers _$result;
+    try {
+      _$result = _$v ?? new _$ListUsers._(statusTypes: statusTypes.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'statusTypes';
+        statusTypes.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'ListUsers', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -950,8 +975,20 @@ class WelcomeBuilder implements Builder<Welcome, WelcomeBuilder> {
 
   @override
   _$Welcome build() {
-    final _$result =
-        _$v ?? new _$Welcome._(log: log?.build(), message: message);
+    _$Welcome _$result;
+    try {
+      _$result = _$v ?? new _$Welcome._(log: log.build(), message: message);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'log';
+        log.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Welcome', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -1030,8 +1067,20 @@ class ListUsersResponseBuilder
 
   @override
   _$ListUsersResponse build() {
-    final _$result =
-        _$v ?? new _$ListUsersResponse._(statuses: statuses?.build());
+    _$ListUsersResponse _$result;
+    try {
+      _$result = _$v ?? new _$ListUsersResponse._(statuses: statuses.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'statuses';
+        statuses.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'ListUsersResponse', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/collections.g.dart
+++ b/end_to_end_test/lib/collections.g.dart
@@ -207,11 +207,13 @@ class _$Collections extends Collections {
       this.nullableListMultimap,
       this.nullableSetMultimap})
       : super._() {
-    if (list == null) throw new ArgumentError.notNull('list');
-    if (set == null) throw new ArgumentError.notNull('set');
-    if (map == null) throw new ArgumentError.notNull('map');
-    if (listMultimap == null) throw new ArgumentError.notNull('listMultimap');
-    if (setMultimap == null) throw new ArgumentError.notNull('setMultimap');
+    if (list == null) throw new BuiltValueNullFieldError('Collections', 'list');
+    if (set == null) throw new BuiltValueNullFieldError('Collections', 'set');
+    if (map == null) throw new BuiltValueNullFieldError('Collections', 'map');
+    if (listMultimap == null)
+      throw new BuiltValueNullFieldError('Collections', 'listMultimap');
+    if (setMultimap == null)
+      throw new BuiltValueNullFieldError('Collections', 'setMultimap');
   }
 
   @override

--- a/end_to_end_test/lib/collections.g.dart
+++ b/end_to_end_test/lib/collections.g.dart
@@ -368,18 +368,49 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
 
   @override
   _$Collections build() {
-    final _$result = _$v ??
-        new _$Collections._(
-            list: list?.build(),
-            set: set?.build(),
-            map: map?.build(),
-            listMultimap: listMultimap?.build(),
-            setMultimap: setMultimap?.build(),
-            nullableList: _nullableList?.build(),
-            nullableSet: _nullableSet?.build(),
-            nullableMap: _nullableMap?.build(),
-            nullableListMultimap: _nullableListMultimap?.build(),
-            nullableSetMultimap: _nullableSetMultimap?.build());
+    _$Collections _$result;
+    try {
+      _$result = _$v ??
+          new _$Collections._(
+              list: list.build(),
+              set: set.build(),
+              map: map.build(),
+              listMultimap: listMultimap.build(),
+              setMultimap: setMultimap.build(),
+              nullableList: _nullableList?.build(),
+              nullableSet: _nullableSet?.build(),
+              nullableMap: _nullableMap?.build(),
+              nullableListMultimap: _nullableListMultimap?.build(),
+              nullableSetMultimap: _nullableSetMultimap?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'list';
+        list.build();
+        _$failedField = 'set';
+        set.build();
+        _$failedField = 'map';
+        map.build();
+        _$failedField = 'listMultimap';
+        listMultimap.build();
+        _$failedField = 'setMultimap';
+        setMultimap.build();
+        _$failedField = 'nullableList';
+        _nullableList?.build();
+        _$failedField = 'nullableSet';
+        _nullableSet?.build();
+        _$failedField = 'nullableMap';
+        _nullableMap?.build();
+        _$failedField = 'nullableListMultimap';
+        _nullableListMultimap?.build();
+        _$failedField = 'nullableSetMultimap';
+        _nullableSetMultimap?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Collections', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/errors_matchers.dart
+++ b/end_to_end_test/lib/errors_matchers.dart
@@ -1,0 +1,20 @@
+import 'package:test/test.dart';
+
+Matcher isErrorContaining(String string) => new _ErrorContaining(string);
+
+class _ErrorContaining extends TypeMatcher {
+  String string;
+
+  _ErrorContaining(this.string) : super("Error");
+
+  @override
+  Description describe(Description description) {
+    super.describe(description);
+    description.add(' containing "$string"');
+    return description;
+  }
+
+  @override
+  bool matches(dynamic item, Map matchState) =>
+      item is Error && item.toString().contains(string);
+}

--- a/end_to_end_test/lib/generics.g.dart
+++ b/end_to_end_test/lib/generics.g.dart
@@ -544,8 +544,21 @@ class CollectionGenericValueBuilder<T>
 
   @override
   _$CollectionGenericValue<T> build() {
-    final _$result =
-        _$v ?? new _$CollectionGenericValue<T>._(values: values?.build());
+    _$CollectionGenericValue<T> _$result;
+    try {
+      _$result =
+          _$v ?? new _$CollectionGenericValue<T>._(values: values.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'values';
+        values.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'CollectionGenericValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -658,11 +671,28 @@ class GenericContainerBuilder
 
   @override
   _$GenericContainer build() {
-    final _$result = _$v ??
-        new _$GenericContainer._(
-            genericValue: genericValue?.build(),
-            boundGenericValue: boundGenericValue?.build(),
-            collectionGenericValue: collectionGenericValue?.build());
+    _$GenericContainer _$result;
+    try {
+      _$result = _$v ??
+          new _$GenericContainer._(
+              genericValue: genericValue.build(),
+              boundGenericValue: boundGenericValue.build(),
+              collectionGenericValue: collectionGenericValue.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'genericValue';
+        genericValue.build();
+        _$failedField = 'boundGenericValue';
+        boundGenericValue.build();
+        _$failedField = 'collectionGenericValue';
+        collectionGenericValue.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'GenericContainer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -742,7 +772,20 @@ class NestedGenericContainerBuilder
 
   @override
   _$NestedGenericContainer build() {
-    final _$result = _$v ?? new _$NestedGenericContainer._(map: map?.build());
+    _$NestedGenericContainer _$result;
+    try {
+      _$result = _$v ?? new _$NestedGenericContainer._(map: map.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'map';
+        map.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'NestedGenericContainer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/generics.g.dart
+++ b/end_to_end_test/lib/generics.g.dart
@@ -316,7 +316,8 @@ class _$GenericValue<T> extends GenericValue<T> {
       (new GenericValueBuilder<T>()..update(updates)).build();
 
   _$GenericValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('GenericValue', 'value');
   }
 
   @override
@@ -356,8 +357,7 @@ class GenericValueBuilder<T>
 
   GenericValueBuilder() {
     if (T == dynamic)
-      throw new ArgumentError.value(
-          'dynamic', 'T', 'All type arguments must be specified.');
+      throw new BuiltValueMissingGenericsError('GenericValue', 'T');
   }
 
   GenericValueBuilder<T> get _$this {
@@ -395,7 +395,8 @@ class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
       (new BoundGenericValueBuilder<T>()..update(updates)).build();
 
   _$BoundGenericValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('BoundGenericValue', 'value');
   }
 
   @override
@@ -436,8 +437,7 @@ class BoundGenericValueBuilder<T extends num>
 
   BoundGenericValueBuilder() {
     if (T == dynamic)
-      throw new ArgumentError.value(
-          'dynamic', 'T', 'All type arguments must be specified.');
+      throw new BuiltValueMissingGenericsError('BoundGenericValue', 'T');
   }
 
   BoundGenericValueBuilder<T> get _$this {
@@ -476,7 +476,8 @@ class _$CollectionGenericValue<T> extends CollectionGenericValue<T> {
       (new CollectionGenericValueBuilder<T>()..update(updates)).build();
 
   _$CollectionGenericValue._({this.values}) : super._() {
-    if (values == null) throw new ArgumentError.notNull('values');
+    if (values == null)
+      throw new BuiltValueNullFieldError('CollectionGenericValue', 'values');
   }
 
   @override
@@ -519,8 +520,7 @@ class CollectionGenericValueBuilder<T>
 
   CollectionGenericValueBuilder() {
     if (T == dynamic)
-      throw new ArgumentError.value(
-          'dynamic', 'T', 'All type arguments must be specified.');
+      throw new BuiltValueMissingGenericsError('CollectionGenericValue', 'T');
   }
 
   CollectionGenericValueBuilder<T> get _$this {
@@ -565,11 +565,14 @@ class _$GenericContainer extends GenericContainer {
   _$GenericContainer._(
       {this.genericValue, this.boundGenericValue, this.collectionGenericValue})
       : super._() {
-    if (genericValue == null) throw new ArgumentError.notNull('genericValue');
+    if (genericValue == null)
+      throw new BuiltValueNullFieldError('GenericContainer', 'genericValue');
     if (boundGenericValue == null)
-      throw new ArgumentError.notNull('boundGenericValue');
+      throw new BuiltValueNullFieldError(
+          'GenericContainer', 'boundGenericValue');
     if (collectionGenericValue == null)
-      throw new ArgumentError.notNull('collectionGenericValue');
+      throw new BuiltValueNullFieldError(
+          'GenericContainer', 'collectionGenericValue');
   }
 
   @override
@@ -674,7 +677,8 @@ class _$NestedGenericContainer extends NestedGenericContainer {
       (new NestedGenericContainerBuilder()..update(updates)).build();
 
   _$NestedGenericContainer._({this.map}) : super._() {
-    if (map == null) throw new ArgumentError.notNull('map');
+    if (map == null)
+      throw new BuiltValueNullFieldError('NestedGenericContainer', 'map');
   }
 
   @override
@@ -754,7 +758,8 @@ class _$CustomBuilderGenericValue<T> extends CustomBuilderGenericValue<T> {
           as _$CustomBuilderGenericValue<T>;
 
   _$CustomBuilderGenericValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('CustomBuilderGenericValue', 'value');
   }
 
   @override
@@ -804,8 +809,8 @@ class _$CustomBuilderGenericValueBuilder<T>
 
   _$CustomBuilderGenericValueBuilder() : super._() {
     if (T == dynamic)
-      throw new ArgumentError.value(
-          'dynamic', 'T', 'All type arguments must be specified.');
+      throw new BuiltValueMissingGenericsError(
+          'CustomBuilderGenericValue', 'T');
   }
 
   CustomBuilderGenericValueBuilder<T> get _$this {

--- a/end_to_end_test/lib/imported_values.g.dart
+++ b/end_to_end_test/lib/imported_values.g.dart
@@ -78,8 +78,10 @@ class _$ImportedValue extends ImportedValue {
       (new ImportedValueBuilder()..update(updates)).build();
 
   _$ImportedValue._({this.simpleValue, this.simpleValues}) : super._() {
-    if (simpleValue == null) throw new ArgumentError.notNull('simpleValue');
-    if (simpleValues == null) throw new ArgumentError.notNull('simpleValues');
+    if (simpleValue == null)
+      throw new BuiltValueNullFieldError('ImportedValue', 'simpleValue');
+    if (simpleValues == null)
+      throw new BuiltValueNullFieldError('ImportedValue', 'simpleValues');
   }
 
   @override

--- a/end_to_end_test/lib/imported_values.g.dart
+++ b/end_to_end_test/lib/imported_values.g.dart
@@ -153,10 +153,25 @@ class ImportedValueBuilder
 
   @override
   _$ImportedValue build() {
-    final _$result = _$v ??
-        new _$ImportedValue._(
-            simpleValue: simpleValue?.build(),
-            simpleValues: simpleValues?.build());
+    _$ImportedValue _$result;
+    try {
+      _$result = _$v ??
+          new _$ImportedValue._(
+              simpleValue: simpleValue.build(),
+              simpleValues: simpleValues.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+        _$failedField = 'simpleValues';
+        simpleValues.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'ImportedValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/interfaces.g.dart
+++ b/end_to_end_test/lib/interfaces.g.dart
@@ -157,8 +157,10 @@ class _$ValueWithInt extends ValueWithInt {
       (new ValueWithIntBuilder()..update(updates)).build();
 
   _$ValueWithInt._({this.anInt, this.note}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
-    if (note == null) throw new ArgumentError.notNull('note');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValueWithInt', 'anInt');
+    if (note == null)
+      throw new BuiltValueNullFieldError('ValueWithInt', 'note');
   }
 
   @override
@@ -239,7 +241,8 @@ class _$ValueWithHasInt extends ValueWithHasInt {
       (new ValueWithHasIntBuilder()..update(updates)).build();
 
   _$ValueWithHasInt._({this.hasInt}) : super._() {
-    if (hasInt == null) throw new ArgumentError.notNull('hasInt');
+    if (hasInt == null)
+      throw new BuiltValueNullFieldError('ValueWithHasInt', 'hasInt');
   }
 
   @override

--- a/end_to_end_test/lib/polymorphism.g.dart
+++ b/end_to_end_test/lib/polymorphism.g.dart
@@ -662,10 +662,23 @@ class CageBuilder implements Builder<Cage, CageBuilder> {
 
   @override
   _$Cage build() {
-    final _$result = _$v ??
-        new _$Cage._(
-            inhabitant: inhabitant,
-            otherInhabitants: otherInhabitants?.build());
+    _$Cage _$result;
+    try {
+      _$result = _$v ??
+          new _$Cage._(
+              inhabitant: inhabitant,
+              otherInhabitants: otherInhabitants.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'otherInhabitants';
+        otherInhabitants.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Cage', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/polymorphism.g.dart
+++ b/end_to_end_test/lib/polymorphism.g.dart
@@ -341,8 +341,8 @@ class _$Cat extends Cat {
       (new CatBuilder()..update(updates)).build();
 
   _$Cat._({this.tail, this.legs}) : super._() {
-    if (tail == null) throw new ArgumentError.notNull('tail');
-    if (legs == null) throw new ArgumentError.notNull('legs');
+    if (tail == null) throw new BuiltValueNullFieldError('Cat', 'tail');
+    if (legs == null) throw new BuiltValueNullFieldError('Cat', 'legs');
   }
 
   @override
@@ -424,8 +424,8 @@ class _$Fish extends Fish {
       (new FishBuilder()..update(updates)).build();
 
   _$Fish._({this.fins, this.legs}) : super._() {
-    if (fins == null) throw new ArgumentError.notNull('fins');
-    if (legs == null) throw new ArgumentError.notNull('legs');
+    if (fins == null) throw new BuiltValueNullFieldError('Fish', 'fins');
+    if (legs == null) throw new BuiltValueNullFieldError('Fish', 'legs');
   }
 
   @override
@@ -507,8 +507,8 @@ class _$Robot extends Robot {
       (new RobotBuilder()..update(updates)).build();
 
   _$Robot._({this.fins, this.legs}) : super._() {
-    if (fins == null) throw new ArgumentError.notNull('fins');
-    if (legs == null) throw new ArgumentError.notNull('legs');
+    if (fins == null) throw new BuiltValueNullFieldError('Robot', 'fins');
+    if (legs == null) throw new BuiltValueNullFieldError('Robot', 'legs');
   }
 
   @override
@@ -590,9 +590,10 @@ class _$Cage extends Cage {
       (new CageBuilder()..update(updates)).build();
 
   _$Cage._({this.inhabitant, this.otherInhabitants}) : super._() {
-    if (inhabitant == null) throw new ArgumentError.notNull('inhabitant');
+    if (inhabitant == null)
+      throw new BuiltValueNullFieldError('Cage', 'inhabitant');
     if (otherInhabitants == null)
-      throw new ArgumentError.notNull('otherInhabitants');
+      throw new BuiltValueNullFieldError('Cage', 'otherInhabitants');
   }
 
   @override
@@ -678,7 +679,7 @@ class _$StandardCat extends StandardCat {
       (new StandardCatBuilder()..update(updates)).build();
 
   _$StandardCat._({this.tail}) : super._() {
-    if (tail == null) throw new ArgumentError.notNull('tail');
+    if (tail == null) throw new BuiltValueNullFieldError('StandardCat', 'tail');
   }
 
   @override
@@ -757,7 +758,7 @@ class _$HasString extends HasString {
       (new HasStringBuilder()..update(updates)).build();
 
   _$HasString._({this.field}) : super._() {
-    if (field == null) throw new ArgumentError.notNull('field');
+    if (field == null) throw new BuiltValueNullFieldError('HasString', 'field');
   }
 
   @override
@@ -831,7 +832,7 @@ class _$HasDouble extends HasDouble {
       (new HasDoubleBuilder()..update(updates)).build();
 
   _$HasDouble._({this.field}) : super._() {
-    if (field == null) throw new ArgumentError.notNull('field');
+    if (field == null) throw new BuiltValueNullFieldError('HasDouble', 'field');
   }
 
   @override
@@ -908,8 +909,10 @@ class _$UsesChainedInterface extends UsesChainedInterface {
       (new UsesChainedInterfaceBuilder()..update(updates)).build();
 
   _$UsesChainedInterface._({this.bar, this.foo}) : super._() {
-    if (bar == null) throw new ArgumentError.notNull('bar');
-    if (foo == null) throw new ArgumentError.notNull('foo');
+    if (bar == null)
+      throw new BuiltValueNullFieldError('UsesChainedInterface', 'bar');
+    if (foo == null)
+      throw new BuiltValueNullFieldError('UsesChainedInterface', 'foo');
   }
 
   @override

--- a/end_to_end_test/lib/standard_json.g.dart
+++ b/end_to_end_test/lib/standard_json.g.dart
@@ -220,13 +220,30 @@ class StandardJsonValueBuilder
 
   @override
   _$StandardJsonValue build() {
-    final _$result = _$v ??
-        new _$StandardJsonValue._(
-            number: number,
-            text: text,
-            keyValues: keyValues?.build(),
-            zoo: zoo?.build(),
-            strings: _strings?.build());
+    _$StandardJsonValue _$result;
+    try {
+      _$result = _$v ??
+          new _$StandardJsonValue._(
+              number: number,
+              text: text,
+              keyValues: keyValues.build(),
+              zoo: zoo.build(),
+              strings: _strings?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'keyValues';
+        keyValues.build();
+        _$failedField = 'zoo';
+        zoo.build();
+        _$failedField = 'strings';
+        _strings?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'StandardJsonValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/standard_json.g.dart
+++ b/end_to_end_test/lib/standard_json.g.dart
@@ -115,10 +115,14 @@ class _$StandardJsonValue extends StandardJsonValue {
   _$StandardJsonValue._(
       {this.number, this.text, this.keyValues, this.zoo, this.strings})
       : super._() {
-    if (number == null) throw new ArgumentError.notNull('number');
-    if (text == null) throw new ArgumentError.notNull('text');
-    if (keyValues == null) throw new ArgumentError.notNull('keyValues');
-    if (zoo == null) throw new ArgumentError.notNull('zoo');
+    if (number == null)
+      throw new BuiltValueNullFieldError('StandardJsonValue', 'number');
+    if (text == null)
+      throw new BuiltValueNullFieldError('StandardJsonValue', 'text');
+    if (keyValues == null)
+      throw new BuiltValueNullFieldError('StandardJsonValue', 'keyValues');
+    if (zoo == null)
+      throw new BuiltValueNullFieldError('StandardJsonValue', 'zoo');
   }
 
   @override

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -877,10 +877,25 @@ class CompoundValueBuilder
 
   @override
   _$CompoundValue build() {
-    final _$result = _$v ??
-        new _$CompoundValue._(
-            simpleValue: simpleValue?.build(),
-            validatedValue: _validatedValue?.build());
+    _$CompoundValue _$result;
+    try {
+      _$result = _$v ??
+          new _$CompoundValue._(
+              simpleValue: simpleValue.build(),
+              validatedValue: _validatedValue?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+        _$failedField = 'validatedValue';
+        _validatedValue?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'CompoundValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -1263,9 +1278,22 @@ class _$ValueWithDefaultsBuilder extends ValueWithDefaultsBuilder {
 
   @override
   _$ValueWithDefaults build() {
-    final _$result = _$v ??
-        new _$ValueWithDefaults._(
-            anInt: anInt, aString: aString, value: value?.build());
+    _$ValueWithDefaults _$result;
+    try {
+      _$result = _$v ??
+          new _$ValueWithDefaults._(
+              anInt: anInt, aString: aString, value: value.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'ValueWithDefaults', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -1822,8 +1850,21 @@ class ListOfFunctionValueBuilder
 
   @override
   _$ListOfFunctionValue build() {
-    final _$result =
-        _$v ?? new _$ListOfFunctionValue._(functions: functions?.build());
+    _$ListOfFunctionValue _$result;
+    try {
+      _$result =
+          _$v ?? new _$ListOfFunctionValue._(functions: functions.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'functions';
+        functions.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'ListOfFunctionValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -2171,11 +2212,28 @@ class FieldDiscoveryValueBuilder
 
   @override
   _$FieldDiscoveryValue build() {
-    final _$result = _$v ??
-        new _$FieldDiscoveryValue._(
-            value: value?.build(),
-            values: values?.build(),
-            recursiveValue: _recursiveValue?.build());
+    _$FieldDiscoveryValue _$result;
+    try {
+      _$result = _$v ??
+          new _$FieldDiscoveryValue._(
+              value: value.build(),
+              values: values.build(),
+              recursiveValue: _recursiveValue?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+        _$failedField = 'values';
+        values.build();
+        _$failedField = 'recursiveValue';
+        _recursiveValue?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'FieldDiscoveryValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -2253,7 +2311,20 @@ class DiscoverableValueBuilder
 
   @override
   _$DiscoverableValue build() {
-    final _$result = _$v ?? new _$DiscoverableValue._(value: value?.build());
+    _$DiscoverableValue _$result;
+    try {
+      _$result = _$v ?? new _$DiscoverableValue._(value: value.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'DiscoverableValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -721,7 +721,8 @@ class _$SimpleValue extends SimpleValue {
       (new SimpleValueBuilder()..update(updates)).build();
 
   _$SimpleValue._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('SimpleValue', 'anInt');
   }
 
   @override
@@ -803,7 +804,8 @@ class _$CompoundValue extends CompoundValue {
       (new CompoundValueBuilder()..update(updates)).build();
 
   _$CompoundValue._({this.simpleValue, this.validatedValue}) : super._() {
-    if (simpleValue == null) throw new ArgumentError.notNull('simpleValue');
+    if (simpleValue == null)
+      throw new BuiltValueNullFieldError('CompoundValue', 'simpleValue');
   }
 
   @override
@@ -896,7 +898,9 @@ class _$CompoundValueNoNesting extends CompoundValueNoNesting {
 
   _$CompoundValueNoNesting._({this.simpleValue, this.validatedValue})
       : super._() {
-    if (simpleValue == null) throw new ArgumentError.notNull('simpleValue');
+    if (simpleValue == null)
+      throw new BuiltValueNullFieldError(
+          'CompoundValueNoNesting', 'simpleValue');
   }
 
   @override
@@ -985,7 +989,8 @@ class _$DerivedValue extends DerivedValue {
       (new DerivedValueBuilder()..update(updates)).build();
 
   _$DerivedValue._({this.anInt}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('DerivedValue', 'anInt');
   }
 
   @override
@@ -1067,7 +1072,8 @@ class _$ValueWithCode extends ValueWithCode {
       (new ValueWithCodeBuilder()..update(updates)).build();
 
   _$ValueWithCode._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValueWithCode', 'anInt');
   }
 
   @override
@@ -1154,8 +1160,10 @@ class _$ValueWithDefaults extends ValueWithDefaults {
           as _$ValueWithDefaults;
 
   _$ValueWithDefaults._({this.anInt, this.aString, this.value}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValueWithDefaults', 'anInt');
+    if (value == null)
+      throw new BuiltValueNullFieldError('ValueWithDefaults', 'value');
   }
 
   @override
@@ -1273,7 +1281,8 @@ class _$ValidatedValue extends ValidatedValue {
       (new ValidatedValueBuilder()..update(updates)).build();
 
   _$ValidatedValue._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValidatedValue', 'anInt');
   }
 
   @override
@@ -1356,7 +1365,8 @@ class _$ValueUsingImportAs extends ValueUsingImportAs {
       (new ValueUsingImportAsBuilder()..update(updates)).build();
 
   _$ValueUsingImportAs._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('ValueUsingImportAs', 'value');
   }
 
   @override
@@ -1511,14 +1521,22 @@ class _$PrimitivesValue extends PrimitivesValue {
       this.dateTime,
       this.uri})
       : super._() {
-    if (boolean == null) throw new ArgumentError.notNull('boolean');
-    if (integer == null) throw new ArgumentError.notNull('integer');
-    if (int64 == null) throw new ArgumentError.notNull('int64');
-    if (dbl == null) throw new ArgumentError.notNull('dbl');
-    if (number == null) throw new ArgumentError.notNull('number');
-    if (string == null) throw new ArgumentError.notNull('string');
-    if (dateTime == null) throw new ArgumentError.notNull('dateTime');
-    if (uri == null) throw new ArgumentError.notNull('uri');
+    if (boolean == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'boolean');
+    if (integer == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'integer');
+    if (int64 == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'int64');
+    if (dbl == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'dbl');
+    if (number == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'number');
+    if (string == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'string');
+    if (dateTime == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'dateTime');
+    if (uri == null)
+      throw new BuiltValueNullFieldError('PrimitivesValue', 'uri');
   }
 
   @override
@@ -1663,7 +1681,8 @@ class _$FunctionValue extends FunctionValue {
       (new FunctionValueBuilder()..update(updates)).build();
 
   _$FunctionValue._({this.function}) : super._() {
-    if (function == null) throw new ArgumentError.notNull('function');
+    if (function == null)
+      throw new BuiltValueNullFieldError('FunctionValue', 'function');
   }
 
   @override
@@ -1738,7 +1757,8 @@ class _$ListOfFunctionValue extends ListOfFunctionValue {
       (new ListOfFunctionValueBuilder()..update(updates)).build();
 
   _$ListOfFunctionValue._({this.functions}) : super._() {
-    if (functions == null) throw new ArgumentError.notNull('functions');
+    if (functions == null)
+      throw new BuiltValueNullFieldError('ListOfFunctionValue', 'functions');
   }
 
   @override
@@ -1821,7 +1841,8 @@ class _$PartiallySerializableValue extends PartiallySerializableValue {
 
   _$PartiallySerializableValue._({this.value, this.transientValue})
       : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('PartiallySerializableValue', 'value');
   }
 
   @override
@@ -1908,7 +1929,8 @@ class _$NamedFactoryValue extends NamedFactoryValue {
       (new NamedFactoryValueBuilder()..update(updates)).build();
 
   _$NamedFactoryValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('NamedFactoryValue', 'value');
   }
 
   @override
@@ -1984,7 +2006,8 @@ class _$WireNameValue extends WireNameValue {
       (new WireNameValueBuilder()..update(updates)).build();
 
   _$WireNameValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('WireNameValue', 'value');
   }
 
   @override
@@ -2063,8 +2086,10 @@ class _$FieldDiscoveryValue extends FieldDiscoveryValue {
 
   _$FieldDiscoveryValue._({this.value, this.values, this.recursiveValue})
       : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
-    if (values == null) throw new ArgumentError.notNull('values');
+    if (value == null)
+      throw new BuiltValueNullFieldError('FieldDiscoveryValue', 'value');
+    if (values == null)
+      throw new BuiltValueNullFieldError('FieldDiscoveryValue', 'values');
   }
 
   @override
@@ -2164,7 +2189,8 @@ class _$DiscoverableValue extends DiscoverableValue {
       (new DiscoverableValueBuilder()..update(updates)).build();
 
   _$DiscoverableValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('DiscoverableValue', 'value');
   }
 
   @override
@@ -2242,7 +2268,8 @@ class _$SecondDiscoverableValue extends SecondDiscoverableValue {
       (new SecondDiscoverableValueBuilder()..update(updates)).build();
 
   _$SecondDiscoverableValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('SecondDiscoverableValue', 'value');
   }
 
   @override
@@ -2321,7 +2348,8 @@ class _$ThirdDiscoverableValue extends ThirdDiscoverableValue {
       (new ThirdDiscoverableValueBuilder()..update(updates)).build();
 
   _$ThirdDiscoverableValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('ThirdDiscoverableValue', 'value');
   }
 
   @override

--- a/end_to_end_test/test/generics_test.dart
+++ b/end_to_end_test/test/generics_test.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import 'package:built_value/built_value.dart';
+import 'package:end_to_end_test/errors_matchers.dart';
 import 'package:end_to_end_test/generics.dart';
 import 'package:test/test.dart';
 
@@ -13,12 +15,22 @@ void main() {
 
     test('throws on null for non-nullable fields on build', () {
       expect(() => new GenericValue<int>(),
-          throwsA(new isInstanceOf<ArgumentError>()));
+          throwsA(new isInstanceOf<BuiltValueNullFieldError>()));
     });
 
     test('throws on missing generic type parameter', () {
       expect(() => new GenericValue<dynamic>((b) => b..value = 1),
-          throwsA(new isInstanceOf<ArgumentError>()));
+          throwsA(new isInstanceOf<BuiltValueMissingGenericsError>()));
+    });
+
+    test('includes parameter name in missing generics error message', () {
+      expect(() => new GenericValue<dynamic>((b) => b..value = 1),
+          throwsA(isErrorContaining('"T"')));
+    });
+
+    test('includes class name in missing generics null error message', () {
+      expect(() => new GenericValue<dynamic>((b) => b..value = 1),
+          throwsA(isErrorContaining('"GenericValue"')));
     });
 
     test('fields can be set via build constructor', () {

--- a/end_to_end_test/test/private_value_test.g.dart
+++ b/end_to_end_test/test/private_value_test.g.dart
@@ -22,7 +22,8 @@ class _$PrivateValue extends _PrivateValue {
       (new _PrivateValueBuilder()..update(updates)).build();
 
   _$PrivateValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('_PrivateValue', 'value');
   }
 
   @override

--- a/end_to_end_test/test/values_test.dart
+++ b/end_to_end_test/test/values_test.dart
@@ -129,6 +129,25 @@ void main() {
       new CompoundValue((b) => b..simpleValue.anInt = 1);
     });
 
+    test('throws on null for non-nullable nested fields on build', () {
+      expect(() => new CompoundValue(),
+          throwsA(new isInstanceOf<BuiltValueNestedFieldError>()));
+    });
+
+    test('includes helpful information in null error message', () {
+      expect(
+          () => new CompoundValue(),
+          throwsA(allOf(
+              // Mentions outer type.
+              isErrorContaining('"CompoundValue"'),
+              // Mentions field in outer type.
+              isErrorContaining('"simpleValue"'),
+              // Mentions inner type.
+              isErrorContaining('"SimpleValue"'),
+              // Mentions field in inner type.
+              isErrorContaining('"anInt"'))));
+    });
+
     test('allows nested updates', () {
       expect(
           new CompoundValue((b) => b

--- a/end_to_end_test/test/values_test.dart
+++ b/end_to_end_test/test/values_test.dart
@@ -2,7 +2,9 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import 'package:built_value/built_value.dart';
 import 'package:end_to_end_test/enums.dart';
+import 'package:end_to_end_test/errors_matchers.dart';
 import 'package:end_to_end_test/values.dart';
 import 'package:quiver/core.dart';
 import 'package:test/test.dart';
@@ -14,8 +16,17 @@ void main() {
     });
 
     test('throws on null for non-nullable fields on build', () {
+      expect(() => new SimpleValue(),
+          throwsA(new isInstanceOf<BuiltValueNullFieldError>()));
+    });
+
+    test('includes field name in null error message', () {
+      expect(() => new SimpleValue(), throwsA(isErrorContaining('anInt')));
+    });
+
+    test('includes class name in null error message', () {
       expect(
-          () => new SimpleValue(), throwsA(new isInstanceOf<ArgumentError>()));
+          () => new SimpleValue(), throwsA(isErrorContaining('SimpleValue')));
     });
 
     test('throws on null replace', () {

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -207,11 +207,13 @@ class _$Collections extends Collections {
       this.nullableListMultimap,
       this.nullableSetMultimap})
       : super._() {
-    if (list == null) throw new ArgumentError.notNull('list');
-    if (set == null) throw new ArgumentError.notNull('set');
-    if (map == null) throw new ArgumentError.notNull('map');
-    if (listMultimap == null) throw new ArgumentError.notNull('listMultimap');
-    if (setMultimap == null) throw new ArgumentError.notNull('setMultimap');
+    if (list == null) throw new BuiltValueNullFieldError('Collections', 'list');
+    if (set == null) throw new BuiltValueNullFieldError('Collections', 'set');
+    if (map == null) throw new BuiltValueNullFieldError('Collections', 'map');
+    if (listMultimap == null)
+      throw new BuiltValueNullFieldError('Collections', 'listMultimap');
+    if (setMultimap == null)
+      throw new BuiltValueNullFieldError('Collections', 'setMultimap');
   }
 
   @override

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -368,18 +368,49 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
 
   @override
   _$Collections build() {
-    final _$result = _$v ??
-        new _$Collections._(
-            list: list?.build(),
-            set: set?.build(),
-            map: map?.build(),
-            listMultimap: listMultimap?.build(),
-            setMultimap: setMultimap?.build(),
-            nullableList: _nullableList?.build(),
-            nullableSet: _nullableSet?.build(),
-            nullableMap: _nullableMap?.build(),
-            nullableListMultimap: _nullableListMultimap?.build(),
-            nullableSetMultimap: _nullableSetMultimap?.build());
+    _$Collections _$result;
+    try {
+      _$result = _$v ??
+          new _$Collections._(
+              list: list.build(),
+              set: set.build(),
+              map: map.build(),
+              listMultimap: listMultimap.build(),
+              setMultimap: setMultimap.build(),
+              nullableList: _nullableList?.build(),
+              nullableSet: _nullableSet?.build(),
+              nullableMap: _nullableMap?.build(),
+              nullableListMultimap: _nullableListMultimap?.build(),
+              nullableSetMultimap: _nullableSetMultimap?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'list';
+        list.build();
+        _$failedField = 'set';
+        set.build();
+        _$failedField = 'map';
+        map.build();
+        _$failedField = 'listMultimap';
+        listMultimap.build();
+        _$failedField = 'setMultimap';
+        setMultimap.build();
+        _$failedField = 'nullableList';
+        _nullableList?.build();
+        _$failedField = 'nullableSet';
+        _nullableSet?.build();
+        _$failedField = 'nullableMap';
+        _nullableMap?.build();
+        _$failedField = 'nullableListMultimap';
+        _nullableListMultimap?.build();
+        _$failedField = 'nullableSetMultimap';
+        _nullableSetMultimap?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Collections', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/example/lib/generics.g.dart
+++ b/example/lib/generics.g.dart
@@ -491,8 +491,21 @@ class CollectionGenericValueBuilder<T>
 
   @override
   _$CollectionGenericValue<T> build() {
-    final _$result =
-        _$v ?? new _$CollectionGenericValue<T>._(values: values?.build());
+    _$CollectionGenericValue<T> _$result;
+    try {
+      _$result =
+          _$v ?? new _$CollectionGenericValue<T>._(values: values.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'values';
+        values.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'CollectionGenericValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -605,11 +618,28 @@ class GenericContainerBuilder
 
   @override
   _$GenericContainer build() {
-    final _$result = _$v ??
-        new _$GenericContainer._(
-            genericValue: genericValue?.build(),
-            boundGenericValue: boundGenericValue?.build(),
-            collectionGenericValue: collectionGenericValue?.build());
+    _$GenericContainer _$result;
+    try {
+      _$result = _$v ??
+          new _$GenericContainer._(
+              genericValue: genericValue.build(),
+              boundGenericValue: boundGenericValue.build(),
+              collectionGenericValue: collectionGenericValue.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'genericValue';
+        genericValue.build();
+        _$failedField = 'boundGenericValue';
+        boundGenericValue.build();
+        _$failedField = 'collectionGenericValue';
+        collectionGenericValue.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'GenericContainer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/example/lib/generics.g.dart
+++ b/example/lib/generics.g.dart
@@ -263,7 +263,8 @@ class _$GenericValue<T> extends GenericValue<T> {
       (new GenericValueBuilder<T>()..update(updates)).build();
 
   _$GenericValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('GenericValue', 'value');
   }
 
   @override
@@ -303,8 +304,7 @@ class GenericValueBuilder<T>
 
   GenericValueBuilder() {
     if (T == dynamic)
-      throw new ArgumentError.value(
-          'dynamic', 'T', 'All type arguments must be specified.');
+      throw new BuiltValueMissingGenericsError('GenericValue', 'T');
   }
 
   GenericValueBuilder<T> get _$this {
@@ -342,7 +342,8 @@ class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
       (new BoundGenericValueBuilder<T>()..update(updates)).build();
 
   _$BoundGenericValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('BoundGenericValue', 'value');
   }
 
   @override
@@ -383,8 +384,7 @@ class BoundGenericValueBuilder<T extends num>
 
   BoundGenericValueBuilder() {
     if (T == dynamic)
-      throw new ArgumentError.value(
-          'dynamic', 'T', 'All type arguments must be specified.');
+      throw new BuiltValueMissingGenericsError('BoundGenericValue', 'T');
   }
 
   BoundGenericValueBuilder<T> get _$this {
@@ -423,7 +423,8 @@ class _$CollectionGenericValue<T> extends CollectionGenericValue<T> {
       (new CollectionGenericValueBuilder<T>()..update(updates)).build();
 
   _$CollectionGenericValue._({this.values}) : super._() {
-    if (values == null) throw new ArgumentError.notNull('values');
+    if (values == null)
+      throw new BuiltValueNullFieldError('CollectionGenericValue', 'values');
   }
 
   @override
@@ -466,8 +467,7 @@ class CollectionGenericValueBuilder<T>
 
   CollectionGenericValueBuilder() {
     if (T == dynamic)
-      throw new ArgumentError.value(
-          'dynamic', 'T', 'All type arguments must be specified.');
+      throw new BuiltValueMissingGenericsError('CollectionGenericValue', 'T');
   }
 
   CollectionGenericValueBuilder<T> get _$this {
@@ -512,11 +512,14 @@ class _$GenericContainer extends GenericContainer {
   _$GenericContainer._(
       {this.genericValue, this.boundGenericValue, this.collectionGenericValue})
       : super._() {
-    if (genericValue == null) throw new ArgumentError.notNull('genericValue');
+    if (genericValue == null)
+      throw new BuiltValueNullFieldError('GenericContainer', 'genericValue');
     if (boundGenericValue == null)
-      throw new ArgumentError.notNull('boundGenericValue');
+      throw new BuiltValueNullFieldError(
+          'GenericContainer', 'boundGenericValue');
     if (collectionGenericValue == null)
-      throw new ArgumentError.notNull('collectionGenericValue');
+      throw new BuiltValueNullFieldError(
+          'GenericContainer', 'collectionGenericValue');
   }
 
   @override

--- a/example/lib/interfaces.g.dart
+++ b/example/lib/interfaces.g.dart
@@ -114,8 +114,10 @@ class _$ValueWithInt extends ValueWithInt {
       (new ValueWithIntBuilder()..update(updates)).build() as _$ValueWithInt;
 
   _$ValueWithInt._({this.anInt, this.note}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
-    if (note == null) throw new ArgumentError.notNull('note');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValueWithInt', 'anInt');
+    if (note == null)
+      throw new BuiltValueNullFieldError('ValueWithInt', 'note');
   }
 
   @override

--- a/example/lib/polymorphism.g.dart
+++ b/example/lib/polymorphism.g.dart
@@ -129,8 +129,8 @@ class _$Cat extends Cat {
       (new CatBuilder()..update(updates)).build();
 
   _$Cat._({this.tail, this.legs}) : super._() {
-    if (tail == null) throw new ArgumentError.notNull('tail');
-    if (legs == null) throw new ArgumentError.notNull('legs');
+    if (tail == null) throw new BuiltValueNullFieldError('Cat', 'tail');
+    if (legs == null) throw new BuiltValueNullFieldError('Cat', 'legs');
   }
 
   @override
@@ -212,8 +212,8 @@ class _$Fish extends Fish {
       (new FishBuilder()..update(updates)).build();
 
   _$Fish._({this.fins, this.legs}) : super._() {
-    if (fins == null) throw new ArgumentError.notNull('fins');
-    if (legs == null) throw new ArgumentError.notNull('legs');
+    if (fins == null) throw new BuiltValueNullFieldError('Fish', 'fins');
+    if (legs == null) throw new BuiltValueNullFieldError('Fish', 'legs');
   }
 
   @override

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -551,10 +551,25 @@ class CompoundValueBuilder
 
   @override
   _$CompoundValue build() {
-    final _$result = _$v ??
-        new _$CompoundValue._(
-            simpleValue: simpleValue?.build(),
-            validatedValue: _validatedValue?.build());
+    _$CompoundValue _$result;
+    try {
+      _$result = _$v ??
+          new _$CompoundValue._(
+              simpleValue: simpleValue.build(),
+              validatedValue: _validatedValue?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+        _$failedField = 'validatedValue';
+        _validatedValue?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'CompoundValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -1006,8 +1021,21 @@ class AccountBuilder implements Builder<Account, AccountBuilder> {
 
   @override
   _$Account build() {
-    final _$result = _$v ??
-        new _$Account._(id: id, name: name, keyValues: keyValues?.build());
+    _$Account _$result;
+    try {
+      _$result = _$v ??
+          new _$Account._(id: id, name: name, keyValues: keyValues.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'keyValues';
+        keyValues.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Account', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -319,7 +319,8 @@ class _$SimpleValue extends SimpleValue {
       (new SimpleValueBuilder()..update(updates)).build();
 
   _$SimpleValue._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('SimpleValue', 'anInt');
   }
 
   @override
@@ -399,7 +400,8 @@ class _$VerySimpleValue extends VerySimpleValue {
       (new VerySimpleValueBuilder()..update(updates)).build();
 
   _$VerySimpleValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('VerySimpleValue', 'value');
   }
 
   @override
@@ -476,7 +478,8 @@ class _$CompoundValue extends CompoundValue {
       (new CompoundValueBuilder()..update(updates)).build();
 
   _$CompoundValue._({this.simpleValue, this.validatedValue}) : super._() {
-    if (simpleValue == null) throw new ArgumentError.notNull('simpleValue');
+    if (simpleValue == null)
+      throw new BuiltValueNullFieldError('CompoundValue', 'simpleValue');
   }
 
   @override
@@ -567,7 +570,8 @@ class _$ValidatedValue extends ValidatedValue {
       (new ValidatedValueBuilder()..update(updates)).build();
 
   _$ValidatedValue._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValidatedValue', 'anInt');
   }
 
   @override
@@ -652,7 +656,8 @@ class _$ValueWithCode extends ValueWithCode {
       (new ValueWithCodeBuilder()..update(updates)).build();
 
   _$ValueWithCode._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValueWithCode', 'anInt');
   }
 
   @override
@@ -737,7 +742,8 @@ class _$ValueWithDefaults extends ValueWithDefaults {
           as _$ValueWithDefaults;
 
   _$ValueWithDefaults._({this.anInt, this.aString}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('ValueWithDefaults', 'anInt');
   }
 
   @override
@@ -837,7 +843,8 @@ class _$DerivedValue extends DerivedValue {
       (new DerivedValueBuilder()..update(updates)).build();
 
   _$DerivedValue._({this.anInt}) : super._() {
-    if (anInt == null) throw new ArgumentError.notNull('anInt');
+    if (anInt == null)
+      throw new BuiltValueNullFieldError('DerivedValue', 'anInt');
   }
 
   @override
@@ -921,9 +928,10 @@ class _$Account extends Account {
       (new AccountBuilder()..update(updates)).build();
 
   _$Account._({this.id, this.name, this.keyValues}) : super._() {
-    if (id == null) throw new ArgumentError.notNull('id');
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (keyValues == null) throw new ArgumentError.notNull('keyValues');
+    if (id == null) throw new BuiltValueNullFieldError('Account', 'id');
+    if (name == null) throw new BuiltValueNullFieldError('Account', 'name');
+    if (keyValues == null)
+      throw new BuiltValueNullFieldError('Account', 'keyValues');
   }
 
   @override
@@ -1013,7 +1021,8 @@ class _$WireNameValue extends WireNameValue {
       (new WireNameValueBuilder()..update(updates)).build();
 
   _$WireNameValue._({this.value}) : super._() {
-    if (value == null) throw new ArgumentError.notNull('value');
+    if (value == null)
+      throw new BuiltValueNullFieldError('WireNameValue', 'value');
   }
 
   @override


### PR DESCRIPTION
Add custom `Error` classes: `BuiltValueNullFieldError`, 
  `BuiltValueMissingGenericsError` and `BuiltValueNestedFieldError`. These
  provide clearer error messages on failure. In particular, errors in nested
  builders now report the enclosing class and field name, making them much
  more useful.

Fixes #301 
Fixes #309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/316)
<!-- Reviewable:end -->

  