### PR TITLE
Upgrade to analyzer 5.1.0

### DIFF
--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=4.6.0 <5.0.0'
-  build: '>=1.0.0 <3.0.0'
+  analyzer: '>=5.1.0 <6.0.0'
+  build: '>=2.3.1 <3.0.0'
   build_config: '>=0.3.1 <2.0.0'
   built_collection: ^5.0.0
   built_value: '>=8.1.0 <8.5.0'
@@ -19,7 +19,7 @@ dependencies:
   quiver: '>=0.21.0 <4.0.0'
 
 dev_dependencies:
-  build_test: '>=1.2.0 <3.0.0'
+  build_test: '>=2.1.5 <3.0.0'
   build_runner: '>=1.0.0 <3.0.0'
   pedantic: ^1.4.0
   test: ^1.0.0


### PR DESCRIPTION
Hello,
This PR upgrades a couple of dependencies including analyzer to 5.1.0.

Closes https://github.com/google/built_value.dart/issues/1188