### PR TITLE
Make generated deserialize method not throw cast_nullable_to_non_nullable lint warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 8.2.0 (unreleased)
+
+- Make generator output additional explicit null checks so the generated code complies with the cast_nullable_to_non_nullable lint.
+
 # 8.1.4
 
 - Bump version of `analyzer`.

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -18,3 +18,9 @@ dev_dependencies:
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0
+
+dependency_overrides:
+  built_value:
+    path: ../built_value
+  built_value_generator:
+    path: ../built_value_generator

--- a/built_value/pubspec.yaml
+++ b/built_value/pubspec.yaml
@@ -17,3 +17,7 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.4.0
   test: ^1.16.0
+
+dependency_overrides:
+  built_value_generator:
+    path: ../built_value_generator

--- a/built_value_analyzer_plugin/pubspec.yaml
+++ b/built_value_analyzer_plugin/pubspec.yaml
@@ -17,3 +17,9 @@ dev_dependencies:
   build_test: ^0.10.3
   pedantic: ^1.4.0
   test: ^1.0.0
+
+dependency_overrides:
+  built_value:
+    path: ../built_value
+  built_value_generator:
+    path: ../built_value_generator

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -336,7 +336,7 @@ class $serializerImplName implements StructuredSerializer<$genericName> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current$notNull as String;
       iterator.moveNext();
       final Object$orNull value = iterator.current;
       switch (key) {
@@ -532,10 +532,12 @@ case '${escapeString(field.wireName)}':
       } else {
         // `cast` is empty if no cast is needed.
         var maybeOrNull = field.isNullable && cast.isNotEmpty ? orNull : '';
+        // If cast exists and is not nullable.
+        var maybeNotNull = !field.isNullable && cast.isNotEmpty ? notNull : '';
         return '''
 case '${escapeString(field.wireName)}':
   result.${field.name} = serializers.deserialize(
-      value, specifiedType: $fullType) $cast$maybeOrNull;
+      value, specifiedType: $fullType)$maybeNotNull $cast$maybeOrNull;
   break;
 ''';
       }

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -513,6 +513,8 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
       final fullType = field.generateFullType(
           compilationUnit, genericParameters.toBuiltSet());
       final cast = field.generateCast(compilationUnit, _genericBoundsAsMap);
+      // If cast exists and is not nullable.
+      var maybeNotNull = !field.isNullable && cast.isNotEmpty ? notNull : '';
       if (field.builderFieldUsesNestedBuilder) {
         if (field.builderFieldAutoCreatesNestedBuilder || hasBuilder) {
           return '''
@@ -525,15 +527,13 @@ case '${escapeString(field.wireName)}':
           return '''
 case '${escapeString(field.wireName)}':
   result.${field.name} = (serializers.deserialize(
-      value, specifiedType: $fullType) $cast).toBuilder();
+      value, specifiedType: $fullType)$maybeNotNull $cast).toBuilder();
   break;
 ''';
         }
       } else {
         // `cast` is empty if no cast is needed.
         var maybeOrNull = field.isNullable && cast.isNotEmpty ? orNull : '';
-        // If cast exists and is not nullable.
-        var maybeNotNull = !field.isNullable && cast.isNotEmpty ? notNull : '';
         return '''
 case '${escapeString(field.wireName)}':
   result.${field.name} = serializers.deserialize(

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -22,3 +22,7 @@ dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
   pedantic: ^1.4.0
   test: ^1.0.0
+
+dependency_overrides:
+  built_value:
+    path: ../built_value

--- a/built_value_generator/test/serializer_generator_test.dart
+++ b/built_value_generator/test/serializer_generator_test.dart
@@ -226,6 +226,27 @@ abstract class _Value implements Built<_Value, _ValueBuilder> {
 }
 '''), contains(r'1. Cannot generate serializers for private class _Value'));
     });
+
+    test('deserialize is null safe', () async {
+      final generated = await generate(r'''
+        library value;
+
+        import 'package:test_support/test_support.dart';
+
+        part 'value.g.dart';
+
+        abstract class Value implements Built<Value, ValueBuilder> {
+          static Serializer<Value> get serializer => _$valueSerializer;
+          bool get aBool;
+          
+          Value._();
+          factory Value([void Function(ValueBuilder) updates]) = _$Value;
+        }
+        ''');
+      expect(generated, contains(r'final key = iterator.current! as String;'));
+      expect(generated,
+          contains(r'specifiedType: const FullType(bool))! as bool;'));
+    });
   });
 }
 

--- a/built_value_generator/test/serializer_generator_test.dart
+++ b/built_value_generator/test/serializer_generator_test.dart
@@ -226,27 +226,6 @@ abstract class _Value implements Built<_Value, _ValueBuilder> {
 }
 '''), contains(r'1. Cannot generate serializers for private class _Value'));
     });
-
-    test('deserialize is null safe', () async {
-      final generated = await generate(r'''
-        library value;
-
-        import 'package:test_support/test_support.dart';
-
-        part 'value.g.dart';
-
-        abstract class Value implements Built<Value, ValueBuilder> {
-          static Serializer<Value> get serializer => _$valueSerializer;
-          bool get aBool;
-          
-          Value._();
-          factory Value([void Function(ValueBuilder) updates]) = _$Value;
-        }
-        ''');
-      expect(generated, contains(r'final key = iterator.current! as String;'));
-      expect(generated,
-          contains(r'specifiedType: const FullType(bool))! as bool;'));
-    });
   });
 }
 

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -20,3 +20,9 @@ dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
   pedantic: ^1.4.0
   test: ^1.0.0
+
+dependency_overrides:
+  built_value:
+    path: ../built_value
+  built_value_generator:
+    path: ../built_value_generator

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -23,3 +23,9 @@ dev_dependencies:
   built_value_generator: ^8.1.4
   pedantic: ^1.4.0
   test: ^1.0.0
+
+dependency_overrides:
+  built_value:
+    path: ../built_value
+  built_value_generator:
+    path: ../built_value_generator

--- a/end_to_end_test/analysis_options.yaml
+++ b/end_to_end_test/analysis_options.yaml
@@ -7,3 +7,7 @@ analyzer:
 
   language:
     strict-raw-types: true
+
+linter:
+  rules:
+    - cast_nullable_to_non_nullable

--- a/end_to_end_test/lib/collections_nnbd.g.dart
+++ b/end_to_end_test/lib/collections_nnbd.g.dart
@@ -124,7 +124,7 @@ class _$CollectionsSerializer implements StructuredSerializer<Collections> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {

--- a/end_to_end_test/lib/generics_nnbd.g.dart
+++ b/end_to_end_test/lib/generics_nnbd.g.dart
@@ -68,7 +68,7 @@ class _$GenericValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -125,13 +125,13 @@ class _$BoundGenericValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value =
-              serializers.deserialize(value, specifiedType: parameterT) as num;
+              serializers.deserialize(value, specifiedType: parameterT)! as num;
           break;
       }
     }
@@ -186,7 +186,7 @@ class _$CollectionGenericValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -238,7 +238,7 @@ class _$GenericContainerSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -316,7 +316,7 @@ class _$PassthroughGenericContainerSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -372,7 +372,7 @@ class _$NestedGenericContainerSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -416,13 +416,13 @@ class _$ConcreteGenericSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -458,14 +458,14 @@ class _$NonBuiltGenericSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,
                   specifiedType:
-                      const FullType(NonBuilt, const [const FullType(int)]))
+                      const FullType(NonBuilt, const [const FullType(int)]))!
               as NonBuilt<int>;
           break;
       }

--- a/end_to_end_test/lib/imported_values_nnbd.g.dart
+++ b/end_to_end_test/lib/imported_values_nnbd.g.dart
@@ -44,7 +44,7 @@ class _$ImportedValueSerializer implements StructuredSerializer<ImportedValue> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -101,19 +101,19 @@ class _$ImportedCustomValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'simpleValue':
           result.simpleValue = serializers.deserialize(value,
-                  specifiedType: const FullType(prefix.SimpleValue))
+                  specifiedType: const FullType(prefix.SimpleValue))!
               as prefix.SimpleValue;
           break;
         case 'simpleValues':
           result.simpleValues = serializers.deserialize(value,
                   specifiedType: const FullType(
-                      BuiltList, const [const FullType(prefix.SimpleValue)]))
+                      BuiltList, const [const FullType(prefix.SimpleValue)]))!
               as BuiltList<prefix.SimpleValue>;
           break;
       }
@@ -158,7 +158,7 @@ class _$ImportedCustomNestedValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {

--- a/end_to_end_test/lib/interfaces_nnbd.g.dart
+++ b/end_to_end_test/lib/interfaces_nnbd.g.dart
@@ -64,17 +64,17 @@ class _$ValueWithIntSerializer implements StructuredSerializer<ValueWithInt> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'anInt':
           result.anInt = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'note':
           result.note = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -127,13 +127,13 @@ class _$ValueWithHasIntSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'hasInt':
           result.hasInt = serializers.deserialize(value,
-              specifiedType: const FullType(HasInt)) as HasInt;
+              specifiedType: const FullType(HasInt))! as HasInt;
           break;
       }
     }

--- a/end_to_end_test/lib/polymorphism_nnbd.g.dart
+++ b/end_to_end_test/lib/polymorphism_nnbd.g.dart
@@ -43,17 +43,17 @@ class _$CatSerializer implements StructuredSerializer<Cat> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'tail':
           result.tail = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'legs':
           result.legs = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -88,17 +88,17 @@ class _$FishSerializer implements StructuredSerializer<Fish> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'fins':
           result.fins = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'legs':
           result.legs = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -133,17 +133,17 @@ class _$RobotSerializer implements StructuredSerializer<Robot> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'fins':
           result.fins = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'legs':
           result.legs = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -181,13 +181,13 @@ class _$CageSerializer implements StructuredSerializer<Cage> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'inhabitant':
           result.inhabitant = serializers.deserialize(value,
-              specifiedType: const FullType(Animal)) as Animal;
+              specifiedType: const FullType(Animal))! as Animal;
           break;
         case 'otherInhabitants':
           result.otherInhabitants.replace(serializers.deserialize(value,
@@ -226,13 +226,13 @@ class _$StandardCatSerializer implements StructuredSerializer<StandardCat> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'tail':
           result.tail = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -266,13 +266,13 @@ class _$HasStringSerializer implements StructuredSerializer<HasString> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'field':
           result.field = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -306,13 +306,13 @@ class _$HasDoubleSerializer implements StructuredSerializer<HasDouble> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'field':
           result.field = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
       }
     }
@@ -347,13 +347,13 @@ class _$UsesHandCodedSerializer implements StructuredSerializer<UsesHandCoded> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'fieldInBaseBuilder':
           result.fieldInBaseBuilder = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }

--- a/end_to_end_test/lib/standard_json_nnbd.g.dart
+++ b/end_to_end_test/lib/standard_json_nnbd.g.dart
@@ -86,17 +86,17 @@ class _$StandardJsonValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'number':
           result.number = serializers.deserialize(value,
-              specifiedType: const FullType(num)) as num;
+              specifiedType: const FullType(num))! as num;
           break;
         case 'text':
           result.text = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'value':
           result.value.replace(serializers.deserialize(value,
@@ -219,13 +219,13 @@ class _$ComplexValueSerializer implements StructuredSerializer<ComplexValue> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'primitive':
           result.primitive = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'nullablePrimitive':
           result.nullablePrimitive = serializers.deserialize(value,

--- a/end_to_end_test/lib/values_nnbd.g.dart
+++ b/end_to_end_test/lib/values_nnbd.g.dart
@@ -111,13 +111,13 @@ class _$SimpleValueSerializer implements StructuredSerializer<SimpleValue> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'anInt':
           result.anInt = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'aString':
           result.aString = serializers.deserialize(value,
@@ -167,7 +167,7 @@ class _$CompoundValueSerializer implements StructuredSerializer<CompoundValue> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -225,13 +225,13 @@ class _$CompoundValueNoNestingSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'simpleValue':
           result.simpleValue = serializers.deserialize(value,
-              specifiedType: const FullType(SimpleValue)) as SimpleValue;
+              specifiedType: const FullType(SimpleValue))! as SimpleValue;
           break;
         case 'validatedValue':
           result.validatedValue = serializers.deserialize(value,
@@ -275,13 +275,13 @@ class _$CompoundValueNoAutoNestingSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = (serializers.deserialize(value,
-                      specifiedType: const FullType(NoFieldsValue))
+                      specifiedType: const FullType(NoFieldsValue))!
                   as NoFieldsValue)
               .toBuilder();
           break;
@@ -330,13 +330,13 @@ class _$CompoundValueComparableBuildersSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'simpleValue':
           result.simpleValue = serializers.deserialize(value,
-              specifiedType: const FullType(SimpleValue)) as SimpleValue;
+              specifiedType: const FullType(SimpleValue))! as SimpleValue;
           break;
         case 'validatedValue':
           result.validatedValue = serializers.deserialize(value,
@@ -397,13 +397,13 @@ class _$CompoundValueNoNestingFieldSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'simpleValue':
           result.simpleValue = serializers.deserialize(value,
-              specifiedType: const FullType(SimpleValue)) as SimpleValue;
+              specifiedType: const FullType(SimpleValue))! as SimpleValue;
           break;
         case 'validatedValue':
           result.validatedValue = serializers.deserialize(value,
@@ -473,13 +473,13 @@ class _$CompoundValueNestingFieldSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'simpleValue':
           result.simpleValue = serializers.deserialize(value,
-              specifiedType: const FullType(SimpleValue)) as SimpleValue;
+              specifiedType: const FullType(SimpleValue))! as SimpleValue;
           break;
         case 'validatedValue':
           result.validatedValue = serializers.deserialize(value,
@@ -535,13 +535,13 @@ class _$CompoundValueNoAutoNestingFieldSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = (serializers.deserialize(value,
-                      specifiedType: const FullType(NoFieldsValue))
+                      specifiedType: const FullType(NoFieldsValue))!
                   as NoFieldsValue)
               .toBuilder();
           break;
@@ -590,7 +590,7 @@ class _$CompoundValueAutoNestingFieldSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -647,7 +647,7 @@ class _$CompoundValueExplicitNoNestingSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -699,13 +699,13 @@ class _$ValidatedValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'anInt':
           result.anInt = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'aString':
           result.aString = serializers.deserialize(value,
@@ -753,13 +753,13 @@ class _$ValueUsingImportAsSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,
-                  specifiedType: const FullType(using_import_as.TestEnum))
+                  specifiedType: const FullType(using_import_as.TestEnum))!
               as using_import_as.TestEnum;
           break;
         case 'nullableValue':
@@ -846,53 +846,53 @@ class _$PrimitivesValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'boolean':
           result.boolean = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'integer':
           result.integer = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'int64':
           result.int64 = serializers.deserialize(value,
-              specifiedType: const FullType(Int64)) as Int64;
+              specifiedType: const FullType(Int64))! as Int64;
           break;
         case 'dbl':
           result.dbl = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
         case 'number':
           result.number = serializers.deserialize(value,
-              specifiedType: const FullType(num)) as num;
+              specifiedType: const FullType(num))! as num;
           break;
         case 'string':
           result.string = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'dateTime':
           result.dateTime = serializers.deserialize(value,
-              specifiedType: const FullType(DateTime)) as DateTime;
+              specifiedType: const FullType(DateTime))! as DateTime;
           break;
         case 'duration':
           result.duration = serializers.deserialize(value,
-              specifiedType: const FullType(Duration)) as Duration;
+              specifiedType: const FullType(Duration))! as Duration;
           break;
         case 'regExp':
           result.regExp = serializers.deserialize(value,
-              specifiedType: const FullType(RegExp)) as RegExp;
+              specifiedType: const FullType(RegExp))! as RegExp;
           break;
         case 'uri':
           result.uri = serializers.deserialize(value,
-              specifiedType: const FullType(Uri)) as Uri;
+              specifiedType: const FullType(Uri))! as Uri;
           break;
         case 'bigInt':
           result.bigInt = serializers.deserialize(value,
-              specifiedType: const FullType(BigInt)) as BigInt;
+              specifiedType: const FullType(BigInt))! as BigInt;
           break;
       }
     }
@@ -931,13 +931,13 @@ class _$PartiallySerializableValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -972,13 +972,13 @@ class _$NamedFactoryValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1012,13 +1012,13 @@ class _$WireNameValueSerializer implements StructuredSerializer<WireNameValue> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case '\$v':
           result.value = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1069,7 +1069,7 @@ class _$FieldDiscoveryValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -1123,7 +1123,7 @@ class _$DiscoverableValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -1169,13 +1169,13 @@ class _$SecondDiscoverableValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1214,13 +1214,13 @@ class _$ThirdDiscoverableValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
           result.value = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1256,7 +1256,7 @@ class _$RecursiveValueASerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -1299,7 +1299,7 @@ class _$RecursiveValueBSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -1339,13 +1339,13 @@ class _$OtherValueSerializer implements StructuredSerializer<OtherValue> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'other':
           result.other = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1385,13 +1385,13 @@ class _$DefaultsForFieldSettingsValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'serialized':
           result.serialized = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1465,17 +1465,17 @@ class _$ValueWithBuilderInitializerSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'anInt':
           result.anInt = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'anIntWithDefault':
           result.anIntWithDefault = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'nullableInt':
           result.nullableInt = serializers.deserialize(value,
@@ -1539,13 +1539,13 @@ class _$ValueWithBuilderFinalizerSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'anInt':
           result.anInt = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1588,7 +1588,7 @@ class _$SerializesNullsValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -1637,7 +1637,7 @@ class _$NullableObjectValueSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -1686,17 +1686,17 @@ class _$ValueWithHooksSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'hook1Count':
           result.hook1Count = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'hook2Count':
           result.hook2Count = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'hookOrdering':
           result.hookOrdering.replace(serializers.deserialize(value,

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: end_to_end_test
-version: 8.1.3
+version: 8.1.4
 publish_to: none
 description: >
   Tests, not for publishing.
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   build: '>=1.0.0 < 3.0.0'
   build_runner: ^1.0.0
-  built_value_generator: ^8.1.3
+  built_value_generator: ^8.1.4
   fixnum: ^1.0.0
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: end_to_end_test
-version: 8.1.4
+version: 8.1.3
 publish_to: none
 description: >
   Tests, not for publishing.
@@ -15,8 +15,14 @@ dependencies:
 dev_dependencies:
   build: '>=1.0.0 < 3.0.0'
   build_runner: ^1.0.0
-  built_value_generator: ^8.1.4
+  built_value_generator: ^8.1.3
   fixnum: ^1.0.0
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.16.0
+
+dependency_overrides:
+  built_value:
+    path: ../built_value
+  built_value_generator:
+    path: ../built_value_generator

--- a/end_to_end_test/test/values_nnbd_test.dart
+++ b/end_to_end_test/test/values_nnbd_test.dart
@@ -33,6 +33,7 @@ void main() {
       expect(
           () => SimpleValue((b) => b
             ..anInt = 1
+            // ignore: cast_nullable_to_non_nullable
             ..replace(null as SimpleValue)),
           throwsA(const TypeMatcher<Error>()));
     });

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,3 +17,9 @@ dev_dependencies:
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0
+
+dependency_overrides:
+  built_value:
+    path: ../built_value
+  built_value_generator:
+    path: ../built_value_generator

--- a/tool/presubmit
+++ b/tool/presubmit
@@ -16,7 +16,7 @@ for directory in $directories; do
   echo
   cd "$parent_directory/$directory"
 
-  dartfmt -w $(find bin lib test -name \*.dart 2>/dev/null)
+  dart format $(find bin lib test -name \*.dart 2>/dev/null)
 done
 
 for directory in $directories; do
@@ -25,15 +25,15 @@ for directory in $directories; do
   echo
   cd "$parent_directory/$directory"
 
-  pub get
-  pub upgrade
+  dart pub get
+  dart pub upgrade
 
   # Clear any pre-existing build output so package:build doesn't get confused
   # when we use built_value to build itself.
   rm -rf .dart_tool/build/
 
   grep -q build_runner pubspec.yaml && \
-      pub run build_runner build \
+      dart pub run build_runner build \
           --delete-conflicting-outputs \
           --fail-on-severe
 done
@@ -44,7 +44,7 @@ for directory in $directories; do
   echo
   cd "$parent_directory/$directory"
 
-  dartanalyzer \
+  dart analyze \
       --fatal-warnings \
       --fatal-infos \
       --packages="$PWD/.packages" \
@@ -57,5 +57,5 @@ for directory in $directories; do
   echo
   cd "$parent_directory/$directory"
 
-  pub run test
+  dart pub run test
 done


### PR DESCRIPTION
Fixes #1101.

The change adds a couple' null asserts to `deserialize` to prevent cast_nullable_to_non_nullable lint warning.