### PR TITLE
Add readme examples for nullable and BuiltValueField

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ import 'package:built_collection/built_collection.dart';
 part 'person.g.dart';
 
 abstract class Person implements Built<Person, PersonBuilder> {
+  static Serializer<Person> get serializer => _$personSerializer;
+
   // Can never be null.
   int get id;
 
@@ -228,7 +230,6 @@ abstract class Person implements Built<Person, PersonBuilder> {
 
   Person._();
   factory Person([updates(PersonBuilder b)]) = _$Person;
-  static Serializer<Person> get serializer => _$personSerializer;
 }
 ```
 


### PR DESCRIPTION
This adds examples for `@nullable` and `@BuiltValueField` to a new section on the README. As a newcomer to both dart and `built_value`, I would have appreciated a basic example when landing at the repo.

Dave mentioned on #144 that including this as an example might make sense:

> It would make sense to explain this and the other three related annotations on the main README file, I think.

I am not sure which other three those are, nor how to use the other ones I did see there, so I only included the two annotations mentioned above.

**Additionally, although this works for my particular use case, I would feel better about someone more familiar with the library double checking that my example makes sense before merging.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/505)
<!-- Reviewable:end -->
