### PR TITLE
Prepare for separating ClassElement, EnumElement, and MixinElement.

### DIFF
--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -20,10 +20,10 @@ part 'enum_source_class.g.dart';
 
 abstract class EnumSourceClass
     implements Built<EnumSourceClass, EnumSourceClassBuilder> {
-  ClassElement get element;
+  InterfaceElement get element;
 
   factory EnumSourceClass(
-          ParsedLibraryResult parsedLibrary, ClassElement element) =>
+          ParsedLibraryResult parsedLibrary, InterfaceElement element) =>
       _$EnumSourceClass._(element: element);
   EnumSourceClass._();
 
@@ -50,7 +50,10 @@ abstract class EnumSourceClass
   }
 
   @memoized
-  bool get isAbstract => element.isAbstract;
+  bool get isAbstract {
+    final element = this.element;
+    return element is ClassElement && element.isAbstract;
+  }
 
   @memoized
   BuiltList<EnumSourceField> get fields =>

--- a/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_value_generator/lib/src/enum_source_class.g.dart
@@ -8,7 +8,7 @@ part of built_value_generator.enum_source_class;
 
 class _$EnumSourceClass extends EnumSourceClass {
   @override
-  final ClassElement element;
+  final InterfaceElement element;
   ParsedLibraryResult? __parsedLibrary;
   String? __name;
   String? __wireName;
@@ -119,9 +119,9 @@ class EnumSourceClassBuilder
     implements Builder<EnumSourceClass, EnumSourceClassBuilder> {
   _$EnumSourceClass? _$v;
 
-  ClassElement? _element;
-  ClassElement? get element => _$this._element;
-  set element(ClassElement? element) => _$this._element = element;
+  InterfaceElement? _element;
+  InterfaceElement? get element => _$this._element;
+  set element(InterfaceElement? element) => _$this._element = element;
 
   EnumSourceClassBuilder();
 

--- a/built_value_generator/lib/src/enum_source_field.dart
+++ b/built_value_generator/lib/src/enum_source_field.dart
@@ -61,7 +61,7 @@ abstract class EnumSourceField
   bool get isStatic => element.isStatic;
 
   static BuiltList<EnumSourceField> fromClassElement(
-      ParsedLibraryResult parsedLibrary, ClassElement classElement) {
+      ParsedLibraryResult parsedLibrary, InterfaceElement classElement) {
     var result = ListBuilder<EnumSourceField>();
 
     var enumName = classElement.displayName;

--- a/built_value_generator/lib/src/fields.dart
+++ b/built_value_generator/lib/src/fields.dart
@@ -13,7 +13,7 @@ import 'package:built_collection/built_collection.dart';
 ///
 /// If a field is overridden then just the closest (overriding) field is
 /// returned.
-BuiltList<FieldElement> collectFields(ClassElement element) =>
+BuiltList<FieldElement> collectFields(InterfaceElement element) =>
     collectFieldsForType(element.thisType);
 
 /// Gets fields, including from interfaces. Fields from interfaces are only

--- a/built_value_generator/lib/src/memoized_getter.dart
+++ b/built_value_generator/lib/src/memoized_getter.dart
@@ -21,7 +21,8 @@ abstract class MemoizedGetter
 
   bool get isNullable => nullabilitySuffix == NullabilitySuffix.question;
 
-  static Iterable<MemoizedGetter> fromClassElement(ClassElement classElement) {
+  static Iterable<MemoizedGetter> fromClassElement(
+      InterfaceElement classElement) {
     return classElement.fields
         .where((field) =>
             field.getter != null &&

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -23,11 +23,11 @@ part 'serializer_source_class.g.dart';
 
 abstract class SerializerSourceClass
     implements Built<SerializerSourceClass, SerializerSourceClassBuilder> {
-  ClassElement get element;
+  InterfaceElement get element;
 
   ClassElement? get builderElement;
 
-  factory SerializerSourceClass(ClassElement element) =>
+  factory SerializerSourceClass(InterfaceElement element) =>
       _$SerializerSourceClass._(
           element: element,
           builderElement:

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -8,7 +8,7 @@ part of built_value_generator.source_class;
 
 class _$SerializerSourceClass extends SerializerSourceClass {
   @override
-  final ClassElement element;
+  final InterfaceElement element;
   @override
   final ClassElement? builderElement;
   ParsedLibraryResult? __parsedLibrary;
@@ -167,9 +167,9 @@ class SerializerSourceClassBuilder
     implements Builder<SerializerSourceClass, SerializerSourceClassBuilder> {
   _$SerializerSourceClass? _$v;
 
-  ClassElement? _element;
-  ClassElement? get element => _$this._element;
-  set element(ClassElement? element) => _$this._element = element;
+  InterfaceElement? _element;
+  InterfaceElement? get element => _$this._element;
+  set element(InterfaceElement? element) => _$this._element = element;
 
   ClassElement? _builderElement;
   ClassElement? get builderElement => _$this._builderElement;

--- a/built_value_generator/lib/src/serializer_source_library.dart
+++ b/built_value_generator/lib/src/serializer_source_library.dart
@@ -121,8 +121,8 @@ abstract class SerializerSourceLibrary
 
       result.addValues(
           field,
-          types.map(
-              (type) => SerializerSourceClass(type!.element2 as ClassElement)));
+          types.map((type) =>
+              SerializerSourceClass(type!.element2 as InterfaceElement)));
     }
     return result.build();
   }

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -31,9 +31,9 @@ const String _importWithDoubleQuotes =
 
 abstract class ValueSourceClass
     implements Built<ValueSourceClass, ValueSourceClassBuilder> {
-  ClassElement get element;
+  InterfaceElement get element;
 
-  factory ValueSourceClass(ClassElement element) =>
+  factory ValueSourceClass(InterfaceElement element) =>
       _$ValueSourceClass._(element: element);
   ValueSourceClass._();
 
@@ -262,7 +262,10 @@ abstract class ValueSourceClass
   }
 
   @memoized
-  bool get valueClassIsAbstract => element.isAbstract;
+  bool get valueClassIsAbstract {
+    final element = this.element;
+    return element is ClassElement && element.isAbstract;
+  }
 
   @memoized
   BuiltList<ConstructorDeclaration> get valueClassConstructors =>

--- a/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_value_generator/lib/src/value_source_class.g.dart
@@ -8,7 +8,7 @@ part of built_value_generator.source_class;
 
 class _$ValueSourceClass extends ValueSourceClass {
   @override
-  final ClassElement element;
+  final InterfaceElement element;
   ParsedLibraryResult? __parsedLibrary;
   String? __name;
   bool? __isNonNullByDefault;
@@ -259,9 +259,9 @@ class ValueSourceClassBuilder
     implements Builder<ValueSourceClass, ValueSourceClassBuilder> {
   _$ValueSourceClass? _$v;
 
-  ClassElement? _element;
-  ClassElement? get element => _$this._element;
-  set element(ClassElement? element) => _$this._element = element;
+  InterfaceElement? _element;
+  InterfaceElement? get element => _$this._element;
+  set element(InterfaceElement? element) => _$this._element = element;
 
   ValueSourceClassBuilder();
 

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -286,7 +286,7 @@ abstract class ValueSourceField
   static BuiltList<ValueSourceField> fromClassElements(
       BuiltValue settings,
       ParsedLibraryResult parsedLibrary,
-      ClassElement classElement,
+      InterfaceElement classElement,
       ClassElement? builderClassElement) {
     var result = ListBuilder<ValueSourceField>();
 


### PR DESCRIPTION
All three implement InterfaceElement, but in the breaking change for analyzer we will stop implementing ClassElement in EnumElement and MixinElement. This is a minimal change necessary to make google3 green, the might be need for more changes that are not exercised there.