### PR TITLE
Add .dart_tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .buildlog
+.dart_tool/
 .DS_Store
 .idea
 .pub/


### PR DESCRIPTION
The .dart_tool directory is the new canonical location for cache/temp
files for Dart-related tooling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/370)
<!-- Reviewable:end -->
