### PR TITLE
Remove unused dart:async import

### DIFF
--- a/built_value/lib/async_serializer.dart
+++ b/built_value/lib/async_serializer.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:built_value/serializer.dart';
 
 /// Deserializer for `BuiltList` that runs asynchronously.


### PR DESCRIPTION
Since this package does not support Dart 2.0, this import is not
necessary.