### PR TITLE
Fix: escape serializer code

### DIFF
--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -419,7 +419,7 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
 
   static String _toCode(Object object) {
     if (object is String) {
-      return "'$object'";
+      return "'${escapeString(object)}'";
     } else if (object is int) {
       return object.toString();
     } else {


### PR DESCRIPTION
This fixes usages like `@BuiltValueEnumConst(wireName: r'$foo')` which currently generates `'$foo'` in `_toWire/_fromWire`.
With this change it correctly generates `'\$foo'`.

I wonder if instead of escaping all of these could be raw strings?