### PR TITLE
serializers: fix syntax in addBuilderFactory dartdoc

### DIFF
--- a/built_value/lib/serializer.dart
+++ b/built_value/lib/serializer.dart
@@ -188,10 +188,12 @@ abstract class SerializersBuilder {
   /// add your own. For example:
   ///
   /// ```dart
-  /// serializers = (serializers.toBuilder()..addBuilderFactory(
-  ///     const FullType(
-  ///         BuiltList,
-  ///         [FullType(Foo)]), () => new ListBuilder<Foo>)).build();
+  /// serializers = (serializers.toBuilder()
+  ///       ..addBuilderFactory(
+  ///         const FullType(BuiltList, [FullType(Foo)]),
+  ///         () => ListBuilder<Foo>(),
+  ///       ))
+  ///     .build();
   /// ```
   void addBuilderFactory(FullType specifiedType, Function function);
 


### PR DESCRIPTION
The issue I'm fixing here is the second parameter passed to `addBuilderFactory` should be `() => ListBuilder<Foo>()` but currently it's missing the `()` after `<Foo>`. I also updated the syntax to remove the `new` keyword and formatted the code with dartfmt.