### PR TITLE
Avoid dynamic in generated operator==

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 6.0.1 (unreleased)
+
+- Improve generation for `operator==`, don't use `dynamic`.
+
 # 6.0.0
 
 - Update to the latest `source_gen`. This generator can now be used with other

--- a/benchmark/lib/node.g.dart
+++ b/benchmark/lib/node.g.dart
@@ -37,10 +37,12 @@ class _$Node extends Node {
   NodeBuilder toBuilder() => new NodeBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Node) return false;
-    return label == other.label && left == other.left && right == other.right;
+    return other is Node &&
+        label == other.label &&
+        left == other.left &&
+        right == other.right;
   }
 
   @override

--- a/benchmark/lib/simple_value.g.dart
+++ b/benchmark/lib/simple_value.g.dart
@@ -40,10 +40,11 @@ class _$SimpleValue extends SimpleValue {
   SimpleValueBuilder toBuilder() => new SimpleValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SimpleValue) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is SimpleValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override

--- a/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_value_generator/lib/src/enum_source_class.g.dart
@@ -82,10 +82,9 @@ class _$EnumSourceClass extends EnumSourceClass {
       new EnumSourceClassBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! EnumSourceClass) return false;
-    return element == other.element;
+    return other is EnumSourceClass && element == other.element;
   }
 
   @override

--- a/built_value_generator/lib/src/enum_source_field.g.dart
+++ b/built_value_generator/lib/src/enum_source_field.g.dart
@@ -62,10 +62,9 @@ class _$EnumSourceField extends EnumSourceField {
       new EnumSourceFieldBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! EnumSourceField) return false;
-    return element == other.element;
+    return other is EnumSourceField && element == other.element;
   }
 
   @override

--- a/built_value_generator/lib/src/enum_source_library.g.dart
+++ b/built_value_generator/lib/src/enum_source_library.g.dart
@@ -53,10 +53,9 @@ class _$EnumSourceLibrary extends EnumSourceLibrary {
       new EnumSourceLibraryBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! EnumSourceLibrary) return false;
-    return element == other.element;
+    return other is EnumSourceLibrary && element == other.element;
   }
 
   @override

--- a/built_value_generator/lib/src/fixes.g.dart
+++ b/built_value_generator/lib/src/fixes.g.dart
@@ -44,10 +44,10 @@ class _$GeneratorError extends GeneratorError {
       new GeneratorErrorBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! GeneratorError) return false;
-    return message == other.message &&
+    return other is GeneratorError &&
+        message == other.message &&
         offset == other.offset &&
         length == other.length &&
         fix == other.fix;

--- a/built_value_generator/lib/src/memoized_getter.g.dart
+++ b/built_value_generator/lib/src/memoized_getter.g.dart
@@ -41,10 +41,11 @@ class _$MemoizedGetter extends MemoizedGetter {
       new MemoizedGetterBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! MemoizedGetter) return false;
-    return returnType == other.returnType && name == other.name;
+    return other is MemoizedGetter &&
+        returnType == other.returnType &&
+        name == other.name;
   }
 
   @override

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -276,13 +276,11 @@ class _\$${name}Serializer implements PrimitiveSerializer<$name> {
         // Generate maps between enum names and wire names.
         final toWire = '''
          static const Map<String, String> _toWire = const <String, String>{
-           ${wireNameMapping.keys.map(
-                (key) => "'$key': '${wireNameMapping[key]}',").join('\n')}
+           ${wireNameMapping.keys.map((key) => "'$key': '${wireNameMapping[key]}',").join('\n')}
          };''';
         final fromWire = '''
          static const Map<String, String> _fromWire = const <String, String>{
-           ${wireNameMapping.keys.map(
-                (key) => "'${wireNameMapping[key]}': '$key',").join('\n')}
+           ${wireNameMapping.keys.map((key) => "'${wireNameMapping[key]}': '$key',").join('\n')}
          };''';
 
         return '''

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -95,10 +95,11 @@ class _$SerializerSourceClass extends SerializerSourceClass {
       new SerializerSourceClassBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SerializerSourceClass) return false;
-    return element == other.element && builderElement == other.builderElement;
+    return other is SerializerSourceClass &&
+        element == other.element &&
+        builderElement == other.builderElement;
   }
 
   @override

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -87,10 +87,10 @@ class _$SerializerSourceField extends SerializerSourceField {
       new SerializerSourceFieldBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SerializerSourceField) return false;
-    return settings == other.settings &&
+    return other is SerializerSourceField &&
+        settings == other.settings &&
         element == other.element &&
         builderElement == other.builderElement;
   }

--- a/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -65,10 +65,9 @@ class _$SerializerSourceLibrary extends SerializerSourceLibrary {
       new SerializerSourceLibraryBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SerializerSourceLibrary) return false;
-    return element == other.element;
+    return other is SerializerSourceLibrary && element == other.element;
   }
 
   @override

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -611,20 +611,18 @@ abstract class ValueSourceClass
     result.writeln();
 
     result.writeln('@override');
-    result.writeln('bool operator==(dynamic other) {');
+    result.writeln('bool operator==(Object other) {');
     result.writeln('  if (identical(other, this)) return true;');
-    result.writeln('  if (other is! $name) return false;');
+    result.writeln('  return other is $name');
     final comparedFields =
         fields.where((field) => field.builtValueField.compare);
-    if (comparedFields.length == 0) {
-      result.writeln('return true;');
-    } else {
-      result.writeln('return');
+    if (comparedFields.isNotEmpty) {
+      result.writeln('&&');
       result.writeln(comparedFields
           .map((field) => '${field.name} == other.${field.name}')
           .join('&&'));
-      result.writeln(';');
     }
+    result.writeln(';');
     result.writeln('}');
     result.writeln();
 

--- a/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_value_generator/lib/src/value_source_class.g.dart
@@ -171,10 +171,9 @@ class _$ValueSourceClass extends ValueSourceClass {
       new ValueSourceClassBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueSourceClass) return false;
-    return element == other.element;
+    return other is ValueSourceClass && element == other.element;
   }
 
   @override

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -87,10 +87,10 @@ class _$ValueSourceField extends ValueSourceField {
       new ValueSourceFieldBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueSourceField) return false;
-    return settings == other.settings &&
+    return other is ValueSourceField &&
+        settings == other.settings &&
         element == other.element &&
         builderElement == other.builderElement;
   }

--- a/built_value_test/test/values.g.dart
+++ b/built_value_test/test/values.g.dart
@@ -39,10 +39,9 @@ class _$SimpleValue extends SimpleValue {
   SimpleValueBuilder toBuilder() => new SimpleValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SimpleValue) return false;
-    return anInt == other.anInt && map == other.map;
+    return other is SimpleValue && anInt == other.anInt && map == other.map;
   }
 
   @override
@@ -136,10 +135,11 @@ class _$CompoundValue extends CompoundValue {
   CompoundValueBuilder toBuilder() => new CompoundValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CompoundValue) return false;
-    return simpleValue == other.simpleValue && string == other.string;
+    return other is CompoundValue &&
+        simpleValue == other.simpleValue &&
+        string == other.string;
   }
 
   @override
@@ -239,10 +239,9 @@ class _$ComparedValue extends ComparedValue {
   ComparedValueBuilder toBuilder() => new ComparedValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ComparedValue) return false;
-    return name == other.name;
+    return other is ComparedValue && name == other.name;
   }
 
   @override

--- a/chat_example/lib/data_model/data_model.g.dart
+++ b/chat_example/lib/data_model/data_model.g.dart
@@ -464,10 +464,9 @@ class _$Chat extends Chat {
   ChatBuilder toBuilder() => new ChatBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Chat) return false;
-    return text == other.text && targets == other.targets;
+    return other is Chat && text == other.text && targets == other.targets;
   }
 
   @override
@@ -563,10 +562,11 @@ class _$Login extends Login {
   LoginBuilder toBuilder() => new LoginBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Login) return false;
-    return username == other.username && password == other.password;
+    return other is Login &&
+        username == other.username &&
+        password == other.password;
   }
 
   @override
@@ -648,10 +648,9 @@ class _$Status extends Status {
   StatusBuilder toBuilder() => new StatusBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Status) return false;
-    return message == other.message && type == other.type;
+    return other is Status && message == other.message && type == other.type;
   }
 
   @override
@@ -729,10 +728,9 @@ class _$ListUsers extends ListUsers {
   ListUsersBuilder toBuilder() => new ListUsersBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ListUsers) return false;
-    return statusTypes == other.statusTypes;
+    return other is ListUsers && statusTypes == other.statusTypes;
   }
 
   @override
@@ -826,10 +824,10 @@ class _$ShowChat extends ShowChat {
   ShowChatBuilder toBuilder() => new ShowChatBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ShowChat) return false;
-    return username == other.username &&
+    return other is ShowChat &&
+        username == other.username &&
         private == other.private &&
         text == other.text;
   }
@@ -920,10 +918,9 @@ class _$Welcome extends Welcome {
   WelcomeBuilder toBuilder() => new WelcomeBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Welcome) return false;
-    return log == other.log && message == other.message;
+    return other is Welcome && log == other.log && message == other.message;
   }
 
   @override
@@ -1015,10 +1012,9 @@ class _$ListUsersResponse extends ListUsersResponse {
       new ListUsersResponseBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ListUsersResponse) return false;
-    return statuses == other.statuses;
+    return other is ListUsersResponse && statuses == other.statuses;
   }
 
   @override

--- a/end_to_end_test/lib/collections.g.dart
+++ b/end_to_end_test/lib/collections.g.dart
@@ -226,10 +226,10 @@ class _$Collections extends Collections {
   CollectionsBuilder toBuilder() => new CollectionsBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Collections) return false;
-    return list == other.list &&
+    return other is Collections &&
+        list == other.list &&
         set == other.set &&
         map == other.map &&
         listMultimap == other.listMultimap &&

--- a/end_to_end_test/lib/generics.g.dart
+++ b/end_to_end_test/lib/generics.g.dart
@@ -375,10 +375,9 @@ class _$GenericValue<T> extends GenericValue<T> {
       new GenericValueBuilder<T>()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! GenericValue) return false;
-    return value == other.value;
+    return other is GenericValue && value == other.value;
   }
 
   @override
@@ -453,10 +452,9 @@ class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
       new BoundGenericValueBuilder<T>()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! BoundGenericValue) return false;
-    return value == other.value;
+    return other is BoundGenericValue && value == other.value;
   }
 
   @override
@@ -534,10 +532,9 @@ class _$CollectionGenericValue<T> extends CollectionGenericValue<T> {
       new CollectionGenericValueBuilder<T>()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CollectionGenericValue) return false;
-    return values == other.values;
+    return other is CollectionGenericValue && values == other.values;
   }
 
   @override
@@ -638,10 +635,10 @@ class _$GenericContainer extends GenericContainer {
       new GenericContainerBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! GenericContainer) return false;
-    return genericValue == other.genericValue &&
+    return other is GenericContainer &&
+        genericValue == other.genericValue &&
         boundGenericValue == other.boundGenericValue &&
         collectionGenericValue == other.collectionGenericValue;
   }
@@ -762,10 +759,9 @@ class _$NestedGenericContainer extends NestedGenericContainer {
       new NestedGenericContainerBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! NestedGenericContainer) return false;
-    return map == other.map;
+    return other is NestedGenericContainer && map == other.map;
   }
 
   @override
@@ -859,10 +855,9 @@ class _$CustomBuilderGenericValue<T> extends CustomBuilderGenericValue<T> {
       new _$CustomBuilderGenericValueBuilder<T>()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CustomBuilderGenericValue) return false;
-    return value == other.value;
+    return other is CustomBuilderGenericValue && value == other.value;
   }
 
   @override
@@ -944,10 +939,9 @@ class _$ConcreteGeneric extends ConcreteGeneric {
       new ConcreteGenericBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ConcreteGeneric) return false;
-    return value == other.value;
+    return other is ConcreteGeneric && value == other.value;
   }
 
   @override

--- a/end_to_end_test/lib/imported_values.g.dart
+++ b/end_to_end_test/lib/imported_values.g.dart
@@ -94,10 +94,10 @@ class _$ImportedValue extends ImportedValue {
   ImportedValueBuilder toBuilder() => new ImportedValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ImportedValue) return false;
-    return simpleValue == other.simpleValue &&
+    return other is ImportedValue &&
+        simpleValue == other.simpleValue &&
         simpleValues == other.simpleValues;
   }
 

--- a/end_to_end_test/lib/interfaces.g.dart
+++ b/end_to_end_test/lib/interfaces.g.dart
@@ -173,10 +173,9 @@ class _$ValueWithInt extends ValueWithInt {
   ValueWithIntBuilder toBuilder() => new ValueWithIntBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueWithInt) return false;
-    return anInt == other.anInt && note == other.note;
+    return other is ValueWithInt && anInt == other.anInt && note == other.note;
   }
 
   @override
@@ -256,10 +255,9 @@ class _$ValueWithHasInt extends ValueWithHasInt {
       new ValueWithHasIntBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueWithHasInt) return false;
-    return hasInt == other.hasInt;
+    return other is ValueWithHasInt && hasInt == other.hasInt;
   }
 
   @override

--- a/end_to_end_test/lib/mixins.g.dart
+++ b/end_to_end_test/lib/mixins.g.dart
@@ -57,10 +57,9 @@ class _$UsesMixin extends UsesMixin {
   UsesMixinBuilder toBuilder() => new UsesMixinBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! UsesMixin) return false;
-    return typeDef == other.typeDef;
+    return other is UsesMixin && typeDef == other.typeDef;
   }
 
   @override

--- a/end_to_end_test/lib/polymorphism.g.dart
+++ b/end_to_end_test/lib/polymorphism.g.dart
@@ -399,10 +399,9 @@ class _$Cat extends Cat {
   CatBuilder toBuilder() => new CatBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Cat) return false;
-    return tail == other.tail && legs == other.legs;
+    return other is Cat && tail == other.tail && legs == other.legs;
   }
 
   @override
@@ -482,10 +481,9 @@ class _$Fish extends Fish {
   FishBuilder toBuilder() => new FishBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Fish) return false;
-    return fins == other.fins && legs == other.legs;
+    return other is Fish && fins == other.fins && legs == other.legs;
   }
 
   @override
@@ -565,10 +563,9 @@ class _$Robot extends Robot {
   RobotBuilder toBuilder() => new RobotBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Robot) return false;
-    return fins == other.fins && legs == other.legs;
+    return other is Robot && fins == other.fins && legs == other.legs;
   }
 
   @override
@@ -650,10 +647,10 @@ class _$Cage extends Cage {
   CageBuilder toBuilder() => new CageBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Cage) return false;
-    return inhabitant == other.inhabitant &&
+    return other is Cage &&
+        inhabitant == other.inhabitant &&
         otherInhabitants == other.otherInhabitants;
   }
 
@@ -749,10 +746,9 @@ class _$StandardCat extends StandardCat {
   StandardCatBuilder toBuilder() => new StandardCatBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! StandardCat) return false;
-    return tail == other.tail;
+    return other is StandardCat && tail == other.tail;
   }
 
   @override
@@ -829,10 +825,9 @@ class _$HasString extends HasString {
   HasStringBuilder toBuilder() => new HasStringBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! HasString) return false;
-    return field == other.field;
+    return other is HasString && field == other.field;
   }
 
   @override
@@ -903,10 +898,9 @@ class _$HasDouble extends HasDouble {
   HasDoubleBuilder toBuilder() => new HasDoubleBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! HasDouble) return false;
-    return field == other.field;
+    return other is HasDouble && field == other.field;
   }
 
   @override
@@ -984,10 +978,11 @@ class _$UsesChainedInterface extends UsesChainedInterface {
       new UsesChainedInterfaceBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! UsesChainedInterface) return false;
-    return bar == other.bar && foo == other.foo;
+    return other is UsesChainedInterface &&
+        bar == other.bar &&
+        foo == other.foo;
   }
 
   @override
@@ -1066,10 +1061,10 @@ class _$UsesHandCoded extends UsesHandCoded {
   UsesHandCodedBuilder toBuilder() => new UsesHandCodedBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! UsesHandCoded) return false;
-    return fieldInBaseBuilder == other.fieldInBaseBuilder;
+    return other is UsesHandCoded &&
+        fieldInBaseBuilder == other.fieldInBaseBuilder;
   }
 
   @override
@@ -1148,10 +1143,9 @@ class _$ImplementsTwo extends ImplementsTwo {
   ImplementsTwoBuilder toBuilder() => new ImplementsTwoBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ImplementsTwo) return false;
-    return true;
+    return other is ImplementsTwo;
   }
 
   @override

--- a/end_to_end_test/lib/standard_json.g.dart
+++ b/end_to_end_test/lib/standard_json.g.dart
@@ -155,10 +155,10 @@ class _$StandardJsonValue extends StandardJsonValue {
       new StandardJsonValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! StandardJsonValue) return false;
-    return number == other.number &&
+    return other is StandardJsonValue &&
+        number == other.number &&
         text == other.text &&
         keyValues == other.keyValues &&
         zoo == other.zoo &&

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -801,10 +801,11 @@ class _$SimpleValue extends SimpleValue {
   SimpleValueBuilder toBuilder() => new SimpleValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SimpleValue) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is SimpleValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override
@@ -884,10 +885,10 @@ class _$CompoundValue extends CompoundValue {
   CompoundValueBuilder toBuilder() => new CompoundValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CompoundValue) return false;
-    return simpleValue == other.simpleValue &&
+    return other is CompoundValue &&
+        simpleValue == other.simpleValue &&
         validatedValue == other.validatedValue;
   }
 
@@ -996,10 +997,10 @@ class _$CompoundValueNoNesting extends CompoundValueNoNesting {
       new CompoundValueNoNestingBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CompoundValueNoNesting) return false;
-    return simpleValue == other.simpleValue &&
+    return other is CompoundValueNoNesting &&
+        simpleValue == other.simpleValue &&
         validatedValue == other.validatedValue;
   }
 
@@ -1090,10 +1091,10 @@ class _$CompoundValueExplicitNoNesting extends CompoundValueExplicitNoNesting {
       new _$CompoundValueExplicitNoNestingBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CompoundValueExplicitNoNesting) return false;
-    return simpleValue == other.simpleValue &&
+    return other is CompoundValueExplicitNoNesting &&
+        simpleValue == other.simpleValue &&
         validatedValue == other.validatedValue;
   }
 
@@ -1212,10 +1213,9 @@ class _$DerivedValue extends DerivedValue {
   DerivedValueBuilder toBuilder() => new DerivedValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! DerivedValue) return false;
-    return anInt == other.anInt;
+    return other is DerivedValue && anInt == other.anInt;
   }
 
   @override
@@ -1289,10 +1289,11 @@ class _$ValueWithCode extends ValueWithCode {
   ValueWithCodeBuilder toBuilder() => new ValueWithCodeBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueWithCode) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is ValueWithCode &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override
@@ -1380,10 +1381,10 @@ class _$ValueWithDefaults extends ValueWithDefaults {
       new _$ValueWithDefaultsBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueWithDefaults) return false;
-    return anInt == other.anInt &&
+    return other is ValueWithDefaults &&
+        anInt == other.anInt &&
         aString == other.aString &&
         value == other.value;
   }
@@ -1512,10 +1513,11 @@ class _$ValidatedValue extends ValidatedValue {
       new ValidatedValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValidatedValue) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is ValidatedValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override
@@ -1596,10 +1598,9 @@ class _$ValueUsingImportAs extends ValueUsingImportAs {
       new ValueUsingImportAsBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueUsingImportAs) return false;
-    return value == other.value;
+    return other is ValueUsingImportAs && value == other.value;
   }
 
   @override
@@ -1666,10 +1667,9 @@ class _$NoFieldsValue extends NoFieldsValue {
   NoFieldsValueBuilder toBuilder() => new NoFieldsValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! NoFieldsValue) return false;
-    return true;
+    return other is NoFieldsValue;
   }
 
   @override
@@ -1771,10 +1771,10 @@ class _$PrimitivesValue extends PrimitivesValue {
       new PrimitivesValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! PrimitivesValue) return false;
-    return boolean == other.boolean &&
+    return other is PrimitivesValue &&
+        boolean == other.boolean &&
         integer == other.integer &&
         int64 == other.int64 &&
         dbl == other.dbl &&
@@ -1926,10 +1926,9 @@ class _$FunctionValue extends FunctionValue {
   FunctionValueBuilder toBuilder() => new FunctionValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! FunctionValue) return false;
-    return function == other.function;
+    return other is FunctionValue && function == other.function;
   }
 
   @override
@@ -2003,10 +2002,9 @@ class _$ListOfFunctionValue extends ListOfFunctionValue {
       new ListOfFunctionValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ListOfFunctionValue) return false;
-    return functions == other.functions;
+    return other is ListOfFunctionValue && functions == other.functions;
   }
 
   @override
@@ -2101,10 +2099,11 @@ class _$PartiallySerializableValue extends PartiallySerializableValue {
       new PartiallySerializableValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! PartiallySerializableValue) return false;
-    return value == other.value && transientValue == other.transientValue;
+    return other is PartiallySerializableValue &&
+        value == other.value &&
+        transientValue == other.transientValue;
   }
 
   @override
@@ -2188,10 +2187,9 @@ class _$NamedFactoryValue extends NamedFactoryValue {
       new NamedFactoryValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! NamedFactoryValue) return false;
-    return value == other.value;
+    return other is NamedFactoryValue && value == other.value;
   }
 
   @override
@@ -2264,10 +2262,9 @@ class _$WireNameValue extends WireNameValue {
   WireNameValueBuilder toBuilder() => new WireNameValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! WireNameValue) return false;
-    return value == other.value;
+    return other is WireNameValue && value == other.value;
   }
 
   @override
@@ -2347,10 +2344,10 @@ class _$FieldDiscoveryValue extends FieldDiscoveryValue {
       new FieldDiscoveryValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! FieldDiscoveryValue) return false;
-    return value == other.value &&
+    return other is FieldDiscoveryValue &&
+        value == other.value &&
         values == other.values &&
         recursiveValue == other.recursiveValue;
   }
@@ -2465,10 +2462,9 @@ class _$DiscoverableValue extends DiscoverableValue {
       new DiscoverableValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! DiscoverableValue) return false;
-    return value == other.value;
+    return other is DiscoverableValue && value == other.value;
   }
 
   @override
@@ -2558,10 +2554,9 @@ class _$SecondDiscoverableValue extends SecondDiscoverableValue {
       new SecondDiscoverableValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SecondDiscoverableValue) return false;
-    return value == other.value;
+    return other is SecondDiscoverableValue && value == other.value;
   }
 
   @override
@@ -2638,10 +2633,9 @@ class _$ThirdDiscoverableValue extends ThirdDiscoverableValue {
       new ThirdDiscoverableValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ThirdDiscoverableValue) return false;
-    return value == other.value;
+    return other is ThirdDiscoverableValue && value == other.value;
   }
 
   @override

--- a/end_to_end_test/test/private_value_test.g.dart
+++ b/end_to_end_test/test/private_value_test.g.dart
@@ -36,10 +36,9 @@ class _$PrivateValue extends _PrivateValue {
   _PrivateValueBuilder toBuilder() => new _PrivateValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! _PrivateValue) return false;
-    return value == other.value;
+    return other is _PrivateValue && value == other.value;
   }
 
   @override

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -226,10 +226,10 @@ class _$Collections extends Collections {
   CollectionsBuilder toBuilder() => new CollectionsBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Collections) return false;
-    return list == other.list &&
+    return other is Collections &&
+        list == other.list &&
         set == other.set &&
         map == other.map &&
         listMultimap == other.listMultimap &&

--- a/example/lib/generics.g.dart
+++ b/example/lib/generics.g.dart
@@ -280,10 +280,9 @@ class _$GenericValue<T> extends GenericValue<T> {
       new GenericValueBuilder<T>()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! GenericValue) return false;
-    return value == other.value;
+    return other is GenericValue && value == other.value;
   }
 
   @override
@@ -358,10 +357,9 @@ class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
       new BoundGenericValueBuilder<T>()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! BoundGenericValue) return false;
-    return value == other.value;
+    return other is BoundGenericValue && value == other.value;
   }
 
   @override
@@ -439,10 +437,9 @@ class _$CollectionGenericValue<T> extends CollectionGenericValue<T> {
       new CollectionGenericValueBuilder<T>()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CollectionGenericValue) return false;
-    return values == other.values;
+    return other is CollectionGenericValue && values == other.values;
   }
 
   @override
@@ -543,10 +540,10 @@ class _$GenericContainer extends GenericContainer {
       new GenericContainerBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! GenericContainer) return false;
-    return genericValue == other.genericValue &&
+    return other is GenericContainer &&
+        genericValue == other.genericValue &&
         boundGenericValue == other.boundGenericValue &&
         collectionGenericValue == other.collectionGenericValue;
   }

--- a/example/lib/interfaces.g.dart
+++ b/example/lib/interfaces.g.dart
@@ -131,10 +131,9 @@ class _$ValueWithInt extends ValueWithInt {
       new _$ValueWithIntBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueWithInt) return false;
-    return anInt == other.anInt && note == other.note;
+    return other is ValueWithInt && anInt == other.anInt && note == other.note;
   }
 
   @override

--- a/example/lib/polymorphism.g.dart
+++ b/example/lib/polymorphism.g.dart
@@ -138,10 +138,9 @@ class _$Cat extends Cat {
   CatBuilder toBuilder() => new CatBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Cat) return false;
-    return tail == other.tail && legs == other.legs;
+    return other is Cat && tail == other.tail && legs == other.legs;
   }
 
   @override
@@ -221,10 +220,9 @@ class _$Fish extends Fish {
   FishBuilder toBuilder() => new FishBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Fish) return false;
-    return fins == other.fins && legs == other.legs;
+    return other is Fish && fins == other.fins && legs == other.legs;
   }
 
   @override

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -333,10 +333,11 @@ class _$SimpleValue extends SimpleValue {
   SimpleValueBuilder toBuilder() => new SimpleValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! SimpleValue) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is SimpleValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override
@@ -415,10 +416,9 @@ class _$VerySimpleValue extends VerySimpleValue {
       new VerySimpleValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! VerySimpleValue) return false;
-    return value == other.value;
+    return other is VerySimpleValue && value == other.value;
   }
 
   @override
@@ -492,10 +492,10 @@ class _$CompoundValue extends CompoundValue {
   CompoundValueBuilder toBuilder() => new CompoundValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! CompoundValue) return false;
-    return simpleValue == other.simpleValue &&
+    return other is CompoundValue &&
+        simpleValue == other.simpleValue &&
         validatedValue == other.validatedValue;
   }
 
@@ -600,10 +600,11 @@ class _$ValidatedValue extends ValidatedValue {
       new ValidatedValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValidatedValue) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is ValidatedValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override
@@ -685,10 +686,11 @@ class _$ValueWithCode extends ValueWithCode {
   ValueWithCodeBuilder toBuilder() => new ValueWithCodeBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueWithCode) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is ValueWithCode &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override
@@ -772,10 +774,11 @@ class _$ValueWithDefaults extends ValueWithDefaults {
       new _$ValueWithDefaultsBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! ValueWithDefaults) return false;
-    return anInt == other.anInt && aString == other.aString;
+    return other is ValueWithDefaults &&
+        anInt == other.anInt &&
+        aString == other.aString;
   }
 
   @override
@@ -878,10 +881,9 @@ class _$DerivedValue extends DerivedValue {
   DerivedValueBuilder toBuilder() => new DerivedValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! DerivedValue) return false;
-    return anInt == other.anInt;
+    return other is DerivedValue && anInt == other.anInt;
   }
 
   @override
@@ -959,10 +961,12 @@ class _$Account extends Account {
   AccountBuilder toBuilder() => new AccountBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Account) return false;
-    return id == other.id && name == other.name && keyValues == other.keyValues;
+    return other is Account &&
+        id == other.id &&
+        name == other.name &&
+        keyValues == other.keyValues;
   }
 
   @override
@@ -1063,10 +1067,9 @@ class _$WireNameValue extends WireNameValue {
   WireNameValueBuilder toBuilder() => new WireNameValueBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! WireNameValue) return false;
-    return value == other.value;
+    return other is WireNameValue && value == other.value;
   }
 
   @override


### PR DESCRIPTION
Since positive `is` check enables type inference in analyzer and friends, `dynamic` could be avoided in the generated implementation of `operator==`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/475)
<!-- Reviewable:end -->
