### PR TITLE
Use DartTypes.getName() instead of DartType.toString()

### DIFF
--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -111,7 +111,7 @@ abstract class SerializerSourceClass
   @memoized
   BuiltList<String> get genericBounds =>
       BuiltList<String>(element.typeParameters
-          .map((element) => (element.bound ?? '').toString()));
+          .map((element) => DartTypes.getName(element.bound) ?? ''));
 
   @memoized
   String get genericBoundsOrObjectString => genericBounds.isEmpty


### PR DESCRIPTION
We did this some time ago, but because it is not enforced, probably another one crept in.