### PR TITLE
Adds Uint8List serializer

### DIFF
--- a/built_value/lib/serializer.dart
+++ b/built_value/lib/serializer.dart
@@ -73,8 +73,8 @@ abstract class Serializers {
           ..add(NumSerializer())
           ..add(RegExpSerializer())
           ..add(StringSerializer())
-          ..add(UriSerializer())
           ..add(UInt8ListSerializer())
+          ..add(UriSerializer())
           ..addBuilderFactory(const FullType(BuiltList, [FullType.object]),
               () => ListBuilder<Object>())
           ..addBuilderFactory(

--- a/built_value/lib/serializer.dart
+++ b/built_value/lib/serializer.dart
@@ -10,6 +10,7 @@ import 'package:built_value/src/duration_serializer.dart';
 import 'package:built_value/src/int64_serializer.dart';
 import 'package:built_value/src/json_object_serializer.dart';
 import 'package:built_value/src/num_serializer.dart';
+import 'package:built_value/src/uint8list_serializer.dart';
 import 'package:built_value/src/uri_serializer.dart';
 
 import 'src/bool_serializer.dart';
@@ -73,6 +74,7 @@ abstract class Serializers {
           ..add(RegExpSerializer())
           ..add(StringSerializer())
           ..add(UriSerializer())
+          ..add(UInt8ListSerializer())
           ..addBuilderFactory(const FullType(BuiltList, [FullType.object]),
               () => ListBuilder<Object>())
           ..addBuilderFactory(

--- a/built_value/lib/src/uint8list_serializer.dart
+++ b/built_value/lib/src/uint8list_serializer.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/built_value/lib/src/uint8list_serializer.dart
+++ b/built_value/lib/src/uint8list_serializer.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class UInt8ListSerializer implements PrimitiveSerializer<Uint8List> {
+  @override
+  final String wireName = 'UInt8List';
+
+  @override
+  Object serialize(Serializers serializers, Uint8List uint8list,
+      {FullType specifiedType = FullType.unspecified}) {
+    return base64Encode(uint8list).toString();
+  }
+
+  @override
+  Uint8List deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return base64Decode(serialized.toString());
+  }
+
+  @override
+  Iterable<Type> get types => BuiltList<Type>([Uint8List]);
+}

--- a/built_value/test/uint8list_serializer_test.dart
+++ b/built_value/test/uint8list_serializer_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('Uint8List with known specifiedType', () {
+    var serialized =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+    var data = base64Decode(serialized);
+    var specifiedType = const FullType(Uint8List);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('UInt8List with unknown specifiedType', () {
+    var rawData =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+    var serialized = json.decode(json.encode(['UInt8List', rawData])) as Object;
+    var data = base64Decode(rawData.toString());
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      var serialized_by =
+          serializers.serialize(data, specifiedType: specifiedType);
+      expect(serialized_by, serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_value/test/uint8list_serializer_test.dart
+++ b/built_value/test/uint8list_serializer_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Support Uint8List by converting to and from base64 encoded strings. 

[Older Feature Request](https://github.com/google/built_value.dart/issues/194)