### PR TITLE
Fix `BuiltValueSerializer(serializeNulls: true)` for non-primitive fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-# 6.6.0
+# 6.6.0 (unreleased)
 
 - Allow providing your own `toString` via a mixin.
+- Fix `BuiltValueSerializer(serializeNulls: true)` for non-primitive fields.
 
 # 6.5.0
 

--- a/end_to_end_test/lib/collections.dart
+++ b/end_to_end_test/lib/collections.dart
@@ -34,3 +34,33 @@ abstract class Collections implements Built<Collections, CollectionsBuilder> {
       _$Collections;
   Collections._();
 }
+
+// Class with collections and `serializeNulls: true` enabled.
+abstract class CollectionsWithNulls
+    implements Built<CollectionsWithNulls, CollectionsWithNullsBuilder> {
+  @BuiltValueSerializer(serializeNulls: true)
+  static Serializer<CollectionsWithNulls> get serializer =>
+      _$collectionsWithNullsSerializer;
+
+  BuiltList<int> get list;
+  BuiltSet<String> get set;
+  BuiltMap<String, int> get map;
+  BuiltListMultimap<int, bool> get listMultimap;
+  BuiltSetMultimap<String, bool> get setMultimap;
+
+  @nullable
+  BuiltList<int> get nullableList;
+  @nullable
+  BuiltSet<String> get nullableSet;
+  @nullable
+  BuiltMap<String, int> get nullableMap;
+  @nullable
+  BuiltListMultimap<int, bool> get nullableListMultimap;
+  @nullable
+  BuiltSetMultimap<String, bool> get nullableSetMultimap;
+
+  factory CollectionsWithNulls(
+          [void Function(CollectionsWithNullsBuilder) updates]) =
+      _$CollectionsWithNulls;
+  CollectionsWithNulls._();
+}

--- a/end_to_end_test/lib/collections.g.dart
+++ b/end_to_end_test/lib/collections.g.dart
@@ -7,6 +7,8 @@ part of collections;
 // **************************************************************************
 
 Serializer<Collections> _$collectionsSerializer = new _$CollectionsSerializer();
+Serializer<CollectionsWithNulls> _$collectionsWithNullsSerializer =
+    new _$CollectionsWithNullsSerializer();
 
 class _$CollectionsSerializer implements StructuredSerializer<Collections> {
   @override
@@ -74,7 +76,6 @@ class _$CollectionsSerializer implements StructuredSerializer<Collections> {
             specifiedType: const FullType(BuiltSetMultimap,
                 const [const FullType(String), const FullType(bool)])));
     }
-
     return result;
   }
 
@@ -88,6 +89,169 @@ class _$CollectionsSerializer implements StructuredSerializer<Collections> {
       final key = iterator.current as String;
       iterator.moveNext();
       final dynamic value = iterator.current;
+      switch (key) {
+        case 'list':
+          result.list.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))
+              as BuiltList);
+          break;
+        case 'set':
+          result.set.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(String)]))
+              as BuiltSet);
+          break;
+        case 'map':
+          result.map.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, const [
+                const FullType(String),
+                const FullType(int)
+              ])) as BuiltMap);
+          break;
+        case 'listMultimap':
+          result.listMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltListMultimap, const [
+                const FullType(int),
+                const FullType(bool)
+              ])) as BuiltListMultimap);
+          break;
+        case 'setMultimap':
+          result.setMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltSetMultimap, const [
+                const FullType(String),
+                const FullType(bool)
+              ])) as BuiltSetMultimap);
+          break;
+        case 'nullableList':
+          result.nullableList.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))
+              as BuiltList);
+          break;
+        case 'nullableSet':
+          result.nullableSet.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(String)]))
+              as BuiltSet);
+          break;
+        case 'nullableMap':
+          result.nullableMap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, const [
+                const FullType(String),
+                const FullType(int)
+              ])) as BuiltMap);
+          break;
+        case 'nullableListMultimap':
+          result.nullableListMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltListMultimap, const [
+                const FullType(int),
+                const FullType(bool)
+              ])) as BuiltListMultimap);
+          break;
+        case 'nullableSetMultimap':
+          result.nullableSetMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltSetMultimap, const [
+                const FullType(String),
+                const FullType(bool)
+              ])) as BuiltSetMultimap);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CollectionsWithNullsSerializer
+    implements StructuredSerializer<CollectionsWithNulls> {
+  @override
+  final Iterable<Type> types = const [
+    CollectionsWithNulls,
+    _$CollectionsWithNulls
+  ];
+  @override
+  final String wireName = 'CollectionsWithNulls';
+
+  @override
+  Iterable serialize(Serializers serializers, CollectionsWithNulls object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'list',
+      serializers.serialize(object.list,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(int)])),
+      'set',
+      serializers.serialize(object.set,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])),
+      'map',
+      serializers.serialize(object.map,
+          specifiedType: const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)])),
+      'listMultimap',
+      serializers.serialize(object.listMultimap,
+          specifiedType: const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)])),
+      'setMultimap',
+      serializers.serialize(object.setMultimap,
+          specifiedType: const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)])),
+    ];
+    result.add('nullableList');
+    if (object.nullableList == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.nullableList,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(int)])));
+    }
+    result.add('nullableSet');
+    if (object.nullableSet == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.nullableSet,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])));
+    }
+    result.add('nullableMap');
+    if (object.nullableMap == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.nullableMap,
+          specifiedType: const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)])));
+    }
+    result.add('nullableListMultimap');
+    if (object.nullableListMultimap == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.nullableListMultimap,
+          specifiedType: const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)])));
+    }
+    result.add('nullableSetMultimap');
+    if (object.nullableSetMultimap == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.nullableSetMultimap,
+          specifiedType: const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)])));
+    }
+    return result;
+  }
+
+  @override
+  CollectionsWithNulls deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new CollectionsWithNullsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
       switch (key) {
         case 'list':
           result.list.replace(serializers.deserialize(value,
@@ -410,6 +574,267 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             'Collections', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CollectionsWithNulls extends CollectionsWithNulls {
+  @override
+  final BuiltList<int> list;
+  @override
+  final BuiltSet<String> set;
+  @override
+  final BuiltMap<String, int> map;
+  @override
+  final BuiltListMultimap<int, bool> listMultimap;
+  @override
+  final BuiltSetMultimap<String, bool> setMultimap;
+  @override
+  final BuiltList<int> nullableList;
+  @override
+  final BuiltSet<String> nullableSet;
+  @override
+  final BuiltMap<String, int> nullableMap;
+  @override
+  final BuiltListMultimap<int, bool> nullableListMultimap;
+  @override
+  final BuiltSetMultimap<String, bool> nullableSetMultimap;
+
+  factory _$CollectionsWithNulls(
+          [void Function(CollectionsWithNullsBuilder) updates]) =>
+      (new CollectionsWithNullsBuilder()..update(updates)).build();
+
+  _$CollectionsWithNulls._(
+      {this.list,
+      this.set,
+      this.map,
+      this.listMultimap,
+      this.setMultimap,
+      this.nullableList,
+      this.nullableSet,
+      this.nullableMap,
+      this.nullableListMultimap,
+      this.nullableSetMultimap})
+      : super._() {
+    if (list == null) {
+      throw new BuiltValueNullFieldError('CollectionsWithNulls', 'list');
+    }
+    if (set == null) {
+      throw new BuiltValueNullFieldError('CollectionsWithNulls', 'set');
+    }
+    if (map == null) {
+      throw new BuiltValueNullFieldError('CollectionsWithNulls', 'map');
+    }
+    if (listMultimap == null) {
+      throw new BuiltValueNullFieldError(
+          'CollectionsWithNulls', 'listMultimap');
+    }
+    if (setMultimap == null) {
+      throw new BuiltValueNullFieldError('CollectionsWithNulls', 'setMultimap');
+    }
+  }
+
+  @override
+  CollectionsWithNulls rebuild(
+          void Function(CollectionsWithNullsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollectionsWithNullsBuilder toBuilder() =>
+      new CollectionsWithNullsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CollectionsWithNulls &&
+        list == other.list &&
+        set == other.set &&
+        map == other.map &&
+        listMultimap == other.listMultimap &&
+        setMultimap == other.setMultimap &&
+        nullableList == other.nullableList &&
+        nullableSet == other.nullableSet &&
+        nullableMap == other.nullableMap &&
+        nullableListMultimap == other.nullableListMultimap &&
+        nullableSetMultimap == other.nullableSetMultimap;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc(
+            $jc(
+                $jc(
+                    $jc(
+                        $jc(
+                            $jc(
+                                $jc($jc($jc(0, list.hashCode), set.hashCode),
+                                    map.hashCode),
+                                listMultimap.hashCode),
+                            setMultimap.hashCode),
+                        nullableList.hashCode),
+                    nullableSet.hashCode),
+                nullableMap.hashCode),
+            nullableListMultimap.hashCode),
+        nullableSetMultimap.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('CollectionsWithNulls')
+          ..add('list', list)
+          ..add('set', set)
+          ..add('map', map)
+          ..add('listMultimap', listMultimap)
+          ..add('setMultimap', setMultimap)
+          ..add('nullableList', nullableList)
+          ..add('nullableSet', nullableSet)
+          ..add('nullableMap', nullableMap)
+          ..add('nullableListMultimap', nullableListMultimap)
+          ..add('nullableSetMultimap', nullableSetMultimap))
+        .toString();
+  }
+}
+
+class CollectionsWithNullsBuilder
+    implements Builder<CollectionsWithNulls, CollectionsWithNullsBuilder> {
+  _$CollectionsWithNulls _$v;
+
+  ListBuilder<int> _list;
+  ListBuilder<int> get list => _$this._list ??= new ListBuilder<int>();
+  set list(ListBuilder<int> list) => _$this._list = list;
+
+  SetBuilder<String> _set;
+  SetBuilder<String> get set => _$this._set ??= new SetBuilder<String>();
+  set set(SetBuilder<String> set) => _$this._set = set;
+
+  MapBuilder<String, int> _map;
+  MapBuilder<String, int> get map =>
+      _$this._map ??= new MapBuilder<String, int>();
+  set map(MapBuilder<String, int> map) => _$this._map = map;
+
+  ListMultimapBuilder<int, bool> _listMultimap;
+  ListMultimapBuilder<int, bool> get listMultimap =>
+      _$this._listMultimap ??= new ListMultimapBuilder<int, bool>();
+  set listMultimap(ListMultimapBuilder<int, bool> listMultimap) =>
+      _$this._listMultimap = listMultimap;
+
+  SetMultimapBuilder<String, bool> _setMultimap;
+  SetMultimapBuilder<String, bool> get setMultimap =>
+      _$this._setMultimap ??= new SetMultimapBuilder<String, bool>();
+  set setMultimap(SetMultimapBuilder<String, bool> setMultimap) =>
+      _$this._setMultimap = setMultimap;
+
+  ListBuilder<int> _nullableList;
+  ListBuilder<int> get nullableList =>
+      _$this._nullableList ??= new ListBuilder<int>();
+  set nullableList(ListBuilder<int> nullableList) =>
+      _$this._nullableList = nullableList;
+
+  SetBuilder<String> _nullableSet;
+  SetBuilder<String> get nullableSet =>
+      _$this._nullableSet ??= new SetBuilder<String>();
+  set nullableSet(SetBuilder<String> nullableSet) =>
+      _$this._nullableSet = nullableSet;
+
+  MapBuilder<String, int> _nullableMap;
+  MapBuilder<String, int> get nullableMap =>
+      _$this._nullableMap ??= new MapBuilder<String, int>();
+  set nullableMap(MapBuilder<String, int> nullableMap) =>
+      _$this._nullableMap = nullableMap;
+
+  ListMultimapBuilder<int, bool> _nullableListMultimap;
+  ListMultimapBuilder<int, bool> get nullableListMultimap =>
+      _$this._nullableListMultimap ??= new ListMultimapBuilder<int, bool>();
+  set nullableListMultimap(
+          ListMultimapBuilder<int, bool> nullableListMultimap) =>
+      _$this._nullableListMultimap = nullableListMultimap;
+
+  SetMultimapBuilder<String, bool> _nullableSetMultimap;
+  SetMultimapBuilder<String, bool> get nullableSetMultimap =>
+      _$this._nullableSetMultimap ??= new SetMultimapBuilder<String, bool>();
+  set nullableSetMultimap(
+          SetMultimapBuilder<String, bool> nullableSetMultimap) =>
+      _$this._nullableSetMultimap = nullableSetMultimap;
+
+  CollectionsWithNullsBuilder();
+
+  CollectionsWithNullsBuilder get _$this {
+    if (_$v != null) {
+      _list = _$v.list?.toBuilder();
+      _set = _$v.set?.toBuilder();
+      _map = _$v.map?.toBuilder();
+      _listMultimap = _$v.listMultimap?.toBuilder();
+      _setMultimap = _$v.setMultimap?.toBuilder();
+      _nullableList = _$v.nullableList?.toBuilder();
+      _nullableSet = _$v.nullableSet?.toBuilder();
+      _nullableMap = _$v.nullableMap?.toBuilder();
+      _nullableListMultimap = _$v.nullableListMultimap?.toBuilder();
+      _nullableSetMultimap = _$v.nullableSetMultimap?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CollectionsWithNulls other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$CollectionsWithNulls;
+  }
+
+  @override
+  void update(void Function(CollectionsWithNullsBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$CollectionsWithNulls build() {
+    _$CollectionsWithNulls _$result;
+    try {
+      _$result = _$v ??
+          new _$CollectionsWithNulls._(
+              list: list.build(),
+              set: set.build(),
+              map: map.build(),
+              listMultimap: listMultimap.build(),
+              setMultimap: setMultimap.build(),
+              nullableList: _nullableList?.build(),
+              nullableSet: _nullableSet?.build(),
+              nullableMap: _nullableMap?.build(),
+              nullableListMultimap: _nullableListMultimap?.build(),
+              nullableSetMultimap: _nullableSetMultimap?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'list';
+        list.build();
+        _$failedField = 'set';
+        set.build();
+        _$failedField = 'map';
+        map.build();
+        _$failedField = 'listMultimap';
+        listMultimap.build();
+        _$failedField = 'setMultimap';
+        setMultimap.build();
+        _$failedField = 'nullableList';
+        _nullableList?.build();
+        _$failedField = 'nullableSet';
+        _nullableSet?.build();
+        _$failedField = 'nullableMap';
+        _nullableMap?.build();
+        _$failedField = 'nullableListMultimap';
+        _nullableListMultimap?.build();
+        _$failedField = 'nullableSetMultimap';
+        _nullableSetMultimap?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'CollectionsWithNulls', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/end_to_end_test/lib/serializers.dart
+++ b/end_to_end_test/lib/serializers.dart
@@ -24,6 +24,7 @@ part 'serializers.g.dart';
   Cage,
   CollectionGenericValue,
   Collections,
+  CollectionsWithNulls,
   CompoundValue,
   CompoundValueExplicitNoNesting,
   CompoundValueNoNesting,

--- a/end_to_end_test/lib/serializers.g.dart
+++ b/end_to_end_test/lib/serializers.g.dart
@@ -12,6 +12,7 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(Cat.serializer)
       ..add(CollectionGenericValue.serializer)
       ..add(Collections.serializer)
+      ..add(CollectionsWithNulls.serializer)
       ..add(CompoundValue.serializer)
       ..add(CompoundValueExplicitNoNesting.serializer)
       ..add(CompoundValueNoNesting.serializer)
@@ -59,6 +60,42 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(
               BuiltList, const [const FullType(ThirdDiscoverableValue)]),
           () => new ListBuilder<ThirdDiscoverableValue>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => new ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(String)]),
+          () => new SetBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)]),
+          () => new MapBuilder<String, int>())
+      ..addBuilderFactory(
+          const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)]),
+          () => new ListMultimapBuilder<int, bool>())
+      ..addBuilderFactory(
+          const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)]),
+          () => new SetMultimapBuilder<String, bool>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => new ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(String)]),
+          () => new SetBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)]),
+          () => new MapBuilder<String, int>())
+      ..addBuilderFactory(
+          const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)]),
+          () => new ListMultimapBuilder<int, bool>())
+      ..addBuilderFactory(
+          const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)]),
+          () => new SetMultimapBuilder<String, bool>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(int)]),
           () => new ListBuilder<int>())

--- a/end_to_end_test/lib/standard_json.g.dart
+++ b/end_to_end_test/lib/standard_json.g.dart
@@ -44,7 +44,6 @@ class _$StandardJsonValueSerializer
             specifiedType:
                 const FullType(BuiltList, const [const FullType(String)])));
     }
-
     return result;
   }
 

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -67,7 +67,6 @@ class _$SimpleValueSerializer implements StructuredSerializer<SimpleValue> {
         ..add(serializers.serialize(object.aString,
             specifiedType: const FullType(String)));
     }
-
     return result;
   }
 
@@ -117,7 +116,6 @@ class _$CompoundValueSerializer implements StructuredSerializer<CompoundValue> {
         ..add(serializers.serialize(object.validatedValue,
             specifiedType: const FullType(ValidatedValue)));
     }
-
     return result;
   }
 
@@ -171,7 +169,6 @@ class _$CompoundValueNoNestingSerializer
         ..add(serializers.serialize(object.validatedValue,
             specifiedType: const FullType(ValidatedValue)));
     }
-
     return result;
   }
 
@@ -272,7 +269,6 @@ class _$CompoundValueComparableBuildersSerializer
         ..add(serializers.serialize(object.validatedValue,
             specifiedType: const FullType(ValidatedValue)));
     }
-
     return result;
   }
 
@@ -328,7 +324,6 @@ class _$CompoundValueExplicitNoNestingSerializer
         ..add(serializers.serialize(object.validatedValue,
             specifiedType: const FullType(ValidatedValue)));
     }
-
     return result;
   }
 
@@ -379,7 +374,6 @@ class _$ValidatedValueSerializer
         ..add(serializers.serialize(object.aString,
             specifiedType: const FullType(String)));
     }
-
     return result;
   }
 
@@ -727,7 +721,6 @@ class _$FieldDiscoveryValueSerializer
         ..add(serializers.serialize(object.recursiveValue,
             specifiedType: const FullType(FieldDiscoveryValue)));
     }
-
     return result;
   }
 
@@ -993,12 +986,13 @@ class _$SerializesNullsValueSerializer
   Iterable serialize(Serializers serializers, SerializesNullsValue object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object>[];
-
-    result
-      ..add('value')
-      ..add(serializers.serialize(object.value,
+    result.add('value');
+    if (object.value == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.value,
           specifiedType: const FullType(String)));
-
+    }
     return result;
   }
 
@@ -1012,6 +1006,7 @@ class _$SerializesNullsValueSerializer
       final key = iterator.current as String;
       iterator.moveNext();
       final dynamic value = iterator.current;
+      if (value == null) continue;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,

--- a/end_to_end_test/test/collections_serializer_test.dart
+++ b/end_to_end_test/test/collections_serializer_test.dart
@@ -42,4 +42,50 @@ void main() {
       expect(serializers.deserialize(serialized), data);
     });
   });
+
+  group('CollectionsWithNulls', () {
+    var data = CollectionsWithNulls((b) => b
+      ..list.add(1)
+      ..set.add('two')
+      ..map['three'] = 4
+      ..listMultimap.addValues(4, [true, false])
+      ..setMultimap.addValues('five', [true, false]));
+    var serialized = [
+      'CollectionsWithNulls',
+      'list',
+      [1],
+      'set',
+      ['two'],
+      'map',
+      ['three', 4],
+      'listMultimap',
+      [
+        4,
+        [true, false]
+      ],
+      'setMultimap',
+      [
+        'five',
+        [true, false]
+      ],
+      'nullableList',
+      null,
+      'nullableSet',
+      null,
+      'nullableMap',
+      null,
+      'nullableListMultimap',
+      null,
+      'nullableSetMultimap',
+      null,
+    ];
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
 }

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -74,7 +74,6 @@ class _$CollectionsSerializer implements StructuredSerializer<Collections> {
             specifiedType: const FullType(BuiltSetMultimap,
                 const [const FullType(String), const FullType(bool)])));
     }
-
     return result;
   }
 

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -36,7 +36,6 @@ class _$SimpleValueSerializer implements StructuredSerializer<SimpleValue> {
         ..add(serializers.serialize(object.aString,
             specifiedType: const FullType(String)));
     }
-
     return result;
   }
 
@@ -126,7 +125,6 @@ class _$CompoundValueSerializer implements StructuredSerializer<CompoundValue> {
         ..add(serializers.serialize(object.validatedValue,
             specifiedType: const FullType(ValidatedValue)));
     }
-
     return result;
   }
 
@@ -176,7 +174,6 @@ class _$ValidatedValueSerializer
         ..add(serializers.serialize(object.aString,
             specifiedType: const FullType(String)));
     }
-
     return result;
   }
 


### PR DESCRIPTION
Fixes #641 

When generating a serializer with `serializeNulls: true`, do all null handling in the generated code. This avoids problems with trying to get a null value to pass through all the standard serialize logic, just for the sake of getting a null out again.