### PR TITLE
Release 8.2.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 8.2.1
+
+- Fix deps: allow `built_value_generator` to use `built_value 8.2.0`.
+
 # 8.2.0
 
 - Allow writing final parameters in EnumClass constructor and valueOf method.

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark
-version: 8.2.0
+version: 8.2.1
 publish_to: none
 description: >
   Benchmark, not for publishing.
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
-  built_value_generator: ^8.2.0
+  built_value_generator: ^8.2.1
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0

--- a/built_value/pubspec.yaml
+++ b/built_value/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value
-version: 8.2.0
+version: 8.2.1
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the runtime dependency.

--- a/built_value_analyzer_plugin/pubspec.yaml
+++ b/built_value_analyzer_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_analyzer_plugin
-version: 8.2.0
+version: 8.2.1
 description: >
   Experimental analyzer plugin for the built_value code generator.
 homepage: https://github.com/google/built_value.dart
@@ -11,7 +11,7 @@ dependencies:
   analyzer: '>=0.39.0 <0.40.0'
   analyzer_plugin: '>=0.1.0 <0.3.0'
   built_value: '>=7.0.0 <7.1.0'
-  built_value_generator: ^8.2.0
+  built_value_generator: ^8.2.1
 
 dev_dependencies:
   build_test: ^0.10.3

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_generator
-version: 8.2.0
+version: 8.2.1
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the dev dependency.
@@ -13,7 +13,7 @@ dependencies:
   build: '>=1.0.0 <3.0.0'
   build_config: '>=0.3.1 <2.0.0'
   built_collection: ^5.0.0
-  built_value: '>=8.1.0 <8.2.0'
+  built_value: '>=8.1.0 <8.3.0'
   source_gen: '>=0.9.0 <2.0.0'
   quiver: '>=0.21.0 <4.0.0'
 

--- a/built_value_generator/tools/analyzer_plugin/pubspec.yaml
+++ b/built_value_generator/tools/analyzer_plugin/pubspec.yaml
@@ -1,8 +1,8 @@
 name: built_value_analyzer_plugin_loader
-version: 8.2.0
+version: 8.2.1
 description: This pubspec determines the version of the analyzer plugin to load.
 environment:
   sdk: '>=1.24.0-dev.1.0'
 dependencies:
-  built_value_analyzer_plugin: ^8.2.0
-  built_value_generator: ^8.2.0
+  built_value_analyzer_plugin: ^8.2.1
+  built_value_generator: ^8.2.1

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_test
-version: 8.2.0
+version: 8.2.1
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library provides test support.
@@ -16,7 +16,7 @@ dependencies:
   quiver: '>=0.21.0 <4.0.0'
 
 dev_dependencies:
-  built_value_generator: ^8.2.0
+  built_value_generator: ^8.2.1
   build_runner: '>=1.0.0 <3.0.0'
   pedantic: ^1.4.0
   test: ^1.0.0

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chat_example
-version: 8.2.0
+version: 8.2.1
 publish_to: none
 description: >
   Just an example, not for publishing.
@@ -20,6 +20,6 @@ dev_dependencies:
   build_runner: any
   build_test: any
   build_web_compilers: any
-  built_value_generator: ^8.2.0
+  built_value_generator: ^8.2.1
   pedantic: ^1.4.0
   test: ^1.0.0

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: end_to_end_test
-version: 8.2.0
+version: 8.2.1
 publish_to: none
 description: >
   Tests, not for publishing.
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   build: '>=1.0.0 < 3.0.0'
   build_runner: ^1.0.0
-  built_value_generator: ^8.2.0
+  built_value_generator: ^8.2.1
   fixnum: ^1.0.0
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
-  built_value_generator: ^8.2.0
+  built_value_generator: ^8.2.1
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0


### PR DESCRIPTION
Fix deps range for `built_value_generator`.