### PR TITLE
fix(build_value_generator): Escape enum wire keys

### DIFF
--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -397,11 +397,11 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
         // Generate maps between enum names and wire names.
         final toWire = '''
          static const Map<String, Object> _toWire = const <String, Object>{
-           ${wireNameMapping.keys.map((key) => "'$key': ${_toCode(wireNameMapping[key])},").join('\n')}
+           ${wireNameMapping.keys.map((key) => "'${escapeString(key)}': ${_toCode(wireNameMapping[key])},").join('\n')}
          };''';
         final fromWire = '''
          static const Map<Object, String> _fromWire = const <Object, String>{
-           ${wireNameMapping.keys.map((key) => "${_toCode(wireNameMapping[key])}: '$key',").join('\n')}
+           ${wireNameMapping.keys.map((key) => "${_toCode(wireNameMapping[key])}: '${escapeString(key)}',").join('\n')}
          };''';
 
         return '''

--- a/end_to_end_test/lib/enums.dart
+++ b/end_to_end_test/lib/enums.dart
@@ -81,6 +81,9 @@ class DollarValueEnum extends EnumClass {
 
   static const DollarValueEnum value$ = _$value$;
 
+  @BuiltValueEnumConst(wireName: 'value')
+  static const DollarValueEnum $value = _$value;
+
   const DollarValueEnum._(String name) : super(name);
 
   static BuiltSet<DollarValueEnum> get values => _$dollarValues;

--- a/end_to_end_test/lib/enums.g.dart
+++ b/end_to_end_test/lib/enums.g.dart
@@ -117,11 +117,14 @@ final BuiltSet<WireNumberEnum> _$wireNumberValues =
 ]);
 
 const DollarValueEnum _$value$ = const DollarValueEnum._('value\$');
+const DollarValueEnum _$value = const DollarValueEnum._('\$value');
 
 DollarValueEnum _$dollarValueOf(String name) {
   switch (name) {
     case 'value\$':
       return _$value$;
+    case '\$value':
+      return _$value;
     default:
       throw new ArgumentError(name);
   }
@@ -130,6 +133,7 @@ DollarValueEnum _$dollarValueOf(String name) {
 final BuiltSet<DollarValueEnum> _$dollarValues =
     new BuiltSet<DollarValueEnum>(const <DollarValueEnum>[
   _$value$,
+  _$value,
 ]);
 
 const FallbackEnum _$fbYes = const FallbackEnum._('yes');
@@ -262,6 +266,13 @@ class _$WireNumberEnumSerializer
 
 class _$DollarValueEnumSerializer
     implements PrimitiveSerializer<DollarValueEnum> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    '\$value': 'value',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'value': '\$value',
+  };
+
   @override
   final Iterable<Type> types = const <Type>[DollarValueEnum];
   @override
@@ -270,12 +281,13 @@ class _$DollarValueEnumSerializer
   @override
   Object serialize(Serializers serializers, DollarValueEnum object,
           {FullType specifiedType = FullType.unspecified}) =>
-      object.name;
+      _toWire[object.name] ?? object.name;
 
   @override
   DollarValueEnum deserialize(Serializers serializers, Object serialized,
           {FullType specifiedType = FullType.unspecified}) =>
-      DollarValueEnum.valueOf(serialized as String);
+      DollarValueEnum.valueOf(
+          _fromWire[serialized] ?? (serialized is String ? serialized : ''));
 }
 
 class _$FallbackEnumSerializer implements PrimitiveSerializer<FallbackEnum> {


### PR DESCRIPTION
Wire keys of enums need to be escaped in order to properly generate fields that start with a `$` (otherwise interpreted as variables). For example these were not possible before:
```dart
class Base_EnumInt extends EnumClass {
  const Base_EnumInt._(super.name);

  @BuiltValueEnumConst(wireName: '0')
  static const Base_EnumInt $0 = _$baseEnumInt$0;

  @BuiltValueEnumConst(wireName: '1')
  static const Base_EnumInt $1 = _$baseEnumInt$1;

  @BuiltValueEnumConst(wireName: '2')
  static const Base_EnumInt $2 = _$baseEnumInt$2;

  static BuiltSet<Base_EnumInt> get values => _$baseEnumIntValues;

  static Base_EnumInt valueOf(final String name) => _$valueOfBase_EnumInt(name);

  static Serializer<Base_EnumInt> get serializer => _$baseEnumIntSerializer;
}

class Base_EnumString extends EnumClass {
  const Base_EnumString._(super.name);

  static const Base_EnumString test = _$baseEnumStringTest;

  @BuiltValueEnumConst(wireName: 'default')
  static const Base_EnumString $default = _$baseEnumStringDefault;

  static BuiltSet<Base_EnumString> get values => _$baseEnumStringValues;

  static Base_EnumString valueOf(final String name) => _$valueOfBase_EnumString(name);

  static Serializer<Base_EnumString> get serializer => _$baseEnumStringSerializer;
}
```

Edit: I first used raw strings, but `escapeString` makes more sense.