### PR TITLE
Implement support for optional generic bounds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ John Dengis <jadengis@gmail.com>
 Resul Alkan/MetGlobal <me@resulalkan.com>
 Dao Hoang Son <dao@hoangson.vn>
 Ahmed Fwela/Bdaya Development <ahmednfwela@bdaya-dev.com>
+Max Härtwig/Google Inc. <maxhaertwig@google.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 8.3.1
+
+- Add support for optional generic bounds, e.g. `class Foo<T extends Object?>`.
+
 # 8.3.0
 
 - Change generated `build` methods to return only public types, creating

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -107,6 +107,14 @@ abstract class ValueSourceField
       NullabilitySuffix.question;
 
   @memoized
+  bool get hasNullableGenericType =>
+      element.getter?.returnType is TypeParameterType &&
+      (element.getter!.returnType as TypeParameterType)
+              .bound
+              .nullabilitySuffix ==
+          NullabilitySuffix.question;
+
+  @memoized
   bool get isNullable => hasNullableAnnotation || hasNullableType;
 
   @memoized

--- a/end_to_end_test/lib/generics_nnbd.dart
+++ b/end_to_end_test/lib/generics_nnbd.dart
@@ -53,6 +53,18 @@ abstract class BoundGenericValue<T extends num>
   BoundGenericValue._();
 }
 
+abstract class BoundNullableGenericValue<T extends num?>
+    implements Built<BoundNullableGenericValue<T>, BoundNullableGenericValueBuilder<T>> {
+  static Serializer<BoundNullableGenericValue> get serializer =>
+      _$boundNullableGenericValueSerializer;
+
+  T get value;
+
+  factory BoundNullableGenericValue([Function(BoundNullableGenericValueBuilder<T>) updates]) =
+      _$BoundNullableGenericValue<T>;
+  BoundNullableGenericValue._();
+}
+
 abstract class CollectionGenericValue<T>
     implements
         Built<CollectionGenericValue<T>, CollectionGenericValueBuilder<T>> {

--- a/end_to_end_test/lib/generics_nnbd.g.dart
+++ b/end_to_end_test/lib/generics_nnbd.g.dart
@@ -11,6 +11,9 @@ Serializer<GenericValue<Object?>> _$genericValueSerializer =
     new _$GenericValueSerializer();
 Serializer<BoundGenericValue<num>> _$boundGenericValueSerializer =
     new _$BoundGenericValueSerializer();
+Serializer<BoundNullableGenericValue<num>>
+    _$boundNullableGenericValueSerializer =
+    new _$BoundNullableGenericValueSerializer();
 Serializer<CollectionGenericValue<Object?>> _$collectionGenericValueSerializer =
     new _$CollectionGenericValueSerializer();
 Serializer<GenericContainer> _$genericContainerSerializer =
@@ -124,6 +127,66 @@ class _$BoundGenericValueSerializer
         ? new BoundGenericValueBuilder<num>()
         : serializers.newBuilder(specifiedType)
             as BoundGenericValueBuilder<num>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(value, specifiedType: parameterT)! as num;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BoundNullableGenericValueSerializer
+    implements StructuredSerializer<BoundNullableGenericValue<num>> {
+  @override
+  final Iterable<Type> types = const [
+    BoundNullableGenericValue,
+    _$BoundNullableGenericValue
+  ];
+  @override
+  final String wireName = 'BoundNullableGenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, BoundNullableGenericValue<num> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: parameterT),
+    ];
+
+    return result;
+  }
+
+  @override
+  BoundNullableGenericValue<num> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? new BoundNullableGenericValueBuilder<num>()
+        : serializers.newBuilder(specifiedType)
+            as BoundNullableGenericValueBuilder<num>;
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -813,6 +876,97 @@ class BoundGenericValueBuilder<T extends num>
         new _$BoundGenericValue<T>._(
             value: BuiltValueNullFieldError.checkNotNull(
                 value, r'BoundGenericValue', 'value'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$BoundNullableGenericValue<T extends num?>
+    extends BoundNullableGenericValue<T> {
+  @override
+  final T value;
+
+  factory _$BoundNullableGenericValue(
+          [void Function(BoundNullableGenericValueBuilder<T>)? updates]) =>
+      (new BoundNullableGenericValueBuilder<T>()..update(updates))._build();
+
+  _$BoundNullableGenericValue._({required this.value}) : super._() {
+    if (T == dynamic) {
+      throw new BuiltValueMissingGenericsError(
+          'BoundNullableGenericValue', 'T');
+    }
+  }
+
+  @override
+  BoundNullableGenericValue<T> rebuild(
+          void Function(BoundNullableGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BoundNullableGenericValueBuilder<T> toBuilder() =>
+      new BoundNullableGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BoundNullableGenericValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, value.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('BoundNullableGenericValue')
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class BoundNullableGenericValueBuilder<T extends num?>
+    implements
+        Builder<BoundNullableGenericValue<T>,
+            BoundNullableGenericValueBuilder<T>> {
+  _$BoundNullableGenericValue<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  BoundNullableGenericValueBuilder();
+
+  BoundNullableGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BoundNullableGenericValue<T> other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BoundNullableGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(BoundNullableGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BoundNullableGenericValue<T> build() => _build();
+
+  _$BoundNullableGenericValue<T> _build() {
+    final _$result = _$v ??
+        new _$BoundNullableGenericValue<T>._(
+            value: null is T
+                ? value as T
+                : BuiltValueNullFieldError.checkNotNull(
+                    value, 'BoundNullableGenericValue', 'value'));
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/test/generics_nnbd_test.dart
+++ b/end_to_end_test/test/generics_nnbd_test.dart
@@ -67,6 +67,20 @@ void main() {
     });
   });
 
+  group('BoundNullableGenericValue', () {
+    test('can be instantiated', () {
+      BoundNullableGenericValue<int>((b) => b.value = 3);
+      BoundNullableGenericValue<int?>();
+      BoundNullableGenericValue<int?>((b) => b.value = null);
+      BoundNullableGenericValue<int?>((b) => b.value = 3);
+    });
+
+    test('throws on null for non-nullable fields on build', () {
+      expect(() => BoundNullableGenericValue<int>(),
+          throwsA(const TypeMatcher<BuiltValueNullFieldError>()));
+    });
+  });
+
   group('GenericFunction', () {
     test('can be compared', () {
       // Generic functions have troublesome behaviour when casting. Check that


### PR DESCRIPTION
Currently, the library doesn't support optional generic bounds. The optionality of the bounds is simply dropped, resulting in a built value that behaves differently than its abstract class.

The following code

```dart
abstract class Box<T extends Content?> implements Built<Box<T>, BoxBuilder<T>> {
   ...
}
```

results in the generation of

```dart
class _$Box<T extends Content> extends BoxValue<T> {
   ...
}

class BoxBuilder<T extends Content> implements Builder<Box<T>, BoxBuilder<T>> {
    ....
}
```

The correct behavior would be the retention of the question mark (`T extends Content?`). This pull request resolves this issue.