### PR TITLE
Add groups to tests

### DIFF
--- a/built_value_generator/test/built_value_generator_test.dart
+++ b/built_value_generator/test/built_value_generator_test.dart
@@ -14,9 +14,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('generator', () {
-    test('rejects import with "show"', () async {
-      expect(
-          await generate('''library value;
+    group('rejects', () {
+      test('import with "show"', () async {
+        expect(
+            await generate('''library value;
 import 'package:built_value/built_value.dart' show Built, Builder;
 part 'value.g.dart';
 abstract class Value implements Built<Value, ValueBuilder> {
@@ -27,13 +28,13 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop using "show" when importing '
-              '"package:built_value/built_value.dart".'));
-    });
+            contains('1. Stop using "show" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
 
-    test('rejects double quoted import with "show"', () async {
-      expect(
-          await generate('''library value;
+      test('double quoted import with "show"', () async {
+        expect(
+            await generate('''library value;
 import "package:built_value/built_value.dart" show Built, Builder;
 part 'value.g.dart';
 abstract class Value implements Built<Value, ValueBuilder> {
@@ -44,13 +45,13 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop using "show" when importing '
-              '"package:built_value/built_value.dart".'));
-    });
+            contains('1. Stop using "show" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
 
-    test('rejects import with "as"', () async {
-      expect(
-          await generate('''library value;
+      test('import with "as"', () async {
+        expect(
+            await generate('''library value;
 import 'package:built_value/built_value.dart' as bv;
 part 'value.g.dart';
 abstract class Value implements bv.Built<Value, ValueBuilder> {
@@ -61,13 +62,13 @@ abstract class ValueBuilder implements bv.Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop using "as" when importing '
-              '"package:built_value/built_value.dart".'));
-    });
+            contains('1. Stop using "as" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
 
-    test('rejects double quoted import with "as"', () async {
-      expect(
-          await generate('''library value;
+      test('double quoted import with "as"', () async {
+        expect(
+            await generate('''library value;
 import "package:built_value/built_value.dart" as bv;
 part 'value.g.dart';
 abstract class Value implements bv.Built<Value, ValueBuilder> {
@@ -78,54 +79,13 @@ abstract class ValueBuilder implements bv.Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop using "as" when importing '
-              '"package:built_value/built_value.dart".'));
-    });
+            contains('1. Stop using "as" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
 
-    test('suggests to import part file', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains("1. Import generated part: part 'value.g.dart';"));
-    });
-
-    test('suggests to make value class abstract', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Make class abstract.'));
-    });
-
-    test('suggests correct Built type parameters for implements', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Foo, Bar> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Make class implement Built<Value, ValueBuilder>.'));
-    });
-
-    test('rejects "extends" with concrete base', () async {
-      expect(
-          await generate('''library value;
+      test('"extends" with concrete base', () async {
+        expect(
+            await generate('''library value;
 import 'package:built_value/built_value.dart';
 part 'value.g.dart';
 class Foo {}
@@ -137,13 +97,13 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop class extending other classes. '
-              'Only "implements" and "extends Object with" are allowed.'));
-    });
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
 
-    test('rejects "extends" with base with fields', () async {
-      expect(
-          await generate('''library value;
+      test('"extends" with base with fields', () async {
+        expect(
+            await generate('''library value;
 import 'package:built_value/built_value.dart';
 part 'value.g.dart';
 abstract class Foo {
@@ -157,13 +117,13 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop class extending other classes. '
-              'Only "implements" and "extends Object with" are allowed.'));
-    });
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
 
-    test('rejects "extends" with base with abstract getter', () async {
-      expect(
-          await generate('''library value;
+      test('"extends" with base with abstract getter', () async {
+        expect(
+            await generate('''library value;
 import 'package:built_value/built_value.dart';
 part 'value.g.dart';
 abstract class Foo {
@@ -177,13 +137,13 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop class extending other classes. '
-              'Only "implements" and "extends Object with" are allowed.'));
-    });
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
 
-    test('rejects "extends" with base with operator==', () async {
-      expect(
-          await generate('''library value;
+      test('"extends" with base with operator==', () async {
+        expect(
+            await generate('''library value;
 import 'package:built_value/built_value.dart';
 part 'value.g.dart';
 abstract class Foo {
@@ -197,8 +157,480 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''),
-          contains('1. Stop class extending other classes. '
-              'Only "implements" and "extends Object with" are allowed.'));
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
+
+      test('"extends Built"', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value extends Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), allOf(contains('Make class implement Built<Value, ValueBuilder>.')));
+      });
+
+      test('hashCode', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get hashCode => 0;
+}'''), contains('1. Stop implementing hashCode; it will be generated for you.'));
+      });
+
+      test('operator==', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  bool operator==(other) => false;
+}'''), contains('1. Stop implementing operator==; it will be generated for you.'));
+      });
+
+      test('dynamic fields', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  get foo;
+}'''),
+            contains('1. Make field foo have non-dynamic type. If you are '
+                'already specifying a type, please make sure the type is correctly imported.'));
+      });
+
+      test('2.12 rejects @nullable annotation', () async {
+        expect(
+            await generate('''// @dart=2.12
+library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  
+  @nullable
+  int get x;
+}'''),
+            contains('1. Remove "@nullable" from field "x". '
+                'In null safe code, add "?" to the field type instead.'));
+      });
+    });
+
+    group('suggests', () {
+      test('to import part file', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains("1. Import generated part: part 'value.g.dart';"));
+      });
+
+      test('to make value class abstract', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class abstract.'));
+      });
+
+      test('correct Built type parameters for implements', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Foo, Bar> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class implement Built<Value, ValueBuilder>.'));
+      });
+
+      test('making builder initializer static', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  void _initializeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _initializeBuilder signature: '
+                'static void _initializeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder initializer return void', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static String _initializeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _initializeBuilder signature: '
+                'static void _initializeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder initializer accept a builder', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static void _initializeBuilder(String b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _initializeBuilder signature: '
+                'static void _initializeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder finalizer static', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  void _finalizeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _finalizeBuilder signature: '
+                'static void _finalizeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder finalizer return void', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static String _finalizeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _finalizeBuilder signature: '
+                'static void _finalizeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder finalizer accept a builder', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static void _finalizeBuilder(String b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _finalizeBuilder signature: '
+                'static void _finalizeBuilder(ValueBuilder b)'));
+      });
+
+      test('to add constructor to value class', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class have exactly one constructor: Value._();'));
+      });
+
+      test('to add constructor when there is synthetic constructor',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class have exactly one constructor: Value._();'));
+      });
+
+      test('to remove constructor from non-instantiable value class',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+@BuiltValue(instantiable: false)
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value() {}
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Remove all constructors or remove "instantiable: false".'));
+      });
+
+      test('to add factory to value class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains(
+                '1. Add a factory so your class can be instantiated. Example:\n'
+                '\n'
+                'factory Value([void Function(ValueBuilder)? updates]) = _\$Value;'));
+      });
+
+      test('to remove factory from non-instantiable value class',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+@BuiltValue(instantiable: false)
+abstract class Value implements Built<Value, ValueBuilder> {
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Remove all factories or remove "instantiable: false".'));
+      });
+
+      test('to make builder class abstract', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make builder class abstract'));
+      });
+
+      test('correct Builder type parameters', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Foo, Bar> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains(
+                '1. Make builder class implement Builder<Value, ValueBuilder>. '
+                'Currently: Builder<dynamic, dynamic>'));
+      });
+
+      test('to add constructor to builder class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Make builder class '
+                'have exactly one constructor: ValueBuilder._();'));
+      });
+
+      test('constructor for builder class with synthetic constructor',
+          () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+}'''),
+            contains('1. Make builder class '
+                'have exactly one constructor: ValueBuilder._();'));
+      });
+
+      test('to add factory to builder class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+}'''),
+            contains('1. Make builder class have exactly one factory: '
+                'factory ValueBuilder() = _\$ValueBuilder;'));
+      });
+
+      test('value fields must be getters', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+  int foo;
+}'''), contains('1. Make field foo a getter.'));
+      });
+
+      test('value fields must be public', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  int get _foo;
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}'''), contains('1. Make field _foo public; remove the underscore.'));
+      });
+
+      test('builder fields must be normal fields', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+  int get foo;
+}'''),
+            contains('1. Make builder field foo a normal field or a '
+                'getter/setter pair.'));
+      });
+
+      test('builder fields must be in sync', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make builder have exactly these fields: foo'));
+      });
+
+      test('builder fields must be same type', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+  String foo;
+}'''), contains('1. Make builder field foo have type: int'));
+      });
+
+      test('built_collection fields instead of SDK fields', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  List get list;
+  Set get set;
+  Map get map;
+}'''),
+            allOf(
+                contains('1. Make field "list" have type "BuiltList". '
+                    'The current type, "List", is not allowed '
+                    'because it is mutable.'),
+                contains('2. Make field "set" have type "BuiltSet". '
+                    'The current type, "Set", is not allowed '
+                    'because it is mutable.')));
+      });
     });
 
     test(
@@ -220,20 +652,6 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
   ValueBuilder._();
   factory ValueBuilder() = _\$ValueBuilder;
 }'''), isNot(contains('1.')));
-    });
-
-    test('rejects "extends Built"', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value extends Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), allOf(contains('Make class implement Built<Value, ValueBuilder>.')));
     });
 
     test('works with multiple implements', () async {
@@ -266,140 +684,6 @@ abstract class Value implements Built<Value, ValueBuilder> {
 }'''), isNot(contains('1.')));
     });
 
-    test('suggests making builder initializer static', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  void _initializeBuilder(ValueBuilder b) {}
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains('1. Fix _initializeBuilder signature: '
-              'static void _initializeBuilder(ValueBuilder b)'));
-    });
-
-    test('suggests making builder initializer return void', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  static String _initializeBuilder(ValueBuilder b) {}
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains('1. Fix _initializeBuilder signature: '
-              'static void _initializeBuilder(ValueBuilder b)'));
-    });
-
-    test('suggests making builder initializer accept a builder', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  static void _initializeBuilder(String b) {}
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains('1. Fix _initializeBuilder signature: '
-              'static void _initializeBuilder(ValueBuilder b)'));
-    });
-
-    test('suggests making builder finalizer static', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  void _finalizeBuilder(ValueBuilder b) {}
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains('1. Fix _finalizeBuilder signature: '
-              'static void _finalizeBuilder(ValueBuilder b)'));
-    });
-
-    test('suggests making builder finalizer return void', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  static String _finalizeBuilder(ValueBuilder b) {}
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains('1. Fix _finalizeBuilder signature: '
-              'static void _finalizeBuilder(ValueBuilder b)'));
-    });
-
-    test('suggests making builder finalizer accept a builder', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  static void _finalizeBuilder(String b) {}
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains('1. Fix _finalizeBuilder signature: '
-              'static void _finalizeBuilder(ValueBuilder b)'));
-    });
-
-    test('suggests to add constructor to value class', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Make class have exactly one constructor: Value._();'));
-    });
-
-    test('suggests to add constructor when there is synthetic constructor',
-        () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Make class have exactly one constructor: Value._();'));
-    });
-
     test('allows code in constructor of value class', () async {
       expect(
           await generate('''library value;
@@ -417,226 +701,6 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
 }'''),
           isNot(contains(
               '1. Make class have exactly one constructor: Value._();')));
-    });
-
-    test('suggests to remove constructor from non-instantiable value class',
-        () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-@BuiltValue(instantiable: false)
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value() {}
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Remove all constructors or remove "instantiable: false".'));
-    });
-
-    test('suggests to add factory to value class', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains(
-              '1. Add a factory so your class can be instantiated. Example:\n'
-              '\n'
-              'factory Value([void Function(ValueBuilder)? updates]) = _\$Value;'));
-    });
-
-    test('suggests to remove factory from non-instantiable value class',
-        () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-@BuiltValue(instantiable: false)
-abstract class Value implements Built<Value, ValueBuilder> {
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Remove all factories or remove "instantiable: false".'));
-    });
-
-    test('suggests to make builder class abstract', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Make builder class abstract'));
-    });
-
-    test('suggests correct Builder type parameters', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Foo, Bar> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains(
-              '1. Make builder class implement Builder<Value, ValueBuilder>. '
-              'Currently: Builder<dynamic, dynamic>'));
-    });
-
-    test('suggests to add constructor to builder class', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''),
-          contains('1. Make builder class '
-              'have exactly one constructor: ValueBuilder._();'));
-    });
-
-    test('suggests constructor for builder class with synthetic constructor',
-        () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-}'''),
-          contains('1. Make builder class '
-              'have exactly one constructor: ValueBuilder._();'));
-    });
-
-    test('suggests to add factory to builder class', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-}'''),
-          contains('1. Make builder class have exactly one factory: '
-              'factory ValueBuilder() = _\$ValueBuilder;'));
-    });
-
-    test('suggests value fields must be getters', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  int foo;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-  int foo;
-}'''), contains('1. Make field foo a getter.'));
-    });
-
-    test('suggests value fields must be public', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  int get _foo;
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-}'''), contains('1. Make field _foo public; remove the underscore.'));
-    });
-
-    test('rejects dynamic fields', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  get foo;
-}'''),
-          contains('1. Make field foo have non-dynamic type. If you are '
-              'already specifying a type, please make sure the type is correctly imported.'));
-    });
-
-    test('suggests builder fields must be normal fields', () async {
-      expect(
-          await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  int get foo;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-  int get foo;
-}'''),
-          contains('1. Make builder field foo a normal field or a '
-              'getter/setter pair.'));
-    });
-
-    test('suggests builder fields must be in sync', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  int get foo;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-}'''), contains('1. Make builder have exactly these fields: foo'));
-    });
-
-    test('suggests builder fields must be same type', () async {
-      expect(await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  int get foo;
-}
-abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
-  ValueBuilder._();
-  factory ValueBuilder() = _\$ValueBuilder;
-  String foo;
-}'''), contains('1. Make builder field foo have type: int'));
     });
 
     test('ignores setters', () async {
@@ -671,38 +735,9 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
       expect(generated, isNot(contains('super._() {}')));
       expect(generated, contains('super._();'));
     });
-  });
 
-  test('rejects hashCode', () async {
-    expect(
-        await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  int get hashCode => 0;
-}'''),
-        contains(
-            '1. Stop implementing hashCode; it will be generated for you.'));
-  });
-
-  test('rejects operator==', () async {
-    expect(
-        await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  bool operator==(other) => false;
-}'''),
-        contains(
-            '1. Stop implementing operator==; it will be generated for you.'));
-  });
-
-  test('uses toString()', () async {
-    expect(await generate('''library value;
+    test('uses toString()', () async {
+      expect(await generate('''library value;
 import 'package:built_value/built_value.dart';
 part 'value.g.dart';
 abstract class Value implements Built<Value, ValueBuilder> {
@@ -710,32 +745,11 @@ abstract class Value implements Built<Value, ValueBuilder> {
   factory Value([void Function(ValueBuilder) updates]) = _\$Value;
   String toString() => 'hi!';
 }'''), isNot(contains('String toString()')));
-  });
+    });
 
-  test('suggests built_collection fields instead of SDK fields', () async {
-    expect(
-        await generate('''library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  List get list;
-  Set get set;
-  Map get map;
-}'''),
-        allOf(
-            contains('1. Make field "list" have type "BuiltList". '
-                'The current type, "List", is not allowed '
-                'because it is mutable.'),
-            contains('2. Make field "set" have type "BuiltSet". '
-                'The current type, "Set", is not allowed '
-                'because it is mutable.')));
-  });
-
-  test('rejects comparableBuilders with nestedBuilders', () async {
-    expect(
-        await generate('''library value;
+    test('comparableBuilders with nestedBuilders', () async {
+      expect(
+          await generate('''library value;
 import 'package:built_value/built_value.dart';
 part 'value.g.dart';
 @BuiltValue(comparableBuilders: true)
@@ -743,40 +757,24 @@ abstract class Value implements Built<Value, ValueBuilder> {
   Value._();
   factory Value([void Function(ValueBuilder) updates]) = _\$Value;
   }'''),
-        contains(
-            '1. Set `nestedBuilders: false` in order to use `comparableBuilders: true`.'));
-  });
+          contains(
+              '1. Set `nestedBuilders: false` in order to use `comparableBuilders: true`.'));
+    });
 
-  test('Cleans generated class names for private classes', () async {
-    expect(
-        await generate('''library value;
+    test('cleans generated class names for private classes', () async {
+      expect(
+          await generate('''library value;
 import 'package:built_value/built_value.dart';
 part 'value.g.dart';
 abstract class _Value implements Built<_Value, _ValueBuilder> {
   _Value._();
   factory _Value([void Function(_ValueBuilder) updates]) = _\$Value;
 }'''),
-        allOf(
-          isNot(contains(r'_$_')),
-          isNot(contains(r'1.')),
-        ));
-  });
-
-  test('2.12 rejects @nullable annotation', () async {
-    expect(
-        await generate('''// @dart=2.12
-library value;
-import 'package:built_value/built_value.dart';
-part 'value.g.dart';
-abstract class Value implements Built<Value, ValueBuilder> {
-  Value._();
-  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
-  
-  @nullable
-  int get x;
-}'''),
-        contains('1. Remove "@nullable" from field "x". '
-            'In null safe code, add "?" to the field type instead.'));
+          allOf(
+            isNot(contains(r'_$_')),
+            isNot(contains(r'1.')),
+          ));
+    });
   });
 }
 

--- a/built_value_generator/test/serializer_generator_test.dart
+++ b/built_value_generator/test/serializer_generator_test.dart
@@ -178,7 +178,7 @@ abstract class Value implements Built<Value, ValueBuilder> {
               '"function" or mark it "@BuiltValueField(serialize: false)".'));
     });
 
-    test('Cannot generate serializer for private classes', () async {
+    test('cannot generate serializer for private classes', () async {
       expect(await generate(r'''
 library value;
 


### PR DESCRIPTION
I was thinking about how to contribute one feature and got lost in the tests, so I'm opening this to see if it makes sense to you., I believe that grouping the tests make them more clear and may guide other people to contribute.

If you check the `flutter outline` window on IntelliJ the changes look like this:

WDYT?

# Enum Tests
## Before
![image](https://user-images.githubusercontent.com/76348/99273598-3c7a8580-27f7-11eb-84a4-551cf2589b05.png)

## After
![image](https://user-images.githubusercontent.com/76348/99273522-279df200-27f7-11eb-9c4b-85d80630f0de.png)

# Built Value Tests

## Before
![image](https://user-images.githubusercontent.com/76348/99274680-9af43380-27f8-11eb-8463-a71cf99f8362.png)

## After
![image](https://user-images.githubusercontent.com/76348/99274605-89ab2700-27f8-11eb-8ff2-9884c01c1f71.png)

