### PR TITLE
Add cast wrappers to prevent type errors with nnbd

### DIFF
--- a/benchmark/lib/benchmark.dart
+++ b/benchmark/lib/benchmark.dart
@@ -2,12 +2,15 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:benchmark/node.dart';
 import 'package:benchmark/simple_value.dart';
 
 void benchmark() {
   benchmarkHashCode();
   benchmarkNestedRebuilds();
+  benchmarkDeserialization();
 }
 
 void benchmarkHashCode() {
@@ -29,6 +32,16 @@ void benchmarkNestedRebuilds() {
       }
       leafBuilder.label = 'updatedLeaf';
       topBuilder.build();
+    });
+  }
+}
+
+void benchmarkDeserialization() {
+  for (var depth = 0; depth <= 3; ++depth) {
+    final value = Node((b) => _buildNested(b, depth));
+    final serialized = json.decode(json.encode(serializers.serialize(value)));
+    _benchmark('nested deserialization $depth', () {
+      return serializers.deserialize(serialized);
     });
   }
 }

--- a/benchmark/lib/node.dart
+++ b/benchmark/lib/node.dart
@@ -5,19 +5,21 @@
 library node;
 
 import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
 
 part 'node.g.dart';
 
 abstract class Node implements Built<Node, NodeBuilder> {
-  @nullable
-  String get label;
+  String? get label;
 
-  @nullable
-  Node get left;
+  Node? get left;
 
-  @nullable
-  Node get right;
+  Node? get right;
 
-  factory Node([Function(NodeBuilder) updates]) = _$Node;
+  factory Node([Function(NodeBuilder)? updates]) = _$Node;
   Node._();
+  static Serializer<Node> get serializer => _$nodeSerializer;
 }
+
+@SerializersFor([Node])
+Serializers serializers = _$serializers;

--- a/benchmark/lib/node.g.dart
+++ b/benchmark/lib/node.g.dart
@@ -6,15 +6,84 @@ part of node;
 // BuiltValueGenerator
 // **************************************************************************
 
+Serializers _$serializers =
+    (new Serializers().toBuilder()..add(Node.serializer)).build();
+Serializer<Node> _$nodeSerializer = new _$NodeSerializer();
+
+class _$NodeSerializer implements StructuredSerializer<Node> {
+  @override
+  final Iterable<Type> types = const [Node, _$Node];
+  @override
+  final String wireName = 'Node';
+
+  @override
+  Iterable<Object> serialize(Serializers serializers, Node object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[];
+    Object? value;
+    value = object.label;
+    if (value != null) {
+      result
+        ..add('label')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.left;
+    if (value != null) {
+      result
+        ..add('left')
+        ..add(
+            serializers.serialize(value, specifiedType: const FullType(Node)));
+    }
+    value = object.right;
+    if (value != null) {
+      result
+        ..add('right')
+        ..add(
+            serializers.serialize(value, specifiedType: const FullType(Node)));
+    }
+    return result;
+  }
+
+  @override
+  Node deserialize(Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new NodeBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object value = iterator.current;
+      switch (key) {
+        case 'label':
+          result.label = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'left':
+          result.left.replace(serializers.deserialize(value,
+              specifiedType: const FullType(Node)) as Node);
+          break;
+        case 'right':
+          result.right.replace(serializers.deserialize(value,
+              specifiedType: const FullType(Node)) as Node);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$Node extends Node {
   @override
-  final String label;
+  final String? label;
   @override
-  final Node left;
+  final Node? left;
   @override
-  final Node right;
+  final Node? right;
 
-  factory _$Node([void Function(NodeBuilder) updates]) =>
+  factory _$Node([void Function(NodeBuilder)? updates]) =>
       (new NodeBuilder()..update(updates)).build();
 
   _$Node._({this.label, this.left, this.right}) : super._();
@@ -51,19 +120,19 @@ class _$Node extends Node {
 }
 
 class NodeBuilder implements Builder<Node, NodeBuilder> {
-  _$Node _$v;
+  _$Node? _$v;
 
-  String _label;
-  String get label => _$this._label;
-  set label(String label) => _$this._label = label;
+  String? _label;
+  String? get label => _$this._label;
+  set label(String? label) => _$this._label = label;
 
-  NodeBuilder _left;
+  NodeBuilder? _left;
   NodeBuilder get left => _$this._left ??= new NodeBuilder();
-  set left(NodeBuilder left) => _$this._left = left;
+  set left(NodeBuilder? left) => _$this._left = left;
 
-  NodeBuilder _right;
+  NodeBuilder? _right;
   NodeBuilder get right => _$this._right ??= new NodeBuilder();
-  set right(NodeBuilder right) => _$this._right = right;
+  set right(NodeBuilder? right) => _$this._right = right;
 
   NodeBuilder();
 
@@ -85,7 +154,7 @@ class NodeBuilder implements Builder<Node, NodeBuilder> {
   }
 
   @override
-  void update(void Function(NodeBuilder) updates) {
+  void update(void Function(NodeBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -97,7 +166,7 @@ class NodeBuilder implements Builder<Node, NodeBuilder> {
           new _$Node._(
               label: label, left: _left?.build(), right: _right?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'left';
         _left?.build();

--- a/benchmark/lib/simple_value.dart
+++ b/benchmark/lib/simple_value.dart
@@ -13,6 +13,6 @@ abstract class SimpleValue implements Built<SimpleValue, SimpleValueBuilder> {
 
   String get aString;
 
-  factory SimpleValue([Function(SimpleValueBuilder) updates]) = _$SimpleValue;
+  factory SimpleValue([Function(SimpleValueBuilder)? updates]) = _$SimpleValue;
   SimpleValue._();
 }

--- a/benchmark/lib/simple_value.g.dart
+++ b/benchmark/lib/simple_value.g.dart
@@ -12,10 +12,10 @@ class _$SimpleValue extends SimpleValue {
   @override
   final String aString;
 
-  factory _$SimpleValue([void Function(SimpleValueBuilder) updates]) =>
+  factory _$SimpleValue([void Function(SimpleValueBuilder)? updates]) =>
       (new SimpleValueBuilder()..update(updates)).build();
 
-  _$SimpleValue._({this.anInt, this.aString}) : super._() {
+  _$SimpleValue._({required this.anInt, required this.aString}) : super._() {
     BuiltValueNullFieldError.checkNotNull(anInt, 'SimpleValue', 'anInt');
     BuiltValueNullFieldError.checkNotNull(aString, 'SimpleValue', 'aString');
   }
@@ -50,15 +50,15 @@ class _$SimpleValue extends SimpleValue {
 }
 
 class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
-  _$SimpleValue _$v;
+  _$SimpleValue? _$v;
 
-  int _anInt;
-  int get anInt => _$this._anInt;
-  set anInt(int anInt) => _$this._anInt = anInt;
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
 
-  String _aString;
-  String get aString => _$this._aString;
-  set aString(String aString) => _$this._aString = aString;
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
 
   SimpleValueBuilder();
 
@@ -79,7 +79,7 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
   }
 
   @override
-  void update(void Function(SimpleValueBuilder) updates) {
+  void update(void Function(SimpleValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -6,12 +6,15 @@ description: >
 homepage: https://github.com/google/built_value.dart
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   built_collection: ^5.0.0
   built_value: ^8.0.0
 
+dependency_overrides:
+  built_value:
+    path: ../built_value
 dev_dependencies:
   build_runner: ^1.0.0
   built_value_generator: ^8.0.0

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 dependency_overrides:
   built_value:
     path: ../built_value
+
 dev_dependencies:
   build_runner: ^1.0.0
   built_value_generator: ^8.0.0

--- a/benchmark/test/node_test.dart
+++ b/benchmark/test/node_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     test('nested label can be updated', () {
       final node = Node((b) => b.left.label = 'updated');
-      expect(node.left.label, 'updated');
+      expect(node.left!.label, 'updated');
     });
 
     test('nested label update does not affect original', () {
@@ -46,12 +46,12 @@ void main() {
       nestedBuilder.label = 'leaf';
       final node = builder.build();
       nestedBuilder.label = 'updated';
-      expect(node.left.label, 'leaf');
+      expect(node.left!.label, 'leaf');
     });
 
     test('doubly nested label can be updated', () {
       final node = Node((b) => b.left.left.label = 'updated');
-      expect(node.left.left.label, 'updated');
+      expect(node.left!.left!.label, 'updated');
     });
 
     test('doubly nested label update does not affect original', () {
@@ -66,7 +66,7 @@ void main() {
       nestedBuilder.label = 'leaf';
       final node = builder.build();
       nestedBuilder.label = 'updated';
-      expect(node.left.left.label, 'leaf');
+      expect(node.left!.left!.label, 'leaf');
     });
 
     test('structure can be created', () {
@@ -74,9 +74,9 @@ void main() {
         ..left.left.label = 'one'
         ..left.right.left.label = 'two'
         ..right.right.right.label = 'three');
-      expect(node.left.left.label, 'one');
-      expect(node.left.right.left.label, 'two');
-      expect(node.right.right.right.label, 'three');
+      expect(node.left!.left!.label, 'one');
+      expect(node.left!.right!.left!.label, 'two');
+      expect(node.right!.right!.right!.label, 'three');
     });
 
     test('derived structure can be created without affecting original', () {
@@ -91,15 +91,15 @@ void main() {
         ..right.right.right.right.label = 'below 3');
 
       // Original is unchanged.
-      expect(node.left.left.label, 'one');
-      expect(node.left.right.left.label, 'two');
-      expect(node.right.right.right.label, 'three');
+      expect(node.left!.left!.label, 'one');
+      expect(node.left!.right!.left!.label, 'two');
+      expect(node.right!.right!.right!.label, 'three');
 
       // Derived structure is correct.
-      expect(updatedNode.left.left.label, '1');
-      expect(updatedNode.left.right.left.label, '2');
-      expect(updatedNode.right.right.right.label, 'three');
-      expect(updatedNode.right.right.right.right.label, 'below 3');
+      expect(updatedNode.left!.left!.label, '1');
+      expect(updatedNode.left!.right!.left!.label, '2');
+      expect(updatedNode.right!.right!.right!.label, 'three');
+      expect(updatedNode.right!.right!.right!.right!.label, 'below 3');
     });
 
     test('supports setting builders to null to clear', () {
@@ -121,14 +121,14 @@ void main() {
         ..left.right.left = null);
 
       // Original is unchanged.
-      expect(node.left.left.label, 'one');
-      expect(node.left.right.left.label, 'two');
-      expect(node.right.right.right.label, 'three');
+      expect(node.left!.left!.label, 'one');
+      expect(node.left!.right!.left!.label, 'two');
+      expect(node.right!.right!.right!.label, 'three');
 
       // Derived structure is correct.
-      expect(updatedNode.left.left.label, '1');
-      expect(updatedNode.left.right.left, null);
-      expect(updatedNode.right.right.right.label, 'three');
+      expect(updatedNode.left!.left!.label, '1');
+      expect(updatedNode.left!.right!.left, null);
+      expect(updatedNode.right!.right!.right!.label, 'three');
     });
   });
 }

--- a/built_value/lib/json_object.dart
+++ b/built_value/lib/json_object.dart
@@ -64,8 +64,12 @@ abstract class JsonObject {
       return BoolJsonObject(value);
     } else if (value is List<Object>) {
       return ListJsonObject(value);
+    } else if (value is List) {
+      return ListJsonObject(List.castFrom(value));
     } else if (value is Map<String, Object>) {
       return MapJsonObject(value);
+    } else if (value is Map<String, dynamic>) {
+      return MapJsonObject(Map.castFrom(value));
     } else {
       throw ArgumentError.value(value, 'value',
           'Must be bool, List<Object>, Map<String, Object>, num or String');

--- a/built_value/lib/src/built_json_serializers.dart
+++ b/built_value/lib/src/built_json_serializers.dart
@@ -138,7 +138,9 @@ class BuiltJsonSerializers implements Serializers {
       if (serializer is StructuredSerializer) {
         try {
           return serializer.deserialize(
-              this, object.sublist(1) as List<Object>);
+            this,
+            Iterable.castFrom(object.sublist(1)),
+          );
         } on Error catch (error) {
           throw DeserializationError(object, specifiedType, error);
         }
@@ -165,8 +167,11 @@ class BuiltJsonSerializers implements Serializers {
 
       if (serializer is StructuredSerializer) {
         try {
-          return serializer.deserialize(this, object as Iterable<Object>,
-              specifiedType: specifiedType);
+          return serializer.deserialize(
+            this,
+            Iterable.castFrom(object as Iterable),
+            specifiedType: specifiedType,
+          );
         } on Error catch (error) {
           throw DeserializationError(object, specifiedType, error);
         }

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -12,6 +12,10 @@ dependencies:
   built_collection: ^5.0.0
   built_value: ^8.0.0
 
+dependency_overides:
+  built_value:
+    path: ../built_value
+
 dev_dependencies:
   build: ^1.0.0
   build_runner: ^1.0.0

--- a/end_to_end_test/test/standard_json_nnbd_serializer_test.dart
+++ b/end_to_end_test/test/standard_json_nnbd_serializer_test.dart
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file.
 // @dart=2.12
 
+import 'dart:convert';
+
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
@@ -65,6 +67,13 @@ void main() {
     test('can be deserialized', () {
       expect(
           serializersWithPlugin.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+    test('can be deserialized from the output of json.decode', () {
+      expect(
+          serializersWithPlugin.deserialize(
+              json.decode(json.encode(serialized)) as Object,
               specifiedType: specifiedType),
           data);
     });


### PR DESCRIPTION
Closes #984.
I looked at the type errors I got when running with sound null safety, and added cast wrappers (e.g. `Iterable.castFrom`) where I encountered type errors.
I also evaluated doing a deep copy instead (i.e. `List.from`) and added a benchmark to check which one is faster. Cast wrappers are faster:
|Cast wrappers - jit|Cast wrappers - aot|Copy - jit|Copy - aot|
|---|---|---|---|
|nested deserialization 0: 7210767/s<br>nested deserialization 0: 7278953/s<br>nested deserialization 0: 7294079/s<br>nested deserialization 1: 2516580/s<br>nested deserialization 1: 2499335/s<br>nested deserialization 1: 2467185/s<br>nested deserialization 2: 1082605/s<br>nested deserialization 2: 1108822/s<br>nested deserialization 2: 1099959/s<br>nested deserialization 3: 517398/s<br>nested deserialization 3: 519599/s<br>nested deserialization 3: 522565/s|nested deserialization 0: 5734501/s<br>nested deserialization 0: 5749466/s<br>nested deserialization 0: 5754213/s<br>nested deserialization 1: 2062843/s<br>nested deserialization 1: 2065303/s<br>nested deserialization 1: 2066913/s<br>nested deserialization 2: 906207/s<br>nested deserialization 2: 902985/s<br>nested deserialization 2: 902393/s<br>nested deserialization 3: 420446/s<br>nested deserialization 3: 420533/s<br>nested deserialization 3: 419598/s|nested deserialization 0: 6054577/s<br>nested deserialization 0: 6226848/s<br>nested deserialization 0: 6223596/s<br>nested deserialization 1: 2122581/s<br>nested deserialization 1: 2120130/s<br>nested deserialization 1: 2124657/s<br>nested deserialization 2: 909698/s<br>nested deserialization 2: 906233/s<br>nested deserialization 2: 910109/s<br>nested deserialization 3: 424334/s<br>nested deserialization 3: 424159/s<br>nested deserialization 3: 423187/s|nested deserialization 0: 4666552/s<br>nested deserialization 0: 4661829/s<br>nested deserialization 0: 4664917/s<br>nested deserialization 1: 1621026/s<br>nested deserialization 1: 1618778/s<br>nested deserialization 1: 1620415/s<br>nested deserialization 2: 699778/s<br>nested deserialization 2: 699368/s<br>nested deserialization 2: 699180/s<br>nested deserialization 3: 327309/s<br>nested deserialization 3: 326831/s<br>nested deserialization 3: 326636/s|

_Interestingly, aot is slower than jit in both cases._
I also converted the benchmark to null safety, and somewhat unrelatedly, sound null safety is not noticeably faster in jit mode (indistinguishable from noise on my machine), but does bring an improvement for aot:
|Cast wrappers - aot - no sound null safety (for comparison)|
|---|
|nested deserialization 0: 5367603/s<br>nested deserialization 0: 5455621/s<br>nested deserialization 0: 5453196/s<br>nested deserialization 1: 1860031/s<br>nested deserialization 1: 1883178/s<br>nested deserialization 1: 1850925/s<br>nested deserialization 2: 816983/s<br>nested deserialization 2: 824544/s<br>nested deserialization 2: 824415/s<br>nested deserialization 3: 384873/s<br>nested deserialization 3: 383929/s<br>nested deserialization 3: 379484/s|

## Tests
I added one small test to end_to_end_test. Let me know if this is enough or if I should add more tests.
