### PR TITLE
Bump analyzer version, stop using deprecated methods. Release 8.4.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-# 8.4.2 (unpublished)
+# 8.4.2
 
 - Prepare for breaking analyzer changes.
+- Bump version of `analyzer`.
 
 # 8.4.1
 

--- a/built_value_generator/lib/src/dart_types.dart
+++ b/built_value_generator/lib/src/dart_types.dart
@@ -23,13 +23,13 @@ class DartTypes {
 
   static bool isInstantiableBuiltValue(DartType type) {
     return isBuiltValue(type) &&
-        ValueSourceClass(type.element2 as ClassElement).settings.instantiable;
+        ValueSourceClass(type.element as ClassElement).settings.instantiable;
   }
 
   static bool isBuiltValue(DartType type) =>
       type is InterfaceType &&
-      type.element2.allSupertypes
-          .any((interfaceType) => interfaceType.element2.name == 'Built');
+      type.element.allSupertypes
+          .any((interfaceType) => interfaceType.element.name == 'Built');
 
   static bool isBuiltCollection(DartType type) {
     return _builtCollectionNames
@@ -72,15 +72,15 @@ class DartTypes {
     } else if (dartType is InterfaceType) {
       var typeArguments = dartType.typeArguments;
       if (typeArguments.isEmpty) {
-        return dartType.element2.name + suffix;
+        return dartType.element.name + suffix;
       } else {
         final typeArgumentsStr = typeArguments
             .map((type) => getName(type, withNullabilitySuffix: true))
             .join(', ');
-        return '${dartType.element2.name}<$typeArgumentsStr>$suffix';
+        return '${dartType.element.name}<$typeArgumentsStr>$suffix';
       }
     } else if (dartType is TypeParameterType) {
-      return dartType.element2.name + suffix;
+      return dartType.element.name + suffix;
     } else if (dartType.isVoid) {
       return 'void';
     } else {

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -143,7 +143,7 @@ abstract class SerializerSourceClass
   @memoized
   bool get isBuiltValue =>
       element.allSupertypes
-          .map((type) => type.element2.name)
+          .map((type) => type.element.name)
           .any((name) => name.startsWith('Built')) &&
       !element.name.startsWith(r'_$') &&
       element.fields.any((field) => field.name == 'serializer');
@@ -152,7 +152,7 @@ abstract class SerializerSourceClass
   @memoized
   bool get isEnumClass =>
       element.allSupertypes
-          .map((type) => type.element2.name)
+          .map((type) => type.element.name)
           .any((name) => name == 'EnumClass') &&
       !element.name.startsWith(r'_$') &&
       element.fields.any((field) => field.name == 'serializer');
@@ -193,7 +193,7 @@ abstract class SerializerSourceClass
       if (fieldElement.setter != null) continue;
 
       final fieldType = fieldElement.type;
-      final fieldTypeElement = fieldType.element2;
+      final fieldTypeElement = fieldType.element;
 
       // Type is not fully specified, ignore.
       if (fieldTypeElement is! ClassElement) continue;
@@ -202,7 +202,7 @@ abstract class SerializerSourceClass
       // of type List<Foo> means we need to be able to serialize Foo.
       if (fieldType is ParameterizedType) {
         for (final type in fieldType.typeArguments) {
-          final typeElement = type.element2;
+          final typeElement = type.element;
 
           // Type is not fully specified, ignore.
           if (typeElement is! ClassElement) continue;

--- a/built_value_generator/lib/src/serializer_source_library.dart
+++ b/built_value_generator/lib/src/serializer_source_library.dart
@@ -122,7 +122,7 @@ abstract class SerializerSourceLibrary
       result.addValues(
           field,
           types.map((type) =>
-              SerializerSourceClass(type!.element2 as InterfaceElement)));
+              SerializerSourceClass(type!.element as InterfaceElement)));
     }
     return result.build();
   }

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -75,7 +75,7 @@ abstract class ValueSourceClass
 
   @memoized
   bool get implementsBuilt => element.allSupertypes
-      .any((interfaceType) => interfaceType.element2.name == 'Built');
+      .any((interfaceType) => interfaceType.element.name == 'Built');
 
   @memoized
   bool get extendsIsAllowed {
@@ -93,18 +93,18 @@ abstract class ValueSourceClass
 
     for (var supertype in [
       element.supertype,
-      ...element.supertype!.element2.allSupertypes
+      ...element.supertype!.element.allSupertypes
     ]) {
       if (DartTypes.tryGetName(supertype) == 'Object') continue;
 
       // Base class must be abstract.
-      final superElement = supertype!.element2;
+      final superElement = supertype!.element;
       if (superElement is! ClassElement || !superElement.isAbstract) {
         return false;
       }
 
       // Base class must have no fields.
-      if (supertype.element2.fields
+      if (supertype.element.fields
           .any((field) => !field.isStatic && !field.isSynthetic)) {
         return false;
       }
@@ -116,9 +116,9 @@ abstract class ValueSourceClass
       }
 
       // Base class must not implement operator==, hashCode or toString.
-      if (supertype.element2.getMethod('hashCode') != null) return false;
-      if (supertype.element2.getMethod('==') != null) return false;
-      if (supertype.element2.getMethod('toString') != null) return false;
+      if (supertype.element.getMethod('hashCode') != null) return false;
+      if (supertype.element.getMethod('==') != null) return false;
+      if (supertype.element.getMethod('toString') != null) return false;
     }
 
     return true;
@@ -216,7 +216,7 @@ abstract class ValueSourceClass
   @memoized
   String get builderParameters {
     return builderElement!.allSupertypes
-        .where((interfaceType) => interfaceType.element2.name == 'Builder')
+        .where((interfaceType) => interfaceType.element.name == 'Builder')
         .single
         .typeArguments
         .map((type) => DartTypes.getName(type))
@@ -316,7 +316,7 @@ abstract class ValueSourceClass
   BuiltList<String> get builderImplements => BuiltList<String>.build((b) => b
     ..add('Builder<$name$_generics, ${name}Builder$_generics>')
     ..addAll(element.interfaces
-        .where((interface) => needsBuiltValue(interface.element2))
+        .where((interface) => needsBuiltValue(interface.element))
         .map(_parentBuilderInterfaceName)));
 
   /// Returns the `with` clause for the builder.
@@ -325,7 +325,7 @@ abstract class ValueSourceClass
   /// the corresponding builders.
   @memoized
   BuiltList<String> get builderMixins => element.mixins
-      .where((interface) => needsBuiltValue(interface.element2))
+      .where((interface) => needsBuiltValue(interface.element))
       .map(_parentBuilderInterfaceName)
       .toBuiltList();
 
@@ -364,7 +364,7 @@ abstract class ValueSourceClass
     // Check for any `toString` implementation apart from the one defined on
     // `Object`.
     var method = element.lookUpConcreteMethod('toString', element.library)!;
-    var clazz = method.enclosingElement3;
+    var clazz = method.enclosingElement;
     return clazz is! ClassElement || clazz.name != 'Object';
   }
 
@@ -376,7 +376,7 @@ abstract class ValueSourceClass
     // TODO(davidmorgan): more exact type check.
     return !classElement.displayName.startsWith('_\$') &&
         (classElement.allSupertypes.any(
-                (interfaceType) => interfaceType.element2.name == 'Built') ||
+                (interfaceType) => interfaceType.element.name == 'Built') ||
             classElement.metadata
                 .map((annotation) => annotation.computeConstantValue())
                 .any((value) =>
@@ -1077,7 +1077,7 @@ abstract class ValueSourceClass
         }
         if (field.hasNullableGenericType) {
           genericFields[name] =
-              field.element.getter!.returnType.element2!.displayName;
+              field.element.getter!.returnType.element!.displayName;
         }
       } else if (!field.isNullable && field.isAutoCreateNestedBuilder) {
         // If not nullable, go via the public accessor, which instantiates

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=4.6.0 <5.0.0'
+  analyzer: '>=4.6.0 <6.0.0'
   build: '>=1.0.0 <3.0.0'
   build_config: '>=0.3.1 <2.0.0'
   built_collection: ^5.0.0


### PR DESCRIPTION
Fix #1188