### PR TITLE
Drop dependency on quiver

### DIFF
--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -14,7 +14,6 @@ import 'package:built_value_generator/src/enum_source_field.dart';
 import 'package:built_value_generator/src/strings.dart';
 import 'package:collection/collection.dart'
     show IterableExtension, IterableNullableExtension;
-import 'package:quiver/iterables.dart';
 
 part 'enum_source_class.g.dart';
 
@@ -102,10 +101,11 @@ abstract class EnumSourceClass
 
   @memoized
   Iterable<String> get identifiers {
-    return concat([
-      <String?>[valuesIdentifier, valueOfIdentifier],
-      fields.map<String?>((field) => field.generatedIdentifier)
-    ]).whereNotNull().toList();
+    return [
+      valuesIdentifier,
+      valueOfIdentifier,
+      for (var field in fields) field.generatedIdentifier,
+    ].whereNotNull().toList();
   }
 
   static bool needsEnumClass(ClassElement classElement) {
@@ -114,15 +114,15 @@ abstract class EnumSourceClass
   }
 
   Iterable<String> computeErrors() {
-    return concat([
-      _checkAbstract(),
-      _checkFields(),
-      _checkFallbackFields(),
-      _checkConstructor(),
-      _checkValuesGetter(),
-      _checkValueOf(),
-      _checkMixin(),
-    ]).toList();
+    return [
+      ..._checkAbstract(),
+      ..._checkFields(),
+      ..._checkFallbackFields(),
+      ..._checkConstructor(),
+      ..._checkValuesGetter(),
+      ..._checkValueOf(),
+      ..._checkMixin(),
+    ];
   }
 
   Iterable<String> _checkAbstract() {
@@ -130,7 +130,7 @@ abstract class EnumSourceClass
   }
 
   Iterable<String> _checkFields() {
-    return concat(fields.map((field) => field.errors));
+    return fields.expand((field) => field.errors);
   }
 
   Iterable<String> _checkFallbackFields() {

--- a/built_value_generator/lib/src/enum_source_library.dart
+++ b/built_value_generator/lib/src/enum_source_library.dart
@@ -11,7 +11,6 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/analyzer.dart';
 import 'package:built_value_generator/src/enum_source_class.dart';
 import 'package:built_value_generator/src/library_elements.dart';
-import 'package:quiver/iterables.dart';
 import 'package:source_gen/source_gen.dart';
 
 part 'enum_source_library.g.dart';
@@ -59,11 +58,11 @@ abstract class EnumSourceLibrary
   }
 
   Iterable<String> _computeErrors() {
-    return concat([
-      _checkPart(),
-      _checkIdentifiers(),
-      concat(classes.map((c) => c.computeErrors()))
-    ]);
+    return [
+      ..._checkPart(),
+      ..._checkIdentifiers(),
+      for (var c in classes) ...c.computeErrors(),
+    ];
   }
 
   Iterable<String> _checkPart() {

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -17,7 +17,7 @@ import 'package:built_value_generator/src/memoized_getter.dart';
 import 'package:built_value_generator/src/metadata.dart';
 import 'package:built_value_generator/src/strings.dart';
 import 'package:built_value_generator/src/value_source_field.dart';
-import 'package:quiver/iterables.dart';
+import 'package:collection/collection.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'dart_types.dart';
@@ -384,14 +384,14 @@ abstract class ValueSourceClass
   }
 
   Iterable<GeneratorError> computeErrors() {
-    return concat([
-      _checkPart(),
-      _checkSettings(),
-      _checkValueClass(),
-      _checkBuilderClass(),
-      _checkFieldList(),
-      concat(fields.map((field) => field.computeErrors()))
-    ]);
+    return [
+      ..._checkPart(),
+      ..._checkSettings(),
+      ..._checkValueClass(),
+      ..._checkBuilderClass(),
+      ..._checkFieldList(),
+      for (var field in fields) ...field.computeErrors()
+    ];
   }
 
   Iterable<GeneratorError> _checkPart() {
@@ -719,9 +719,9 @@ abstract class ValueSourceClass
   String get _boundedGenerics => genericParameters.isEmpty
       ? ''
       : '<' +
-          zip(<Iterable>[genericParameters, genericBounds]).map((zipped) {
-            final parameter = zipped[0] as String;
-            final bound = zipped[1] as String;
+          IterableZip([genericParameters, genericBounds]).map((zipped) {
+            final parameter = zipped[0];
+            final bound = zipped[1];
             return bound.isEmpty ? parameter : '$parameter extends $bound';
           }).join(', ') +
           '>';

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_generator
-version: 8.4.2
+version: 8.4.3-dev
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the dev dependency.
@@ -16,7 +16,6 @@ dependencies:
   built_value: '>=8.1.0 <8.5.0'
   collection: ^1.15.0
   source_gen: '>=0.9.0 <2.0.0'
-  quiver: '>=0.21.0 <4.0.0'
 
 dev_dependencies:
   build_test: '>=1.2.0 <3.0.0'


### PR DESCRIPTION
The package had been used for only two utilities, `concat` and `zip`.

Replace `zip` with `IterableZip` from `package:collection` which is also
an existing dependency.

Replace `concat` with either `...` elements in a list literal (since
the collections are always iterated anyway) or by replacing `.map` with
`.expand`.
