### PR TITLE
Fix `num` deserialization so it does not always convert to `double`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 6.7.2 (not yet published)
 
 - Bug fix: fix generated `operator==` when a field is called `other`.
+- Fix `num` deserialization so it does not always convert to `double`.
 - Bump version of `analyzer`.
 - Internal: replace analyzer's `DartType.displayName` with custom code
   generator.

--- a/built_value/lib/src/num_serializer.dart
+++ b/built_value/lib/src/num_serializer.dart
@@ -37,7 +37,7 @@ class NumSerializer implements PrimitiveSerializer<num> {
     } else if (serialized == DoubleSerializer.infinity) {
       return double.infinity;
     } else {
-      return (serialized as num).toDouble();
+      return serialized as num;
     }
   }
 }


### PR DESCRIPTION
Fixes #682 