### PR TITLE
upgrade analyzer dependency to 5.2.0

### DIFF
--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=4.6.0 <6.0.0'
+  analyzer: '>=5.2.0 <6.0.0'
   build: '>=1.0.0 <3.0.0'
   build_config: '>=0.3.1 <2.0.0'
   built_collection: ^5.0.0


### PR DESCRIPTION
[The `.element` interface was introduced (and `.element2` was deprecated)][1] in the analyzer at version 5.2.0.

Since, migrating over to the `.element` interface at 05da0d3d78, versions [less than 5.2.0 of the analyzer][2] will not work. 

Here, we update the analyzer dependency accordingly.

Resolves, #1203

[1]: https://github.com/dart-lang/sdk/commit/683e2419da03b68074c9c744d9c2566f51c588f5
[2]: https://github.com/google/built_value.dart/blob/v8.4.3/built_value_generator/pubspec.yaml#L12