### PR TITLE
Add ignored linter conflicting with flutter defaults

### DIFF
--- a/built_value_generator/lib/built_value_generator.dart
+++ b/built_value_generator/lib/built_value_generator.dart
@@ -64,6 +64,7 @@ class BuiltValueGenerator extends Generator {
           '\n'
           '// ignore_for_file: '
           'always_put_control_body_on_new_line,'
+          'always_specify_types'
           'annotate_overrides,'
           'avoid_annotating_with_dynamic,'
           'avoid_as,'

--- a/built_value_generator/lib/built_value_generator.dart
+++ b/built_value_generator/lib/built_value_generator.dart
@@ -64,7 +64,7 @@ class BuiltValueGenerator extends Generator {
           '\n'
           '// ignore_for_file: '
           'always_put_control_body_on_new_line,'
-          'always_specify_types'
+          'always_specify_types,'
           'annotate_overrides,'
           'avoid_annotating_with_dynamic,'
           'avoid_as,'


### PR DESCRIPTION
The generated files created seems to not include `always_specify_types` among the generated ignored linters. This causes problems with the default flutter `analysis_options.yaml` and results in a pretty unreadable analyzer output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/584)
<!-- Reviewable:end -->
