### PR TITLE
Use DartTypes.getName() instead of DartType.displayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 6.7.2 (not yet published)
+
+- Replace analyzer's `DartType.displayName` with custom code generator.
+
 # 6.7.1
 
 - Fix codegen for custom builders when fields use types that have an import

--- a/built_value_generator/lib/src/dart_types.dart
+++ b/built_value_generator/lib/src/dart_types.dart
@@ -34,7 +34,7 @@ class DartTypes {
 
   static bool isBuiltCollection(DartType type) {
     return _builtCollectionNames
-        .any((name) => type.displayName.startsWith('$name<'));
+        .any((name) => getName(type).startsWith('$name<'));
   }
 
   static bool isBuilt(DartType type) =>
@@ -46,13 +46,29 @@ class DartTypes {
   /// Gets the name of a `DartType`. Supports `Function` types, which will
   /// be returned using the `Function()` syntax.
   static String getName(DartType dartType) {
-    if (dartType is FunctionType) {
+    if (dartType == null) {
+      return null;
+    } else if (dartType.isDynamic) {
+      return 'dynamic';
+    } else if (dartType is FunctionType) {
       return getName(dartType.returnType) +
           ' Function(' +
           dartType.parameters.map((p) => getName(p.type)).join(', ') +
           ')';
+    } else if (dartType is InterfaceType) {
+      var typeArguments = dartType.typeArguments;
+      if (typeArguments.isEmpty || typeArguments.every((t) => t.isDynamic)) {
+        return dartType.element.name;
+      } else {
+        final typeArgumentsStr = typeArguments.map(getName).join(', ');
+        return '${dartType.element.name}<$typeArgumentsStr>';
+      }
+    } else if (dartType is TypeParameterType) {
+      return dartType.element.name;
+    } else if (dartType.isVoid) {
+      return 'void';
     } else {
-      return dartType.displayName;
+      throw UnimplementedError('(${dartType.runtimeType}) $dartType');
     }
   }
 }

--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/dart_types.dart';
 import 'package:built_value_generator/src/enum_source_field.dart';
 import 'package:built_value_generator/src/strings.dart';
 import 'package:quiver/iterables.dart';
@@ -37,7 +38,7 @@ abstract class EnumSourceClass
   BuiltValueEnum get settings {
     var annotations = element.metadata
         .map((annotation) => annotation.computeConstantValue())
-        .where((value) => value?.type?.displayName == 'BuiltValueEnum');
+        .where((value) => DartTypes.getName(value?.type) == 'BuiltValueEnum');
     if (annotations.isEmpty) return const BuiltValueEnum();
     var annotation = annotations.single;
     return BuiltValueEnum(
@@ -102,7 +103,7 @@ abstract class EnumSourceClass
 
   static bool needsEnumClass(ClassElement classElement) {
     // `Object` and mixins return `null` for `supertype`.
-    return classElement.supertype?.displayName == 'EnumClass';
+    return DartTypes.getName(classElement.supertype) == 'EnumClass';
   }
 
   Iterable<String> computeErrors() {

--- a/built_value_generator/lib/src/enum_source_field.dart
+++ b/built_value_generator/lib/src/enum_source_field.dart
@@ -9,6 +9,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 
+import 'dart_types.dart';
+
 part 'enum_source_field.g.dart';
 
 abstract class EnumSourceField
@@ -25,13 +27,14 @@ abstract class EnumSourceField
   String get name => element.displayName;
 
   @memoized
-  String get type => element.getter.returnType.displayName;
+  String get type => DartTypes.getName(element.getter.returnType);
 
   @memoized
   BuiltValueEnumConst get settings {
     var annotations = element.metadata
         .map((annotation) => annotation.computeConstantValue())
-        .where((value) => value?.type?.displayName == 'BuiltValueEnumConst');
+        .where(
+            (value) => DartTypes.getName(value?.type) == 'BuiltValueEnumConst');
     if (annotations.isEmpty) return const BuiltValueEnumConst();
     var annotation = annotations.single;
     return BuiltValueEnumConst(
@@ -61,7 +64,7 @@ abstract class EnumSourceField
 
     var enumName = classElement.displayName;
     for (var fieldElement in classElement.fields) {
-      final type = fieldElement.getter.returnType.displayName;
+      final type = DartTypes.getName(fieldElement.getter.returnType);
       if (!fieldElement.isSynthetic &&
           (type == enumName || type == 'dynamic')) {
         result.add(EnumSourceField(parsedLibrary, fieldElement));

--- a/built_value_generator/lib/src/memoized_getter.dart
+++ b/built_value_generator/lib/src/memoized_getter.dart
@@ -2,6 +2,7 @@ library built_value_generator.memoized_getter;
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/dart_types.dart';
 import 'package:built_value_generator/src/metadata.dart'
     show metadataToStringValue;
 
@@ -24,7 +25,7 @@ abstract class MemoizedGetter
             field.getter.metadata.any(
                 (metadata) => metadataToStringValue(metadata) == 'memoized'))
         .map((field) => MemoizedGetter((b) => b
-          ..returnType = field.getter.returnType.toString()
+          ..returnType = DartTypes.getName(field.getter.returnType)
           ..name = field.displayName))
         .toList();
   }

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -16,6 +16,8 @@ import 'package:built_value_generator/src/serializer_source_field.dart';
 import 'package:built_value_generator/src/strings.dart';
 import 'package:built_value_generator/src/value_source_class.dart';
 
+import 'dart_types.dart';
+
 part 'serializer_source_class.g.dart';
 
 abstract class SerializerSourceClass
@@ -49,7 +51,8 @@ abstract class SerializerSourceClass
 
     var annotations = serializerField.getter.metadata
         .map((annotation) => annotation.computeConstantValue())
-        .where((value) => value?.type?.displayName == 'BuiltValueSerializer');
+        .where((value) =>
+            DartTypes.getName(value?.type) == 'BuiltValueSerializer');
     if (annotations.isEmpty) return const BuiltValueSerializer();
 
     var annotation = annotations.single;

--- a/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_value_generator/lib/src/serializer_source_field.dart
@@ -55,7 +55,7 @@ abstract class SerializerSourceField
   BuiltValueField get builtValueField {
     var annotations = element.getter.metadata
         .map((annotation) => annotation.computeConstantValue())
-        .where((value) => value?.type?.displayName == 'BuiltValueField');
+        .where((value) => DartTypes.getName(value?.type) == 'BuiltValueField');
     if (annotations.isEmpty) return const BuiltValueField();
     var annotation = annotations.single;
     return BuiltValueField(
@@ -75,7 +75,7 @@ abstract class SerializerSourceField
   String get wireName => builtValueField.wireName ?? name;
 
   @memoized
-  String get type => element.getter.returnType.displayName;
+  String get type => DartTypes.getName(element.getter.returnType);
 
   /// The [type] plus any import prefix.
   @memoized
@@ -115,8 +115,8 @@ abstract class SerializerSourceField
     // builder is needed. Otherwise, use the same logic as built_value when
     // it decides whether to use a nested builder.
     return builderFieldElementIsValid
-        ? element.getter.returnType.displayName !=
-            builderElement.getter.returnType.displayName
+        ? DartTypes.getName(element.getter.returnType) !=
+            DartTypes.getName(builderElement.getter.returnType)
         : settings.nestedBuilders &&
             DartTypes.needsNestedBuilder(element.getter.returnType);
   }
@@ -132,7 +132,7 @@ abstract class SerializerSourceField
 
   @memoized
   bool get needsBuilder =>
-      element.getter.returnType.displayName.contains('<') &&
+      DartTypes.getName(element.getter.returnType).contains('<') &&
       DartTypes.isBuilt(element.getter.returnType);
 
   Iterable<String> computeErrors() {

--- a/built_value_generator/lib/src/serializer_source_library.dart
+++ b/built_value_generator/lib/src/serializer_source_library.dart
@@ -13,6 +13,8 @@ import 'package:built_value_generator/src/serializer_source_class.dart';
 import 'package:quiver/iterables.dart';
 import 'package:source_gen/source_gen.dart';
 
+import 'dart_types.dart';
+
 part 'serializer_source_library.g.dart';
 
 abstract class SerializerSourceLibrary
@@ -37,13 +39,14 @@ abstract class SerializerSourceLibrary
     var result = MapBuilder<String, ElementAnnotation>();
     var accessors = element.definingCompilationUnit.accessors
         .where((element) =>
-            element.isGetter && element.returnType.displayName == 'Serializers')
+            element.isGetter &&
+            DartTypes.getName(element.returnType) == 'Serializers')
         .toList();
 
     for (var accessor in accessors) {
       final annotations = accessor.variable.metadata
           .where((annotation) =>
-              annotation.computeConstantValue()?.type?.displayName ==
+              DartTypes.getName(annotation.computeConstantValue()?.type) ==
               'SerializersFor')
           .toList();
       if (annotations.isEmpty) continue;

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -95,7 +95,7 @@ abstract class ValueSourceField
   BuiltValueField get builtValueField {
     var annotations = element.getter.metadata
         .map((annotation) => annotation.computeConstantValue())
-        .where((value) => value?.type?.displayName == 'BuiltValueField');
+        .where((value) => DartTypes.getName(value?.type) == 'BuiltValueField');
     if (annotations.isEmpty) return const BuiltValueField();
     var annotation = annotations.single;
     return BuiltValueField(
@@ -122,7 +122,7 @@ abstract class ValueSourceField
   @memoized
   String get buildElementType {
     // Try to get a resolved type first, it's faster.
-    var result = builderElement.getter?.returnType?.displayName;
+    var result = DartTypes.getName(builderElement.getter?.returnType);
     if (result != null && result != 'dynamic') return result;
     // Go via AST to allow use of unresolvable types not yet generated;
     // this includes generated Builder types.


### PR DESCRIPTION
Stop using DartType.toString() for code generation.

We would like to change DartType.toString() to include nullability suffixes `?` and `*`. And it actually has never been a really good idea to use `toString()` or `DartType.displayName` for code generation.