### PR TITLE
Makes `rebuild` take a void function.

### DIFF
--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -18,7 +18,7 @@ abstract class Built<V extends Built<V, B>, B extends Builder<V, B>> {
   ///
   /// The implementation of this method will be generated for you by the
   /// built_value generator.
-  V rebuild(Function(B) updates);
+  V rebuild(void Function(B) updates);
 
   /// Converts the instance to a builder [B].
   ///


### PR DESCRIPTION
It's not very clear whether a value returned by the `updates` parameter to `rebuild` means anything.
All examples use `=>` notation which returns the builder. The return type is currently `dynamic`, which *suggests* that the value is used for something, potentially something which cannot even be typed.

Marking the parameter as a `void` returning function makes it clear that you should not worry about the return value.