### PR TITLE
Ignore avoid_as lint on generate files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 David Morgan/Google Inc. <davidmorgan@google.com>
 Resul Alkan/MetGlobal <me@resulalkan.com>
+Guilherme Torres Castro <guilherme.torres.castro@gmail.com>

--- a/benchmark/lib/node.g.dart
+++ b/benchmark/lib/node.g.dart
@@ -6,19 +6,6 @@ part of node;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$Node extends Node {
   @override
   final String label;
@@ -127,3 +114,17 @@ class NodeBuilder implements Builder<Node, NodeBuilder> {
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/benchmark/lib/simple_value.g.dart
+++ b/benchmark/lib/simple_value.g.dart
@@ -6,19 +6,6 @@ part of simple_value;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$SimpleValue extends SimpleValue {
   @override
   final int anInt;
@@ -108,3 +95,17 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/built_value_generator.dart
+++ b/built_value_generator/lib/built_value_generator.dart
@@ -59,8 +59,10 @@ class BuiltValueGenerator extends Generator {
     }
 
     if (result.isNotEmpty) {
-      return '// ignore_for_file: always_put_control_body_on_new_line\n'
+      return '$result\n'
+          '// ignore_for_file: always_put_control_body_on_new_line\n'
           '// ignore_for_file: annotate_overrides\n'
+          '// ignore_for_file: avoid_as\n'
           '// ignore_for_file: avoid_annotating_with_dynamic\n'
           '// ignore_for_file: avoid_catches_without_on_clauses\n'
           '// ignore_for_file: avoid_returning_this\n'
@@ -71,9 +73,7 @@ class BuiltValueGenerator extends Generator {
           '// ignore_for_file: unnecessary_const\n'
           '// ignore_for_file: unnecessary_new\n'
           '// ignore_for_file: test_types_in_equals\n'
-          '// ignore_for_file: avoid_as\n'        
-          '\n'
-          '$result';
+          '\n';
     } else {
       return null;
     }

--- a/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_value_generator/lib/src/enum_source_class.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.enum_source_class;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$EnumSourceClass extends EnumSourceClass {
   @override
   final ClassElement element;
@@ -142,3 +129,17 @@ class EnumSourceClassBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/enum_source_field.g.dart
+++ b/built_value_generator/lib/src/enum_source_field.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.enum_source_field;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$EnumSourceField extends EnumSourceField {
   @override
   final FieldElement element;
@@ -122,3 +109,17 @@ class EnumSourceFieldBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/enum_source_library.g.dart
+++ b/built_value_generator/lib/src/enum_source_library.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.enum_source_library;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$EnumSourceLibrary extends EnumSourceLibrary {
   @override
   final LibraryElement element;
@@ -113,3 +100,17 @@ class EnumSourceLibraryBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/fixes.g.dart
+++ b/built_value_generator/lib/src/fixes.g.dart
@@ -6,19 +6,6 @@ part of 'fixes.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$GeneratorError extends GeneratorError {
   @override
   final String message;
@@ -130,3 +117,17 @@ class GeneratorErrorBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/memoized_getter.g.dart
+++ b/built_value_generator/lib/src/memoized_getter.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.memoized_getter;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$MemoizedGetter extends MemoizedGetter {
   @override
   final String returnType;
@@ -111,3 +98,17 @@ class MemoizedGetterBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.source_class;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$SerializerSourceClass extends SerializerSourceClass {
   @override
   final ClassElement element;
@@ -166,3 +153,17 @@ class SerializerSourceClassBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.source_field;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$SerializerSourceField extends SerializerSourceField {
   @override
   final BuiltValue settings;
@@ -169,3 +156,17 @@ class SerializerSourceFieldBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.source_library;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$SerializerSourceLibrary extends SerializerSourceLibrary {
   @override
   final LibraryElement element;
@@ -126,3 +113,17 @@ class SerializerSourceLibraryBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_value_generator/lib/src/value_source_class.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.source_class;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$ValueSourceClass extends ValueSourceClass {
   @override
   final ClassElement element;
@@ -231,3 +218,17 @@ class ValueSourceClassBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -6,19 +6,6 @@ part of built_value_generator.source_field;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$ValueSourceField extends ValueSourceField {
   @override
   final BuiltValue settings;
@@ -173,3 +160,17 @@ class ValueSourceFieldBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/built_value_generator/test/enum_class_generator_test.dart
+++ b/built_value_generator/test/enum_class_generator_test.dart
@@ -10,7 +10,24 @@ import 'package:built_value_generator/built_value_generator.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
-final String correctInput = r'''
+const String ignoreLintStatements = r'''
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals
+''';
+
+const String correctInput = r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -31,7 +48,7 @@ class TestEnum extends EnumClass {
 abstract class TestEnumMixin = Object with _$TestEnumMixin;
 ''';
 
-final String correctOutput = r'''
+const String correctOutput = r'''
 const TestEnum _$yes = const TestEnum._('yes');
 const TestEnum _$no = const TestEnum._('no');
 const TestEnum _$maybe = const TestEnum._('maybe');
@@ -68,7 +85,8 @@ abstract class _$TestEnumMixin {
   // ignore: non_constant_identifier_names
   _$TestEnumMeta get TestEnum => const _$TestEnumMeta();
 }
-''';
+'''
+    '$ignoreLintStatements';
 
 void main() {
   group('generator', () {
@@ -109,11 +127,13 @@ void main() {
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Specify a type for field "aNull".
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on missing built_value import', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 part 'test_enum.g.dart';
@@ -128,15 +148,18 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Import EnumClass: import 'package:built_value/built_value.dart';
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on missing part statement', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -153,15 +176,18 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), contains(r'''
+'''),
+          contains(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Import generated part: part 'test_enum.g.dart';
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on non-const static fields', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -178,17 +204,20 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Make field "yes" const.
 //        2. Make field "no" const.
 //        3. Make field "maybe" const.
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on non-const non-static fields', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -205,17 +234,20 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Make field "yes" static const.
 //        2. Make field "no" static const.
 //        3. Make field "maybe" static const.
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('ignores static const fields of wrong type', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -235,11 +267,14 @@ class TestEnum extends EnumClass {
 }
 
 abstract class TestEnumMixin = Object with _$TestEnumMixin;
-'''), endsWith(correctOutput));
+'''
+              '$ignoreLintStatements'),
+          endsWith(correctOutput));
     });
 
     test('matches generated names to rhs for field names', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -256,7 +291,8 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 const TestEnum _$no = const TestEnum._('yes');
 const TestEnum _$maybe = const TestEnum._('no');
 const TestEnum _$yes = const TestEnum._('maybe');
@@ -279,11 +315,13 @@ final BuiltSet<TestEnum> _$values = new BuiltSet<TestEnum>(const <TestEnum>[
   _$maybe,
   _$yes,
 ]);
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('matches generated names to values and valueOf', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -300,7 +338,8 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$vls;
   static TestEnum valueOf(String name) => _$vlOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 const TestEnum _$yes = const TestEnum._('yes');
 const TestEnum _$no = const TestEnum._('no');
 const TestEnum _$maybe = const TestEnum._('maybe');
@@ -323,11 +362,13 @@ final BuiltSet<TestEnum> _$vls = new BuiltSet<TestEnum>(const <TestEnum>[
   _$no,
   _$maybe,
 ]);
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on name clash for field rhs', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -344,15 +385,18 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Generated identifier "_$no" is used multiple times in test_enum, change to something else.
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on name clash for values', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -369,11 +413,13 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$no;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Generated identifier "_$no" is used multiple times in test_enum, change to something else.
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('does not fail with clash across multiple files', () async {
@@ -384,7 +430,8 @@ class TestEnum extends EnumClass {
     });
 
     test('fails with error on missing constructor', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -399,15 +446,18 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Have exactly one constructor: const TestEnum._(String name) : super(name);
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on incorrect constructor', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -424,15 +474,18 @@ class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Have exactly one constructor: const TestEnum._(String name) : super(name);
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on too many constructors', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -453,15 +506,18 @@ class TestEnum extends EnumClass {
 
 abstract class BuiltSet<T> {
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Have exactly one constructor: const TestEnum._(String name) : super(name);
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on missing values getter', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -477,15 +533,18 @@ class TestEnum extends EnumClass {
 
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Add getter: static BuiltSet<TestEnum> get values => _$values
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on missing valueOf', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -501,15 +560,18 @@ class TestEnum extends EnumClass {
 
   static BuiltSet<TestEnum> get values => _$values;
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Add method: static TestEnum valueOf(String name) => _$valueOf(name)
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on wrong mixin declaration', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -526,15 +588,18 @@ class TestEnum extends EnumClass {
 }
 
 class TestEnumMixin = Object with _$TestEnumMixin;
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Remove mixin or declare using exactly: abstract class TestEnumMixin = Object with _$TestEnumMixin;
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('fails with error on abstract class', () async {
-      expect(await generate(r'''
+      expect(
+          await generate(r'''
 library test_enum;
 
 import 'package:built_value/built_value.dart';
@@ -549,11 +614,13 @@ abstract class TestEnum extends EnumClass {
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
 }
-'''), endsWith(r'''
+'''),
+          endsWith(r'''
 // Error: Please make the following changes to use EnumClass:
 //
 //        1. Make TestEnum concrete; remove "abstract".
-'''));
+'''
+              '$ignoreLintStatements'));
     });
 
     test('is robust to newlines in input', () async {

--- a/built_value_test/test/values.g.dart
+++ b/built_value_test/test/values.g.dart
@@ -6,19 +6,6 @@ part of values;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$SimpleValue extends SimpleValue {
   @override
   final int anInt;
@@ -398,3 +385,17 @@ class ComparedValueBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/chat_example/lib/data_model/data_model.g.dart
+++ b/chat_example/lib/data_model/data_model.g.dart
@@ -6,19 +6,6 @@ part of data_model;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 const StatusType _$online = const StatusType._('online');
 const StatusType _$away = const StatusType._('away');
 const StatusType _$offline = const StatusType._('offline');
@@ -1116,3 +1103,17 @@ class ListUsersResponseBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/chat_example/lib/data_model/serializers.g.dart
+++ b/chat_example/lib/data_model/serializers.g.dart
@@ -6,19 +6,6 @@ part of serializers;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializers _$serializers = (new Serializers().toBuilder()
       ..add(Chat.serializer)
       ..add(ListUsers.serializer)
@@ -43,3 +30,17 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(BuiltSet, const [const FullType(String)]),
           () => new SetBuilder<String>()))
     .build();
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/collections.g.dart
+++ b/end_to_end_test/lib/collections.g.dart
@@ -6,19 +6,6 @@ part of collections;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<Collections> _$collectionsSerializer = new _$CollectionsSerializer();
 
 class _$CollectionsSerializer implements StructuredSerializer<Collections> {
@@ -430,3 +417,17 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/enums.g.dart
+++ b/end_to_end_test/lib/enums.g.dart
@@ -6,19 +6,6 @@ part of enums;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 const TestEnum _$yes = const TestEnum._('yes');
 const TestEnum _$no = const TestEnum._('no');
 const TestEnum _$maybe = const TestEnum._('maybe');
@@ -152,3 +139,17 @@ class _$WireNameEnumSerializer implements PrimitiveSerializer<WireNameEnum> {
           {FullType specifiedType = FullType.unspecified}) =>
       WireNameEnum.valueOf(_fromWire[serialized] ?? serialized as String);
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/generics.g.dart
+++ b/end_to_end_test/lib/generics.g.dart
@@ -6,19 +6,6 @@ part of generics;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<GenericValue> _$genericValueSerializer =
     new _$GenericValueSerializer();
 Serializer<BoundGenericValue> _$boundGenericValueSerializer =
@@ -1105,3 +1092,17 @@ class GenericFunctionBuilder<T>
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/imported_values.g.dart
+++ b/end_to_end_test/lib/imported_values.g.dart
@@ -6,19 +6,6 @@ part of imported_values;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<ImportedValue> _$importedValueSerializer =
     new _$ImportedValueSerializer();
 
@@ -185,3 +172,17 @@ class ImportedValueBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/interfaces.g.dart
+++ b/end_to_end_test/lib/interfaces.g.dart
@@ -6,19 +6,6 @@ part of interfaces;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 const EnumWithInt _$one = const EnumWithInt._('one');
 const EnumWithInt _$two = const EnumWithInt._('two');
 const EnumWithInt _$three = const EnumWithInt._('three');
@@ -319,3 +306,17 @@ class ValueWithHasIntBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/mixins.g.dart
+++ b/end_to_end_test/lib/mixins.g.dart
@@ -6,19 +6,6 @@ part of mixins;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<UsesMixin> _$usesMixinSerializer = new _$UsesMixinSerializer();
 
 class _$UsesMixinSerializer implements StructuredSerializer<UsesMixin> {
@@ -116,3 +103,17 @@ class UsesMixinBuilder implements Builder<UsesMixin, UsesMixinBuilder> {
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/polymorphism.g.dart
+++ b/end_to_end_test/lib/polymorphism.g.dart
@@ -6,19 +6,6 @@ part of polymorphism;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<Cat> _$catSerializer = new _$CatSerializer();
 Serializer<Fish> _$fishSerializer = new _$FishSerializer();
 Serializer<Robot> _$robotSerializer = new _$RobotSerializer();
@@ -1233,3 +1220,17 @@ class ImplementsTwoBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/serializers.g.dart
+++ b/end_to_end_test/lib/serializers.g.dart
@@ -6,19 +6,6 @@ part of serializers;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializers _$serializers = (new Serializers().toBuilder()
       ..add(BoundGenericValue.serializer)
       ..add(Cage.serializer)
@@ -136,3 +123,17 @@ Serializers _$serializers = (new Serializers().toBuilder()
     .build();
 Serializers _$moreSerializers =
     (new Serializers().toBuilder()..add(Cat.serializer)).build();
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/standard_json.g.dart
+++ b/end_to_end_test/lib/standard_json.g.dart
@@ -6,19 +6,6 @@ part of standard_json;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<StandardJsonValue> _$standardJsonValueSerializer =
     new _$StandardJsonValueSerializer();
 
@@ -292,3 +279,17 @@ class StandardJsonValueBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -6,19 +6,6 @@ part of values;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<SimpleValue> _$simpleValueSerializer = new _$SimpleValueSerializer();
 Serializer<CompoundValue> _$compoundValueSerializer =
     new _$CompoundValueSerializer();
@@ -3034,3 +3021,17 @@ class RecursiveValueBBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/end_to_end_test/test/private_value_test.g.dart
+++ b/end_to_end_test/test/private_value_test.g.dart
@@ -6,19 +6,6 @@ part of value_test;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 class _$PrivateValue extends _PrivateValue {
   @override
   final int value;
@@ -95,3 +82,17 @@ class _PrivateValueBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -6,19 +6,6 @@ part of collections;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<Collections> _$collectionsSerializer = new _$CollectionsSerializer();
 
 class _$CollectionsSerializer implements StructuredSerializer<Collections> {
@@ -430,3 +417,17 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/example/lib/enums.g.dart
+++ b/example/lib/enums.g.dart
@@ -6,19 +6,6 @@ part of enums;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 const TestEnum _$yes = const TestEnum._('yes');
 const TestEnum _$no = const TestEnum._('no');
 const TestEnum _$maybe = const TestEnum._('maybe');
@@ -152,3 +139,17 @@ class _$WireNameEnumSerializer implements PrimitiveSerializer<WireNameEnum> {
           {FullType specifiedType = FullType.unspecified}) =>
       WireNameEnum.valueOf(_fromWire[serialized] ?? serialized as String);
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/example/lib/generics.g.dart
+++ b/example/lib/generics.g.dart
@@ -6,19 +6,6 @@ part of generics;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<GenericValue> _$genericValueSerializer =
     new _$GenericValueSerializer();
 Serializer<BoundGenericValue> _$boundGenericValueSerializer =
@@ -660,3 +647,17 @@ class GenericContainerBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/example/lib/interfaces.g.dart
+++ b/example/lib/interfaces.g.dart
@@ -6,19 +6,6 @@ part of interfaces;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 const EnumWithInt _$one = const EnumWithInt._('one');
 const EnumWithInt _$two = const EnumWithInt._('two');
 const EnumWithInt _$three = const EnumWithInt._('three');
@@ -213,3 +200,17 @@ class _$ValueWithIntBuilder extends ValueWithIntBuilder {
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/example/lib/polymorphism.g.dart
+++ b/example/lib/polymorphism.g.dart
@@ -6,19 +6,6 @@ part of polymorphism;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<Cat> _$catSerializer = new _$CatSerializer();
 Serializer<Fish> _$fishSerializer = new _$FishSerializer();
 
@@ -294,3 +281,17 @@ class FishBuilder implements Builder<Fish, FishBuilder>, AnimalBuilder {
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/example/lib/serializers.g.dart
+++ b/example/lib/serializers.g.dart
@@ -6,19 +6,6 @@ part of serializers;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializers _$serializers = (new Serializers().toBuilder()
       ..add(Account.serializer)
       ..add(Cat.serializer)
@@ -33,3 +20,17 @@ Serializers _$serializers = (new Serializers().toBuilder()
               const [const FullType(String), const FullType(JsonObject)]),
           () => new MapBuilder<String, JsonObject>()))
     .build();
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -6,19 +6,6 @@ part of values;
 // BuiltValueGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line
-// ignore_for_file: annotate_overrides
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_catches_without_on_clauses
-// ignore_for_file: avoid_returning_this
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: omit_local_variable_types
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: sort_constructors_first
-// ignore_for_file: unnecessary_const
-// ignore_for_file: unnecessary_new
-// ignore_for_file: test_types_in_equals
-
 Serializer<SimpleValue> _$simpleValueSerializer = new _$SimpleValueSerializer();
 Serializer<VerySimpleValue> _$verySimpleValueSerializer =
     new _$VerySimpleValueSerializer();
@@ -1154,3 +1141,17 @@ class WireNameValueBuilder
     return _$result;
   }
 }
+
+// ignore_for_file: always_put_control_body_on_new_line
+// ignore_for_file: annotate_overrides
+// ignore_for_file: avoid_as
+// ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: omit_local_variable_types
+// ignore_for_file: prefer_expression_function_bodies
+// ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
+// ignore_for_file: test_types_in_equals


### PR DESCRIPTION
When using polymorphism the code generated violates the [avoid_as](http://dart-lang.github.io/linter/lints/avoid_as.html) rule.

Example:
```
  @override
  void replace(covariant PasswordState other) {
    if (other == null) {
      throw new ArgumentError.notNull('other');
    }
    _$v = other as _$PasswordState;
  }
```

This PR simple ignore this warning in the generated files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/523)
<!-- Reviewable:end -->
