### PR TITLE
Stop making use of the `tmp` constructor for `ParsedLibraryResultImpl`.

### DIFF
--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -6,7 +6,6 @@ library built_value_generator.enum_source_class;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/analysis/results.dart'; // ignore: implementation_imports
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/enum_source_field.dart';
@@ -26,8 +25,7 @@ abstract class EnumSourceClass
 
   @memoized
   ParsedLibraryResult get parsedLibrary =>
-      // ignore: deprecated_member_use
-      ParsedLibraryResultImpl.tmp(element.library);
+      element.library.session.getParsedLibraryByElement(element.library);
 
   @memoized
   String get name => element.name;

--- a/built_value_generator/lib/src/enum_source_library.dart
+++ b/built_value_generator/lib/src/enum_source_library.dart
@@ -6,7 +6,6 @@ library built_value_generator.enum_source_library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/analysis/results.dart'; // ignore: implementation_imports
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/enum_source_class.dart';
@@ -26,8 +25,7 @@ abstract class EnumSourceLibrary
 
   @memoized
   ParsedLibraryResult get parsedLibrary =>
-      // ignore: deprecated_member_use
-      ParsedLibraryResultImpl.tmp(element.library);
+      element.library.session.getParsedLibraryByElement(element.library);
 
   @memoized
   String get name => element.name;

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -7,7 +7,6 @@ library built_value_generator.source_class;
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:analyzer/src/dart/analysis/results.dart'; // ignore: implementation_imports
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/enum_source_class.dart';
@@ -34,8 +33,7 @@ abstract class SerializerSourceClass
 
   @memoized
   ParsedLibraryResult get parsedLibrary =>
-      // ignore: deprecated_member_use
-      ParsedLibraryResultImpl.tmp(element.library);
+      element.library.session.getParsedLibraryByElement(element.library);
 
   // TODO(davidmorgan): share common code in a nicer way.
   @memoized

--- a/built_value_generator/lib/src/serializer_source_library.dart
+++ b/built_value_generator/lib/src/serializer_source_library.dart
@@ -6,7 +6,6 @@ library built_value_generator.source_library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/analysis/results.dart'; // ignore: implementation_imports
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/library_elements.dart';
@@ -26,8 +25,7 @@ abstract class SerializerSourceLibrary
 
   @memoized
   ParsedLibraryResult get parsedLibrary =>
-      // ignore: deprecated_member_use
-      ParsedLibraryResultImpl.tmp(element.library);
+      element.library.session.getParsedLibraryByElement(element.library);
 
   @memoized
   bool get hasSerializers => serializersForAnnotations.isNotEmpty;

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -7,7 +7,6 @@ library built_value_generator.source_class;
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/analysis/results.dart'; // ignore: implementation_imports
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/fixes.dart';
@@ -33,8 +32,7 @@ abstract class ValueSourceClass
 
   @memoized
   ParsedLibraryResult get parsedLibrary =>
-      // ignore: deprecated_member_use
-      ParsedLibraryResultImpl.tmp(element.library);
+      element.library.session.getParsedLibraryByElement(element.library);
 
   @memoized
   String get name => element.displayName;

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.33.3 <0.37.0'
+  analyzer: '>=0.34.0 <0.37.0'
   analyzer_plugin: '>=0.0.1-alpha.5 <0.0.1-alpha.9'
   build: ^1.0.0
   build_config: '>=0.3.1 <0.5.0'


### PR DESCRIPTION
This was a temporary analyzer API; it has been deprecated and replaced
by a method in AnalysisSession.