### PR TITLE
WIP add oldWireNames support

### DIFF
--- a/built_value/lib/built_value.dart
+++ b/built_value/lib/built_value.dart
@@ -163,12 +163,17 @@ class BuiltValueField {
   /// indicates the setting is to be taken from the `autoCreateNestedBuilders` setting on the class.
   final bool? autoCreateNestedBuilder;
 
+  /// Previously used wirenames. Will deserialize old wirenames to this field if they
+  /// are available. Current wirename is given priority. Defaults to an empty list.
+  final List<String> oldWireNames;
+
   const BuiltValueField(
       {this.compare,
       this.serialize,
       this.wireName,
       this.nestedBuilder,
-      this.autoCreateNestedBuilder});
+      this.autoCreateNestedBuilder,
+      this.oldWireNames = const []});
 }
 
 /// Optionally, annotate a Built Value `Serializer` getters with this to

--- a/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_value_generator/lib/src/serializer_source_field.dart
@@ -97,6 +97,10 @@ abstract class SerializerSourceField
   String get name => element.displayName;
 
   @memoized
+  String get capitalizedName =>
+      name.substring(0, 1).toUpperCase() + name.substring(1);
+
+  @memoized
   String get wireName => builtValueField.wireName ?? name;
 
   @memoized

--- a/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_value_generator/lib/src/serializer_source_field.dart
@@ -65,6 +65,11 @@ abstract class SerializerSourceField
         compare: annotation.getField('compare').toBoolValue(),
         serialize: annotation.getField('serialize').toBoolValue(),
         wireName: annotation.getField('wireName').toStringValue(),
+        oldWireNames: annotation
+            .getField('oldWireNames')
+            .toListValue()
+            .map((value) => value.toStringValue())
+            .toList(),
         nestedBuilder: annotation.getField('nestedBuilder').toBoolValue(),
         autoCreateNestedBuilder:
             annotation.getField('autoCreateNestedBuilder').toBoolValue());
@@ -93,6 +98,9 @@ abstract class SerializerSourceField
 
   @memoized
   String get wireName => builtValueField.wireName ?? name;
+
+  @memoized
+  List<String> get oldWireNames => builtValueField.oldWireNames ?? [];
 
   @memoized
   String get type => stripNullabilitySuffix(typeWithNullabilitySuffix);

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -25,6 +25,7 @@ class _$SerializerSourceField extends SerializerSourceField {
   bool __isNullable;
   String __name;
   String __wireName;
+  List<String> __oldWireNames;
   String __type;
   String __typeWithNullabilitySuffix;
   String __typeWithPrefix;
@@ -78,6 +79,9 @@ class _$SerializerSourceField extends SerializerSourceField {
 
   @override
   String get wireName => __wireName ??= super.wireName;
+
+  @override
+  List<String> get oldWireNames => __oldWireNames ??= super.oldWireNames;
 
   @override
   String get type => __type ??= super.type;

--- a/example/lib/values.dart
+++ b/example/lib/values.dart
@@ -191,3 +191,24 @@ abstract class WireNameValue
 
   WireNameValue._();
 }
+
+/// If you need to migrate to a different wirename you can do so using the
+/// [BuiltValue.oldWireNames] annotation field
+@BuiltValue(wireName: 'V')
+abstract class MigratedWireNameValue
+    implements Built<MigratedWireNameValue, MigratedWireNameValueBuilder> {
+  static Serializer<MigratedWireNameValue> get serializer =>
+      _$migratedWireNameValueSerializer;
+
+  @BuiltValueField(wireName: 'value', oldWireNames: ['v'])
+  int get value;
+
+  @BuiltValueField(oldWireNames: ['validatedValueV1', 'validatedValueV2'])
+  ValidatedValue get validatedValue;
+
+  factory MigratedWireNameValue(
+          [void Function(MigratedWireNameValueBuilder) updates]) =
+      _$MigratedWireNameValue;
+
+  MigratedWireNameValue._();
+}

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -337,6 +337,7 @@ class _$MigratedWireNameValueSerializer
   MigratedWireNameValue deserialize(
       Serializers serializers, Iterable<Object> serialized,
       {FullType specifiedType = FullType.unspecified}) {
+    var $haveSetValidatedValue = false;
     final result = new MigratedWireNameValueBuilder();
 
     final iterator = serialized.iterator;
@@ -355,12 +356,15 @@ class _$MigratedWireNameValueSerializer
           break;
         case 'validatedValueV1':
         case 'validatedValueV2':
+          if ($haveSetValidatedValue) break;
           result.validatedValue.replace(serializers.deserialize(value,
               specifiedType: const FullType(ValidatedValue)) as ValidatedValue);
+          $haveSetValidatedValue = true;
           break;
         case 'validatedValue':
           result.validatedValue.replace(serializers.deserialize(value,
               specifiedType: const FullType(ValidatedValue)) as ValidatedValue);
+          $haveSetValidatedValue = true;
           break;
       }
     }

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -16,6 +16,8 @@ Serializer<ValidatedValue> _$validatedValueSerializer =
 Serializer<Account> _$accountSerializer = new _$AccountSerializer();
 Serializer<WireNameValue> _$wireNameValueSerializer =
     new _$WireNameValueSerializer();
+Serializer<MigratedWireNameValue> _$migratedWireNameValueSerializer =
+    new _$MigratedWireNameValueSerializer();
 
 class _$SimpleValueSerializer implements StructuredSerializer<SimpleValue> {
   @override
@@ -298,6 +300,67 @@ class _$WireNameValueSerializer implements StructuredSerializer<WireNameValue> {
         case 'v':
           result.value = serializers.deserialize(value,
               specifiedType: const FullType(int)) as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$MigratedWireNameValueSerializer
+    implements StructuredSerializer<MigratedWireNameValue> {
+  @override
+  final Iterable<Type> types = const [
+    MigratedWireNameValue,
+    _$MigratedWireNameValue
+  ];
+  @override
+  final String wireName = 'V';
+
+  @override
+  Iterable<Object> serialize(
+      Serializers serializers, MigratedWireNameValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+      'validatedValue',
+      serializers.serialize(object.validatedValue,
+          specifiedType: const FullType(ValidatedValue)),
+    ];
+
+    return result;
+  }
+
+  @override
+  MigratedWireNameValue deserialize(
+      Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new MigratedWireNameValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object value = iterator.current;
+      switch (key) {
+        case 'v':
+          result.value ??= serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          break;
+        case 'value':
+          result.value = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          break;
+        case 'validatedValueV1':
+        case 'validatedValueV2':
+          result.validatedValue.replace(serializers.deserialize(value,
+              specifiedType: const FullType(ValidatedValue)) as ValidatedValue);
+          break;
+        case 'validatedValue':
+          result.validatedValue.replace(serializers.deserialize(value,
+              specifiedType: const FullType(ValidatedValue)) as ValidatedValue);
           break;
       }
     }
@@ -1139,6 +1202,116 @@ class WireNameValueBuilder
         new _$WireNameValue._(
             value: BuiltValueNullFieldError.checkNotNull(
                 value, 'WireNameValue', 'value'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$MigratedWireNameValue extends MigratedWireNameValue {
+  @override
+  final int value;
+  @override
+  final ValidatedValue validatedValue;
+
+  factory _$MigratedWireNameValue(
+          [void Function(MigratedWireNameValueBuilder) updates]) =>
+      (new MigratedWireNameValueBuilder()..update(updates)).build();
+
+  _$MigratedWireNameValue._({this.value, this.validatedValue}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        value, 'MigratedWireNameValue', 'value');
+    BuiltValueNullFieldError.checkNotNull(
+        validatedValue, 'MigratedWireNameValue', 'validatedValue');
+  }
+
+  @override
+  MigratedWireNameValue rebuild(
+          void Function(MigratedWireNameValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  MigratedWireNameValueBuilder toBuilder() =>
+      new MigratedWireNameValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is MigratedWireNameValue &&
+        value == other.value &&
+        validatedValue == other.validatedValue;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, value.hashCode), validatedValue.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('MigratedWireNameValue')
+          ..add('value', value)
+          ..add('validatedValue', validatedValue))
+        .toString();
+  }
+}
+
+class MigratedWireNameValueBuilder
+    implements Builder<MigratedWireNameValue, MigratedWireNameValueBuilder> {
+  _$MigratedWireNameValue _$v;
+
+  int _value;
+  int get value => _$this._value;
+  set value(int value) => _$this._value = value;
+
+  ValidatedValueBuilder _validatedValue;
+  ValidatedValueBuilder get validatedValue =>
+      _$this._validatedValue ??= new ValidatedValueBuilder();
+  set validatedValue(ValidatedValueBuilder validatedValue) =>
+      _$this._validatedValue = validatedValue;
+
+  MigratedWireNameValueBuilder();
+
+  MigratedWireNameValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _validatedValue = $v.validatedValue.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(MigratedWireNameValue other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$MigratedWireNameValue;
+  }
+
+  @override
+  void update(void Function(MigratedWireNameValueBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$MigratedWireNameValue build() {
+    _$MigratedWireNameValue _$result;
+    try {
+      _$result = _$v ??
+          new _$MigratedWireNameValue._(
+              value: BuiltValueNullFieldError.checkNotNull(
+                  value, 'MigratedWireNameValue', 'value'),
+              validatedValue: validatedValue.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'validatedValue';
+        validatedValue.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'MigratedWireNameValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }


### PR DESCRIPTION
This is a work in progress, but it's ready for initial review, as there are items that I haven't yet been able to resolve. I anticipate this PR needing 2+ reviews to land.

All suggestions are welcome, any guidance is welcome.

### Goals

Make it easy to migrate fields by annotating them with old wire names.

### Checklist

- [x] add `List<String> oldWireNames` to `@BuiltValueField`
- [x] implement deserializing `oldWireNames`
- [x] prioritize `wireName` over `oldWireNames`
- [x] add `MigratedWireNameValue` example
- [ ] add test coverage