### PR TITLE
Support final parameters in EnumClass constructor and valueOf method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 8.2.0 (unreleased)
 
+- Support final parameters in EnumClass constructor and valueOf method.
 - Make generator output additional explicit null checks so the generated code complies with the cast_nullable_to_non_nullable lint.
 
 # 8.1.4

--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -80,7 +80,7 @@ abstract class EnumSourceClass
     var source = parsedLibrary.getElementDeclaration(getter).node.toSource();
     var matches = RegExp(r'static ' +
             element.displayName +
-            r' valueOf\(String name\) \=\> (\_\$\w+)\(name\)\;')
+            r' valueOf\((?:final )?String name\) \=\> (\_\$\w+)\(name\)\;')
         .allMatches(source);
     return matches.isEmpty ? null : matches.first.group(1);
   }
@@ -143,11 +143,16 @@ abstract class EnumSourceClass
   }
 
   Iterable<String> _checkConstructor() {
-    var expectedCode = 'const $name._(String name) : super(name);';
+    var expectedCode =
+        RegExp('const $name._\\((?:final )?String name\\) : super\\(name\\);');
+    print(constructors[0].toString());
     return constructors.length == 1 &&
             constructors.single.contains(expectedCode)
         ? <String>[]
-        : <String>['Have exactly one constructor: $expectedCode'];
+        : <String>[
+            'Have exactly one constructor: '
+                'const $name._((final )?String name) : super(name);'
+          ];
   }
 
   Iterable<String> _checkValuesGetter() {
@@ -162,7 +167,7 @@ abstract class EnumSourceClass
     var result = <String>[];
     if (valueOfIdentifier == null) {
       result.add('Add method: '
-          'static $name valueOf(String name) => _\$valueOf(name)');
+          'static $name valueOf((final )?String name) => _\$valueOf(name)');
     }
     return result;
   }

--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -151,7 +151,7 @@ abstract class EnumSourceClass
         ? <String>[]
         : <String>[
             'Have exactly one constructor: '
-                'const $name._((final )?String name) : super(name);'
+                'const $name._(String name) : super(name);'
           ];
   }
 
@@ -167,7 +167,7 @@ abstract class EnumSourceClass
     var result = <String>[];
     if (valueOfIdentifier == null) {
       result.add('Add method: '
-          'static $name valueOf((final )?String name) => _\$valueOf(name)');
+          'static $name valueOf(String name) => _\$valueOf(name)');
     }
     return result;
   }

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -450,7 +450,7 @@ abstract class ValueSourceClass
     var expectedInterface = 'Built<$name$_generics, ${name}Builder$_generics>';
 
     var implementsClauseIsCorrect = implementsClause != null &&
-        implementsClause.interfaces2
+        implementsClause.interfaces
             .any((type) => type.toSource() == expectedInterface);
 
     // Built parameters need fixing if they are not as expected, unless 1) the
@@ -460,7 +460,7 @@ abstract class ValueSourceClass
     // same interface twice with different type parameters.
     var implementsClauseIsAllowedToBeIncorrect = !settings.instantiable &&
         (implementsClause == null ||
-            !implementsClause.interfaces2.any((type) =>
+            !implementsClause.interfaces.any((type) =>
                 type.toSource() == 'Built' ||
                 type.toSource().startsWith('Built<')));
 
@@ -473,7 +473,7 @@ abstract class ValueSourceClass
           ..fix = 'implements $expectedInterface'));
       } else {
         var found = false;
-        final interfaces = implementsClause.interfaces2.map((type) {
+        final interfaces = implementsClause.interfaces.map((type) {
           if (type.name.name == 'Built') {
             found = true;
             return expectedInterface;

--- a/built_value_generator/test/enum_class_generator_test.dart
+++ b/built_value_generator/test/enum_class_generator_test.dart
@@ -222,7 +222,7 @@ class TestEnum extends EnumClass {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Have exactly one constructor: const TestEnum._((final )?String name) : super(name);'''));
+1. Have exactly one constructor: const TestEnum._(String name) : super(name);'''));
       });
 
       test('with error on incorrect constructor', () async {
@@ -245,7 +245,7 @@ class TestEnum extends EnumClass {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Have exactly one constructor: const TestEnum._((final )?String name) : super(name);'''));
+1. Have exactly one constructor: const TestEnum._(String name) : super(name);'''));
       });
 
       test('with error on too many constructors', () async {
@@ -272,7 +272,7 @@ abstract class BuiltSet<T> {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Have exactly one constructor: const TestEnum._((final )?String name) : super(name);'''));
+1. Have exactly one constructor: const TestEnum._(String name) : super(name);'''));
       });
 
       test('with error on missing values getter', () async {
@@ -316,7 +316,7 @@ class TestEnum extends EnumClass {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Add method: static TestEnum valueOf((final )?String name) => _$valueOf(name)'''));
+1. Add method: static TestEnum valueOf(String name) => _$valueOf(name)'''));
       });
 
       test('with error on wrong mixin declaration', () async {

--- a/built_value_generator/test/enum_class_generator_test.dart
+++ b/built_value_generator/test/enum_class_generator_test.dart
@@ -222,7 +222,7 @@ class TestEnum extends EnumClass {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Have exactly one constructor: const TestEnum._(String name) : super(name);'''));
+1. Have exactly one constructor: const TestEnum._((final )?String name) : super(name);'''));
       });
 
       test('with error on incorrect constructor', () async {
@@ -245,7 +245,7 @@ class TestEnum extends EnumClass {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Have exactly one constructor: const TestEnum._(String name) : super(name);'''));
+1. Have exactly one constructor: const TestEnum._((final )?String name) : super(name);'''));
       });
 
       test('with error on too many constructors', () async {
@@ -272,7 +272,7 @@ abstract class BuiltSet<T> {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Have exactly one constructor: const TestEnum._(String name) : super(name);'''));
+1. Have exactly one constructor: const TestEnum._((final )?String name) : super(name);'''));
       });
 
       test('with error on missing values getter', () async {
@@ -316,7 +316,7 @@ class TestEnum extends EnumClass {
 }
 '''), endsWith(r'''Please make the following changes to use EnumClass:
 
-1. Add method: static TestEnum valueOf(String name) => _$valueOf(name)'''));
+1. Add method: static TestEnum valueOf((final )?String name) => _$valueOf(name)'''));
       });
 
       test('with error on wrong mixin declaration', () async {

--- a/end_to_end_test/lib/enums.dart
+++ b/end_to_end_test/lib/enums.dart
@@ -31,10 +31,10 @@ class SecondTestEnum extends EnumClass {
   static const SecondTestEnum no = _$n;
   static const SecondTestEnum definitely = _$definitely;
 
-  const SecondTestEnum._(String name) : super(name);
+  const SecondTestEnum._(final String name) : super(name);
 
   static BuiltSet<SecondTestEnum> get values => _$vls;
-  static SecondTestEnum valueOf(String name) => _$vlOf(name);
+  static SecondTestEnum valueOf(final String name) => _$vlOf(name);
 }
 
 @BuiltValueEnum(wireName: 'E')


### PR DESCRIPTION
Solves #1093.

This change allows using final params in a class inheriting from `EnumClass`, for its constructor, and `valueOf` method.

I also had to replace the usages of `interfaces2` with `interfaces` (due to deprecation) in [value_source_class.dart](https://github.com/google/built_value.dart/blob/master/built_value_generator/lib/src/value_source_class.dart) for tool/presubmit to pass.