### PR TITLE
Modify pubspec to allow build package of 1.0 and greater

### DIFF
--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   analyzer: ^0.32.1
   analyzer_plugin: ^0.0.1-alpha.4
-  build: ^0.12.0
+  build: '>=0.12.0 <2.0.0'
   build_config: ^0.3.1
   built_collection: '>=2.0.0 <5.0.0'
   built_value: '>=5.5.5 <7.0.0'


### PR DESCRIPTION
Previously built_value_generator relied on build ^0.0.12, and the build package is 1.0. I don't see any reason why I shouldn't allow 1.0, so I upped the version constraint.

Modify pubspec to allow build package of 1.0 and greater (up to next potentially breaking change of 2.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/511)
<!-- Reviewable:end -->
