### PR TITLE
add github actions support

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+# Dependabot configuration file.
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  schedule:
+    # “At 00:00 (UTC) on Sunday.”
+    - cron: '0 0 * * 0'
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [2.12.0, dev]
+
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+
+      - name: Run Presubmits
+        run: tool/presubmit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-
-language: dart
-dart: dev
-script:
-  - tool/presubmit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Built Values for Dart
-[![Build Status](https://travis-ci.org/google/built_value.dart.svg?branch=master)](https://travis-ci.org/google/built_value.dart)
-## Introduction
+![Build Status](https://github.com/google/built_value.dart/workflows/Dart/badge.svg)](https://github.com/google/built_value.dart/actions)
+
+## Built Values for Dart - Introduction
 
 Built Value provides:
 


### PR DESCRIPTION
- add github actions support
- add a CI status badge to the readme
- configure dependabot in order to keep the github action versions up-to-date
- remove the older travis configuration file

cc @davidmorgan 