### PR TITLE
Handle different paths enum source generation

### DIFF
--- a/built_value_generator/lib/src/enum_source_library.dart
+++ b/built_value_generator/lib/src/enum_source_library.dart
@@ -69,12 +69,22 @@ abstract class EnumSourceLibrary
   }
 
   Iterable<String> _checkPart() {
-    var expectedCode = "part '$fileName.g.dart';";
-    var alternativeExpectedCode = 'part "$fileName.g.dart";';
-    return source.contains(expectedCode) ||
-            source.contains(alternativeExpectedCode)
-        ? <String>[]
-        : <String>['Import generated part: $expectedCode'];
+    String expectedFileName = "$fileName.g.dart";
+
+    String regexSource = r'''part\s*['"]([^'\"]*''' +
+        RegExp.escape(expectedFileName) +
+        r''')['"];''';
+
+    final RegExp regex = RegExp(regexSource);
+    final hasMatch = regex.firstMatch(source) != null;
+
+    if (hasMatch) {
+      return <String>[];
+    } else {
+      return <String>[
+        'Import generated part: part "{path}/$expectedFileName";'
+      ];
+    }
   }
 
   Iterable<String> _checkIdentifiers() {


### PR DESCRIPTION
Hi 👋🏻 
This is my first PR here so i am not sure if i am doing it correctly.
I was using this package in our App and i discovered a bug that doesn't let the user generate correctly the .g file in a different folder than the local, even if correctly configured. 

With this build.yaml file:

```yaml
targets:
  $default:
    builders:
      source_gen|combining_builder:
        options:
          build_extensions:
            '^lib/{{}}.dart': 'lib/generated/{{}}.g.dart'
```

Right now, inside the ```_checkPart()``` function the full string containing the path object is hardcoded so its not possible to use a custom path since this check will fail and block the generation.

```dart
    var expectedCode = "part '$fileName.g.dart';";
    var alternativeExpectedCode = 'part "$fileName.g.dart";';
    return source.contains(expectedCode) ||
            source.contains(alternativeExpectedCode)
        ? <String>[]
        : <String>['Import generated part: $expectedCode'];
```

With this PR i simply rewrote the check to use a Regex and verify that the path  is in the right formula.
This Regex should cover multiple situations:

<img width="778" alt="Screenshot 2024-06-26 alle 16 00 14" src="https://github.com/google/built_value.dart/assets/7062082/58d06bd2-ed24-47fb-b56d-313b0dece5c3">

I wanted to add some tests but the generator test also has hardcoded where to build the file so its a little bit more tricky.

I run it locally and it worked fine with those situations.

Let me know what do you think!