### PR TITLE
Fix erroneously generated null check for fields with generic bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix erroneously generated null check for fields with generic bounds.
+
 # 8.3.2
 
 - Migrate `built_value_test` to null safety.

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -1099,16 +1099,16 @@ abstract class ValueSourceClass
     result.writeln('new $implName$_generics._(');
     result.write(fieldBuilders.keys.map((field) {
       if (needsNullCheck.contains(field)) {
+        if (genericFields.containsKey(field)) {
+         final genericType = genericFields[field];
+          return '$field: null is $genericType ? $field as $genericType : '
+              'BuiltValueNullFieldError.checkNotNull(${fieldBuilders[field]}, '
+              "r'$name', '${escapeString(field)}')";
+        }
         return '$field: BuiltValueNullFieldError.checkNotNull('
             "${fieldBuilders[field]}, r'$name', '${escapeString(field)}')";
-      } else if (genericFields.containsKey(field)) {
-        final genericType = genericFields[field];
-        return '$field: null is $genericType ? $field as $genericType : '
-            'BuiltValueNullFieldError.checkNotNull(${fieldBuilders[field]}, '
-            "r'$name', '${escapeString(field)}')";
-      } else {
-        return '$field: ${fieldBuilders[field]}';
       }
+      return '$field: ${fieldBuilders[field]}';
     }).join(','));
     result.writeln(');');
 

--- a/end_to_end_test/lib/generics_nnbd.dart
+++ b/end_to_end_test/lib/generics_nnbd.dart
@@ -47,6 +47,7 @@ abstract class BoundGenericValue<T extends num>
       _$boundGenericValueSerializer;
 
   T get value;
+  T? get nullableValue;
 
   factory BoundGenericValue([Function(BoundGenericValueBuilder<T>) updates]) =
       _$BoundGenericValue<T>;

--- a/end_to_end_test/lib/generics_nnbd.g.dart
+++ b/end_to_end_test/lib/generics_nnbd.g.dart
@@ -109,7 +109,13 @@ class _$BoundGenericValueSerializer
       'value',
       serializers.serialize(object.value, specifiedType: parameterT),
     ];
-
+    Object? value;
+    value = object.nullableValue;
+    if (value != null) {
+      result
+        ..add('nullableValue')
+        ..add(serializers.serialize(value, specifiedType: parameterT));
+    }
     return result;
   }
 
@@ -137,6 +143,10 @@ class _$BoundGenericValueSerializer
         case 'value':
           result.value =
               serializers.deserialize(value, specifiedType: parameterT)! as num;
+          break;
+        case 'nullableValue':
+          result.nullableValue =
+              serializers.deserialize(value, specifiedType: parameterT) as num?;
           break;
       }
     }
@@ -798,12 +808,14 @@ class InitializeGenericValueBuilder<T>
 class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
   @override
   final T value;
+  @override
+  final T? nullableValue;
 
   factory _$BoundGenericValue(
           [void Function(BoundGenericValueBuilder<T>)? updates]) =>
       (new BoundGenericValueBuilder<T>()..update(updates))._build();
 
-  _$BoundGenericValue._({required this.value}) : super._() {
+  _$BoundGenericValue._({required this.value, this.nullableValue}) : super._() {
     BuiltValueNullFieldError.checkNotNull(value, r'BoundGenericValue', 'value');
     if (T == dynamic) {
       throw new BuiltValueMissingGenericsError(r'BoundGenericValue', 'T');
@@ -822,18 +834,21 @@ class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is BoundGenericValue && value == other.value;
+    return other is BoundGenericValue &&
+        value == other.value &&
+        nullableValue == other.nullableValue;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(0, value.hashCode));
+    return $jf($jc($jc(0, value.hashCode), nullableValue.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'BoundGenericValue')
-          ..add('value', value))
+          ..add('value', value)
+          ..add('nullableValue', nullableValue))
         .toString();
   }
 }
@@ -846,12 +861,17 @@ class BoundGenericValueBuilder<T extends num>
   T? get value => _$this._value;
   set value(T? value) => _$this._value = value;
 
+  T? _nullableValue;
+  T? get nullableValue => _$this._nullableValue;
+  set nullableValue(T? nullableValue) => _$this._nullableValue = nullableValue;
+
   BoundGenericValueBuilder();
 
   BoundGenericValueBuilder<T> get _$this {
     final $v = _$v;
     if ($v != null) {
       _value = $v.value;
+      _nullableValue = $v.nullableValue;
       _$v = null;
     }
     return this;
@@ -875,7 +895,8 @@ class BoundGenericValueBuilder<T extends num>
     final _$result = _$v ??
         new _$BoundGenericValue<T>._(
             value: BuiltValueNullFieldError.checkNotNull(
-                value, r'BoundGenericValue', 'value'));
+                value, r'BoundGenericValue', 'value'),
+            nullableValue: nullableValue);
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/test/generics_nnbd_test.dart
+++ b/end_to_end_test/test/generics_nnbd_test.dart
@@ -64,6 +64,9 @@ void main() {
   group('BoundGenericValue', () {
     test('can be instantiated', () {
       BoundGenericValue<int>((b) => b.value = 0);
+      BoundGenericValue<int>((b) => b
+        ..value = 0
+        ..nullableValue = 1);
     });
   });
 


### PR DESCRIPTION
The current implementation generates a null check for all fields with generic bounds, even if they have been declared as nullable. This fix resolved this issue.