### PR TITLE
Extendable nullable annotations

### DIFF
--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -103,10 +103,17 @@ class BuiltValue {
       this.wireName});
 }
 
-/// Nullable annotation for Built Value fields.
+/// NullableAnnotation used by nullable
+///
+/// Can be extended/implemented by another annotation
+class NullableAnnotation {
+  const NullableAnnotation();
+}
+
+/// nullable annotation for Built Value fields.
 ///
 /// Fields marked with this annotation are allowed to be null.
-const String nullable = 'nullable';
+const NullableAnnotation nullable = NullableAnnotation();
 
 /// Optionally, annotate a Built Value field with this to specify settings.
 /// This is only needed for advanced use.

--- a/built_value_generator/lib/src/metadata.dart
+++ b/built_value_generator/lib/src/metadata.dart
@@ -23,6 +23,13 @@ String metadataToStringValue(ElementAnnotation annotation) {
   return value.toStringValue();
 }
 
+/// Gets the `Type` value of an annotation. Throws a descriptive
+/// [InvalidGenerationSourceError] if the annotation can't be resolved.
+DartObject metadataToObjectValue(ElementAnnotation annotation) {
+  final value = getConstantValueFromAnnotation(annotation);
+  return value;
+}
+
 /// Gets a field from an annotation. Throws a descriptive
 /// [InvalidGenerationSourceError] if the annotation can't be resolved.
 DartObject getMetadataField(ElementAnnotation annotation, String name) {

--- a/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_value_generator/lib/src/serializer_source_field.dart
@@ -11,8 +11,9 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/dart_types.dart';
+import 'package:source_gen/source_gen.dart';
 import 'package:built_value_generator/src/metadata.dart'
-    show metadataToStringValue;
+    show metadataToObjectValue;
 
 part 'serializer_source_field.g.dart';
 
@@ -65,8 +66,9 @@ abstract class SerializerSourceField
   }
 
   @memoized
-  bool get isNullable => element.getter.metadata
-      .any((metadata) => metadataToStringValue(metadata) == 'nullable');
+  bool get isNullable => element.getter.metadata.any((metadata) =>
+      TypeChecker.fromRuntime(nullable.runtimeType)
+          .isAssignableFromType(metadataToObjectValue(metadata).type));
 
   @memoized
   String get name => element.displayName;

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -13,8 +13,9 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/dart_types.dart';
 import 'package:built_value_generator/src/fixes.dart';
 import 'package:built_value_generator/src/fields.dart' show collectFields;
+import 'package:source_gen/source_gen.dart';
 import 'package:built_value_generator/src/metadata.dart'
-    show metadataToStringValue;
+    show metadataToObjectValue;
 
 part 'value_source_field.g.dart';
 
@@ -89,8 +90,9 @@ abstract class ValueSourceField
   bool get isGetter => element.getter != null && !element.getter.isSynthetic;
 
   @memoized
-  bool get isNullable => element.getter.metadata
-      .any((metadata) => metadataToStringValue(metadata) == 'nullable');
+  bool get isNullable => element.getter.metadata.any((metadata) =>
+      TypeChecker.fromRuntime(nullable.runtimeType)
+          .isAssignableFromType(metadataToObjectValue(metadata).type));
 
   @memoized
   BuiltValueField get builtValueField {


### PR DESCRIPTION
When using another generator with built_value, this enables other other generator's annotations to extend built_value's `nullable` using `NullableAnnotation`, 

```
@nullable
@OtherGeneratorAnnotation
get int field;
```

Where `OtherGenerator` requires fields marked `@OtherGeneratorAnnotation` are also `@nullable`, this removes the need to have to explicitly annotate with `@nullable `and `@OtherGeneratorAnnotation` (and potentially forget to add `@nullable`) by having `OtherGeneratorAnnotation` extend `NullableAnnotation`.

```
@OtherGeneratorAnnotation
get int field;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_value.dart/616)
<!-- Reviewable:end -->
