### PR TITLE
Add an ISO8601 serializer for Duration

### DIFF
--- a/built_value/lib/iso_8601_duration_serializer.dart
+++ b/built_value/lib/iso_8601_duration_serializer.dart
@@ -1,0 +1,96 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Alternative serializer for [Duration].
+///
+/// Install this to use ISO8601 compatible format instead of the default
+/// (microseconds). Use [SerializersBuilder.add] to install it.
+///
+/// Note that this serializer is not 100% compatible with the ISO8601 format
+/// due to limitations of the [Duration] class, but is designed to produce and
+/// consume reasonable strings that match the standard.
+class Iso8601DurationSerializer extends PrimitiveSerializer<Duration> {
+  @override
+  Duration deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final String value = serialized;
+    return _parseDuration(value);
+  }
+
+  @override
+  Object serialize(Serializers serializers, Duration object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return _writeIso8601Duration(object);
+  }
+
+  @override
+  Iterable<Type> get types => BuiltList(const [Duration]);
+
+  @override
+  String get wireName => 'Duration';
+
+  Duration _parseDuration(String value) {
+    final match = _parseFormat.firstMatch(value);
+    if (match != null) {
+      // Iterate through the capture groups to build the unit mappings
+      final unitMappings = <String, int>{};
+
+      // Start iterating at 1, because match[0] is the full match
+      for (var i = 1; i <= match.groupCount; i++) {
+        final group = match[i];
+        if (group == null) {
+          continue;
+        }
+        // Get all but last character in group
+        // RegExp ensures this must be an int
+        final value = int.parse(group.substring(0, group.length - 1));
+        // Get last character
+        final unit = group.substring(group.length - 1);
+        unitMappings[unit] = value;
+      }
+      return Duration(
+        days: unitMappings[_dayToken] ?? 0,
+        hours: unitMappings[_hourToken] ?? 0,
+        minutes: unitMappings[_minuteToken] ?? 0,
+        seconds: unitMappings[_secondToken] ?? 0,
+      );
+    } else {
+      throw FormatException("Invalid duration format", value);
+    }
+  }
+
+  String _writeIso8601Duration(Duration duration) {
+    if (duration == Duration.zero) {
+      // format for zero.
+      return 'PT0S';
+    }
+    final days = duration.inDays;
+    final hours = (duration - Duration(days: days)).inHours;
+    final minutes = (duration - Duration(days: days, hours: hours)).inMinutes;
+    final seconds =
+        (duration - Duration(days: days, hours: hours, minutes: minutes))
+            .inSeconds;
+    final buffer = StringBuffer(_durationToken)
+      ..write(days == 0 ? '' : '$days$_dayToken');
+    if (!(hours == 0 && minutes == 0 && seconds == 0)) {
+      buffer
+        ..write(_timeToken)
+        ..write(hours == 0 ? '' : '$hours$_hourToken')
+        ..write(minutes == 0 ? '' : '$minutes$_minuteToken')
+        ..write(seconds == 0 ? '' : '$seconds$_secondToken');
+    }
+    return buffer.toString();
+  }
+
+  // Unit tokens
+  static const _durationToken = 'P';
+  static const _dayToken = 'D';
+  static const _timeToken = 'T';
+  static const _hourToken = 'H';
+  static const _minuteToken = 'M';
+  static const _secondToken = 'S';
+
+  // Parse format for ISO8601
+  static final _parseFormat = RegExp(
+      '^P(?!\$)(0D|[1-9][0-9]*D)?(?:T(?!\$)(0H|[1-9][0-9]*H)?(0M|[1-9][0-9]*M)?(0S|[1-9][0-9]*S)?)?\$');
+}

--- a/built_value/test/iso_8601_duration_serializer_test.dart
+++ b/built_value/test/iso_8601_duration_serializer_test.dart
@@ -1,0 +1,79 @@
+import 'package:built_value/iso_8601_duration_serializer.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers =
+      (Serializers().toBuilder()..add(Iso8601DurationSerializer())).build();
+
+  const testTable = const [
+    {
+      #s: 'P1DT2H3M4S',
+      #d: Duration(days: 1, hours: 2, minutes: 3, seconds: 4),
+    },
+    {
+      #s: 'PT0S',
+      #d: Duration.zero,
+    },
+    {
+      #s: 'PT2H',
+      #d: Duration(hours: 2),
+    },
+    {
+      #s: 'PT2H3M',
+      #d: Duration(hours: 2, minutes: 3),
+    },
+    {
+      #s: 'P2D',
+      #d: Duration(days: 2),
+    },
+  ];
+  const badOnes = const [
+    'P',
+    'P0',
+    'PT2S567',
+  ];
+
+  group('Duration with known specifiedType', () {
+    var specifiedType = const FullType(Duration);
+    testTable.forEach((testValue) {
+      test('can be serialized', () {
+        expect(
+            serializers.serialize(testValue[#d], specifiedType: specifiedType),
+            testValue[#s]);
+      });
+
+      test('can be deserialized', () {
+        expect(
+            serializers.deserialize(testValue[#s],
+                specifiedType: specifiedType),
+            testValue[#d]);
+      });
+    });
+    badOnes.forEach((badOne) {
+      test('deserialize throws if not ISO format', () {
+        expect(
+            () => serializers.deserialize(badOne, specifiedType: specifiedType),
+            throwsA(const TypeMatcher<FormatException>()));
+      });
+    });
+  });
+
+  group('Duration with unknown specifiedType', () {
+    var specifiedType = FullType.unspecified;
+    testTable.forEach((testValue) {
+      test('can be serialized', () {
+        expect(
+            serializers.serialize(testValue[#d], specifiedType: specifiedType),
+            ['Duration', testValue[#s]]);
+      });
+
+      test('can be deserialized', () {
+        expect(
+            serializers.deserialize(['Duration', testValue[#s]],
+                specifiedType: specifiedType),
+            testValue[#d]);
+      });
+    });
+  });
+}


### PR DESCRIPTION
I was using built_value to interface with a Spring server serving Durations in the ISO8601 format as described [here](https://en.wikipedia.org/wiki/ISO_8601#Durations). The microsecond Duration serializer was insufficient for handling this data.

I wrote a serializer in a in a similar vein to the already existing `Iso8601DateTimeSerializer` to handle these formatted durations.

This serializer does not support the full range of acceptable ISO8601 durations due to the limitations of the Dart `Duration` object (i.e. no year or week settings), but works for the range of values covered by
the `Duration` object.

This serializer is complete with tests similar to the ones for `Iso8601DateTimeSerializer`, and cover a lot of the edge cases, but I would be happy to add more if need be.

Please let me know if there is anything else you would like me to change.