### PR TITLE
Add explicit error message to enum ArgumentError

### DIFF
--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -202,7 +202,11 @@ abstract class EnumSourceClass
 
     var fallback = fields.firstWhereOrNull((field) => field.settings.fallback);
     if (fallback == null) {
-      result.writeln('default: throw new ArgumentError(name);');
+      result
+        ..writeln('default: throw new ArgumentError(')
+        ..writeln("'`\$name` is not one of the supported values: '")
+        ..writeln("'${fields.map((field) => field.name).join(', ')}',")
+        ..writeln(');');
     } else {
       result.writeln('default: return ${fallback.generatedIdentifier};');
     }

--- a/built_value_generator/test/enum_class_generator_test.dart
+++ b/built_value_generator/test/enum_class_generator_test.dart
@@ -45,7 +45,10 @@ TestEnum _$valueOf(String name) {
     case 'maybe':
       return _$maybe;
     default:
-      throw new ArgumentError(name);
+      throw new ArgumentError(
+        '`$name` is not one of the supported values: '
+        'yes, no, maybe',
+      );
   }
 }
 
@@ -482,7 +485,10 @@ TestEnum _$valueOf(String name) {
     case 'maybe':
       return _$yes;
     default:
-      throw new ArgumentError(name);
+      throw new ArgumentError(
+        '`$name` is not one of the supported values: '
+        'yes, no, maybe',
+      );
   }
 }
 
@@ -526,7 +532,10 @@ TestEnum _$vlOf(String name) {
     case 'maybe':
       return _$maybe;
     default:
-      throw new ArgumentError(name);
+      throw new ArgumentError(
+        '`$name` is not one of the supported values: '
+        'yes, no, maybe',
+      );
   }
 }
 


### PR DESCRIPTION
Presently when an unexpected value is provided for an enum without a fallback an `ArgumentError` is thrown containing only the unexpected value as the message. This provides little information to the developer and also prevents any meaningful introspection to be performed. I propose an error similar to [json_serializable](https://github.com/google/json_serializable.dart/blob/f7cb51662b21d11b3fdb6c5e0fdd46431cec59d4/json_annotation/lib/src/enum_helpers.dart#L38) to provide more clarity.