### PR TITLE
Fix nested builder bug in custom builders, and allow define abstract getters/setters in custom builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 8.4.0
+
+- Allow abstract getters and setters in custom builders (necessary to use autocreated nested builders in custom builders).
+
 # 8.3.3
 
 - Fix erroneously generated null check for fields with generic bounds.

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark
-version: 8.3.3
+version: 8.4.0
 publish_to: none
 description: >
   Benchmark, not for publishing.
@@ -10,11 +10,11 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.0
+  built_value: ^8.4.0
 
 dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
-  built_value_generator: ^8.3.3
+  built_value_generator: ^8.4.0
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0

--- a/built_value/pubspec.yaml
+++ b/built_value/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value
-version: 8.3.3
+version: 8.4.0
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the runtime dependency.

--- a/built_value_analyzer_plugin/pubspec.yaml
+++ b/built_value_analyzer_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_analyzer_plugin
-version: 8.3.3
+version: 8.4.0
 description: >
   Experimental analyzer plugin for the built_value code generator.
 homepage: https://github.com/google/built_value.dart

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -30,6 +30,8 @@ class _$ValueSourceField extends ValueSourceField {
   bool? __builderFieldExists;
   bool? __builderFieldIsNormalField;
   bool? __builderFieldIsGetterSetterPair;
+  bool? __builderFieldIsAbstract;
+  String? ___fullBuildElementType;
   String? __buildElementType;
   String? __builderElementTypeWithPrefix;
   bool? __isNestedBuilder;
@@ -104,6 +106,14 @@ class _$ValueSourceField extends ValueSourceField {
   @override
   bool get builderFieldIsGetterSetterPair =>
       __builderFieldIsGetterSetterPair ??= super.builderFieldIsGetterSetterPair;
+
+  @override
+  bool get builderFieldIsAbstract =>
+      __builderFieldIsAbstract ??= super.builderFieldIsAbstract;
+
+  @override
+  String get _fullBuildElementType =>
+      ___fullBuildElementType ??= super._fullBuildElementType;
 
   @override
   String get buildElementType => __buildElementType ??= super.buildElementType;

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_generator
-version: 8.3.3
+version: 8.4.0
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the dev dependency.
@@ -13,7 +13,7 @@ dependencies:
   build: '>=1.0.0 <3.0.0'
   build_config: '>=0.3.1 <2.0.0'
   built_collection: ^5.0.0
-  built_value: '>=8.1.0 <8.4.0'
+  built_value: ^8.4.0
   collection: ^1.15.0
   source_gen: '>=0.9.0 <2.0.0'
   quiver: '>=0.21.0 <4.0.0'

--- a/built_value_generator/test/built_value_generator_test.dart
+++ b/built_value_generator/test/built_value_generator_test.dart
@@ -636,7 +636,8 @@ abstract class Value implements Built<Value, ValueBuilder> {
 }'''), contains('1. Make field _foo public; remove the underscore.'));
       });
 
-      test('builder fields must be normal fields', () async {
+      test('builder fields must be normal fields or getter/setter pairs',
+          () async {
         expect(
             await generate('''library value;
 import 'package:built_value/built_value.dart';
@@ -653,6 +654,26 @@ abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
 }'''),
             contains('1. Make builder field foo a normal field or a '
                 'getter/setter pair.'));
+      });
+
+      test('builder field getter/setter pairs must both be abstract or defined',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  int get foo;
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  int get foo;
+  set foo(int value) {
+    print('hi');
+  }
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Explicit getter/setter pair must both be defined.'));
       });
 
       test('builder fields must be in sync', () async {

--- a/built_value_generator/tools/analyzer_plugin/pubspec.yaml
+++ b/built_value_generator/tools/analyzer_plugin/pubspec.yaml
@@ -1,8 +1,8 @@
 name: built_value_analyzer_plugin_loader
-version: 8.3.3
+version: 8.4.0
 description: This pubspec determines the version of the analyzer plugin to load.
 environment:
-  sdk: '>=1.24.0-dev.1.0'
+  sdk: '>=2.14.0 <3.0.0'
 dependencies:
-  built_value_analyzer_plugin: ^8.3.3
-  built_value_generator: ^8.3.3
+  built_value_analyzer_plugin: ^8.4.0
+  built_value_generator: ^8.4.0

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_test
-version: 8.3.3
+version: 8.4.0
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library provides test support.
@@ -9,14 +9,14 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  built_value: ^8.0.0
+  built_value: ^8.4.0
   built_collection: ^5.0.0
   collection: ^1.0.0
   matcher: ^0.12.0
   quiver: '>=0.21.0 <4.0.0'
 
 dev_dependencies:
-  built_value_generator: ^8.3.3
+  built_value_generator: ^8.4.0
   build_runner: '>=1.0.0 <3.0.0'
   pedantic: ^1.4.0
   test: ^1.0.0

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chat_example
-version: 8.3.3
+version: 8.4.0
 publish_to: none
 description: >
   Just an example, not for publishing.
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.0
+  built_value: ^8.4.0
   shelf: ^1.0.0
   shelf_proxy: ^1.0.0
   shelf_web_socket: ^1.0.0
@@ -20,6 +20,6 @@ dev_dependencies:
   build_runner: any
   build_test: any
   build_web_compilers: any
-  built_value_generator: ^8.3.3
+  built_value_generator: ^8.4.0
   pedantic: ^1.4.0
   test: ^1.0.0

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -4881,10 +4881,10 @@ class ValueWithOnSetBuilder
     implements Builder<ValueWithOnSet, ValueWithOnSetBuilder> {
   _$ValueWithOnSet _$v;
 
-  void Function() onSet = () {};
-
   int _value;
   int get value => _$this._value;
+  void Function() onSet = () {};
+
   set value(int value) {
     _$this._value = value;
     onSet();

--- a/end_to_end_test/lib/values_nnbd.dart
+++ b/end_to_end_test/lib/values_nnbd.dart
@@ -233,6 +233,30 @@ abstract class ExplicitNestedListBuilder
   ExplicitNestedListBuilder._();
 }
 
+abstract class ExplicitNonNullBuilderNullableSetter
+    implements
+        Built<ExplicitNonNullBuilderNullableSetter,
+            ExplicitNonNullBuilderNullableSetterBuilder> {
+  SimpleValue? get simpleValue;
+
+  factory ExplicitNonNullBuilderNullableSetter(
+      [void Function(ExplicitNonNullBuilderNullableSetterBuilder)
+          updates]) = _$ExplicitNonNullBuilderNullableSetter;
+  ExplicitNonNullBuilderNullableSetter._();
+}
+
+abstract class ExplicitNonNullBuilderNullableSetterBuilder
+    implements
+        Builder<ExplicitNonNullBuilderNullableSetter,
+            ExplicitNonNullBuilderNullableSetterBuilder> {
+  SimpleValueBuilder get simpleValue;
+  set simpleValue(SimpleValueBuilder? value);
+
+  factory ExplicitNonNullBuilderNullableSetterBuilder() =
+      _$ExplicitNonNullBuilderNullableSetterBuilder;
+  ExplicitNonNullBuilderNullableSetterBuilder._();
+}
+
 abstract class DerivedValue
     implements Built<DerivedValue, DerivedValueBuilder> {
   int get anInt;

--- a/end_to_end_test/lib/values_nnbd.g.dart
+++ b/end_to_end_test/lib/values_nnbd.g.dart
@@ -3062,6 +3062,115 @@ class _$ExplicitNestedListBuilder extends ExplicitNestedListBuilder {
   }
 }
 
+class _$ExplicitNonNullBuilderNullableSetter
+    extends ExplicitNonNullBuilderNullableSetter {
+  @override
+  final SimpleValue? simpleValue;
+
+  factory _$ExplicitNonNullBuilderNullableSetter(
+          [void Function(ExplicitNonNullBuilderNullableSetterBuilder)?
+              updates]) =>
+      (new ExplicitNonNullBuilderNullableSetterBuilder()..update(updates))
+          .build() as _$ExplicitNonNullBuilderNullableSetter;
+
+  _$ExplicitNonNullBuilderNullableSetter._({this.simpleValue}) : super._();
+
+  @override
+  ExplicitNonNullBuilderNullableSetter rebuild(
+          void Function(ExplicitNonNullBuilderNullableSetterBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$ExplicitNonNullBuilderNullableSetterBuilder toBuilder() =>
+      new _$ExplicitNonNullBuilderNullableSetterBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ExplicitNonNullBuilderNullableSetter &&
+        simpleValue == other.simpleValue;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, simpleValue.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ExplicitNonNullBuilderNullableSetter')
+          ..add('simpleValue', simpleValue))
+        .toString();
+  }
+}
+
+class _$ExplicitNonNullBuilderNullableSetterBuilder
+    extends ExplicitNonNullBuilderNullableSetterBuilder {
+  _$ExplicitNonNullBuilderNullableSetter? _$v;
+
+  SimpleValueBuilder? _simpleValue;
+  @override
+  SimpleValueBuilder get simpleValue {
+    _$this;
+    return _simpleValue ??= new SimpleValueBuilder();
+  }
+
+  @override
+  set simpleValue(SimpleValueBuilder? simpleValue) {
+    _$this;
+    _simpleValue = simpleValue;
+  }
+
+  _$ExplicitNonNullBuilderNullableSetterBuilder() : super._();
+
+  ExplicitNonNullBuilderNullableSetterBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ExplicitNonNullBuilderNullableSetter other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ExplicitNonNullBuilderNullableSetter;
+  }
+
+  @override
+  void update(
+      void Function(ExplicitNonNullBuilderNullableSetterBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ExplicitNonNullBuilderNullableSetter build() => _build();
+
+  _$ExplicitNonNullBuilderNullableSetter _build() {
+    _$ExplicitNonNullBuilderNullableSetter _$result;
+    try {
+      _$result = _$v ??
+          new _$ExplicitNonNullBuilderNullableSetter._(
+              simpleValue: _simpleValue?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        _simpleValue?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'ExplicitNonNullBuilderNullableSetter',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 class _$DerivedValue extends DerivedValue {
   @override
   final int anInt;
@@ -5112,10 +5221,10 @@ class ValueWithOnSetBuilder
     implements Builder<ValueWithOnSet, ValueWithOnSetBuilder> {
   _$ValueWithOnSet? _$v;
 
-  void Function() onSet = () {};
-
   int? _value;
   int? get value => _$this._value;
+  void Function() onSet = () {};
+
   set value(int? value) {
     _$this._value = value;
     onSet();

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: end_to_end_test
-version: 8.3.3
+version: 8.4.0
 publish_to: none
 description: >
   Tests, not for publishing.
@@ -10,12 +10,12 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.0
+  built_value: ^8.4.0
 
 dev_dependencies:
   build: '>=1.0.0 < 3.0.0'
   build_runner: ^1.0.0
-  built_value_generator: ^8.3.3
+  built_value_generator: ^8.4.0
   fixnum: ^1.0.0
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'

--- a/end_to_end_test/test/values_nnbd_test.dart
+++ b/end_to_end_test/test/values_nnbd_test.dart
@@ -256,6 +256,30 @@ void main() {
     });
   });
 
+  group('ExplicitNonNullBuilderNullableSetter', () {
+    final simpleValue = SimpleValue((b) => b.anInt = 1);
+
+    test('defaults the value to null', () {
+      expect(ExplicitNonNullBuilderNullableSetter().simpleValue, isNull);
+    });
+
+    test('allows setting the value', () {
+      final value = ExplicitNonNullBuilderNullableSetter(
+          (b) => b.simpleValue.replace(simpleValue));
+
+      expect(value.simpleValue, equals(simpleValue));
+    });
+
+    test('allows setting the value to null', () {
+      var value = ExplicitNonNullBuilderNullableSetter(
+          (b) => b.simpleValue.replace(simpleValue));
+
+      value = value.rebuild((b) => b.simpleValue = null);
+
+      expect(value.simpleValue, isNull);
+    });
+  });
+
   group('DerivedValue', () {
     test('caches derivedValue', () {
       final value = DerivedValue((b) => b..anInt = 7);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.0
+  built_value: ^8.4.0
 
 dev_dependencies:
   build_runner: ^1.0.0
-  built_value_generator: ^8.3.3
+  built_value_generator: ^8.4.0
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0


### PR DESCRIPTION
Fixes #1173.

Previously, getters and setters could only be explicitly defined. This made sense for pre-null-safety, since there wasn't any reason to create a getter/setter pair over a normal field. However, with null safety, there was no way to use custom builders that had nested builders.

This fixes the bug where nested builders couldn't be used in custom builders, as well as allows the definition of abstract getters and setters such that auto created nested builders can also be utilized without needing null checks (by defining a setter with a nullable parameter).