### PR TITLE
Allow providing your own `toString` via a mixin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 6.6.0
+
+- Allow providing your own `toString` via a mixin.
+
 # 6.5.0
 
 - Add `Iso8601DurationSerializer` for use when you want ISO8601 serialization

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -261,7 +261,13 @@ abstract class ValueSourceClass
   bool get implementsOperatorEquals => element.getMethod('==') != null;
 
   @memoized
-  bool get implementsToString => element.getMethod('toString') != null;
+  bool get implementsToString {
+    // Check for any `toString` implementation apart from the one defined on
+    // `Object`.
+    var method = element.lookUpConcreteMethod('toString', element.library);
+    var clazz = method.enclosingElement;
+    return clazz is! ClassElement || clazz.name != 'Object';
+  }
 
   @memoized
   CompilationUnitElement get compilationUnit =>

--- a/end_to_end_test/lib/values.dart
+++ b/end_to_end_test/lib/values.dart
@@ -513,3 +513,17 @@ abstract class SerializesNullsValue
       _$SerializesNullsValue;
   SerializesNullsValue._();
 }
+
+// Check that `toString` from a mixin is not redefined.
+abstract class CustomToStringValue extends Object
+    with CustomToString
+    implements Built<CustomToStringValue, CustomToStringValueBuilder> {
+  factory CustomToStringValue(
+          [void Function(CustomToStringValueBuilder) updates]) =
+      _$CustomToStringValue;
+  CustomToStringValue._();
+}
+
+mixin CustomToString {
+  String toString() => 'custom';
+}

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -3874,4 +3874,59 @@ class SerializesNullsValueBuilder
   }
 }
 
+class _$CustomToStringValue extends CustomToStringValue {
+  factory _$CustomToStringValue(
+          [void Function(CustomToStringValueBuilder) updates]) =>
+      (new CustomToStringValueBuilder()..update(updates)).build();
+
+  _$CustomToStringValue._() : super._();
+
+  @override
+  CustomToStringValue rebuild(
+          void Function(CustomToStringValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CustomToStringValueBuilder toBuilder() =>
+      new CustomToStringValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CustomToStringValue;
+  }
+
+  @override
+  int get hashCode {
+    return 617836932;
+  }
+}
+
+class CustomToStringValueBuilder
+    implements Builder<CustomToStringValue, CustomToStringValueBuilder> {
+  _$CustomToStringValue _$v;
+
+  CustomToStringValueBuilder();
+
+  @override
+  void replace(CustomToStringValue other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$CustomToStringValue;
+  }
+
+  @override
+  void update(void Function(CustomToStringValueBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$CustomToStringValue build() {
+    final _$result = _$v ?? new _$CustomToStringValue._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
 // ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/end_to_end_test/test/values_test.dart
+++ b/end_to_end_test/test/values_test.dart
@@ -310,4 +310,10 @@ void main() {
       expect(notified, true);
     });
   });
+
+  group(CustomToStringValue, () {
+    test('has custom toString()', () {
+      expect(CustomToStringValue().toString(), 'custom');
+    });
+  });
 }


### PR DESCRIPTION
Fixes #582 