### PR TITLE
Generate code that formats faster with "short" style.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 8.9.3 (unreleased)
 
+- Generate code that formats faster with current "short" style. Both versions
+  are fast with the coming "tall" style.
 - Mark `@nullable` deprecated: it does nothing and should not be used.
 
 # 8.9.2

--- a/benchmark/lib/node.g.dart
+++ b/benchmark/lib/node.g.dart
@@ -102,7 +102,10 @@ class NodeBuilder implements Builder<Node, NodeBuilder> {
     try {
       _$result = _$v ??
           new _$Node._(
-              label: label, left: _left?.build(), right: _right?.build());
+            label: label,
+            left: _left?.build(),
+            right: _right?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/benchmark/lib/simple_value.g.dart
+++ b/benchmark/lib/simple_value.g.dart
@@ -93,10 +93,11 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
   _$SimpleValue _build() {
     final _$result = _$v ??
         new _$SimpleValue._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'SimpleValue', 'anInt'),
-            aString: BuiltValueNullFieldError.checkNotNull(
-                aString, r'SimpleValue', 'aString'));
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'SimpleValue', 'anInt'),
+          aString: BuiltValueNullFieldError.checkNotNull(
+              aString, r'SimpleValue', 'aString'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_value_generator/lib/src/enum_source_class.g.dart
@@ -160,12 +160,11 @@ class EnumSourceClassBuilder
   _$EnumSourceClass _build() {
     final _$result = _$v ??
         new _$EnumSourceClass._(
-            parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
-                parsedLibraryResults,
-                r'EnumSourceClass',
-                'parsedLibraryResults'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'EnumSourceClass', 'element'));
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults, r'EnumSourceClass', 'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'EnumSourceClass', 'element'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/enum_source_field.g.dart
+++ b/built_value_generator/lib/src/enum_source_field.g.dart
@@ -131,10 +131,11 @@ class EnumSourceFieldBuilder
   _$EnumSourceField _build() {
     final _$result = _$v ??
         new _$EnumSourceField._(
-            parsedLibrary: BuiltValueNullFieldError.checkNotNull(
-                parsedLibrary, r'EnumSourceField', 'parsedLibrary'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'EnumSourceField', 'element'));
+          parsedLibrary: BuiltValueNullFieldError.checkNotNull(
+              parsedLibrary, r'EnumSourceField', 'parsedLibrary'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'EnumSourceField', 'element'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/enum_source_library.g.dart
+++ b/built_value_generator/lib/src/enum_source_library.g.dart
@@ -123,12 +123,13 @@ class EnumSourceLibraryBuilder
   _$EnumSourceLibrary _build() {
     final _$result = _$v ??
         new _$EnumSourceLibrary._(
-            parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
-                parsedLibraryResults,
-                r'EnumSourceLibrary',
-                'parsedLibraryResults'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'EnumSourceLibrary', 'element'));
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'EnumSourceLibrary',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'EnumSourceLibrary', 'element'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/fixes.g.dart
+++ b/built_value_generator/lib/src/fixes.g.dart
@@ -117,11 +117,12 @@ class GeneratorErrorBuilder
   _$GeneratorError _build() {
     final _$result = _$v ??
         new _$GeneratorError._(
-            message: BuiltValueNullFieldError.checkNotNull(
-                message, r'GeneratorError', 'message'),
-            offset: offset,
-            length: length,
-            fix: fix);
+          message: BuiltValueNullFieldError.checkNotNull(
+              message, r'GeneratorError', 'message'),
+          offset: offset,
+          length: length,
+          fix: fix,
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/memoized_getter.g.dart
+++ b/built_value_generator/lib/src/memoized_getter.g.dart
@@ -113,12 +113,13 @@ class MemoizedGetterBuilder
   _$MemoizedGetter _build() {
     final _$result = _$v ??
         new _$MemoizedGetter._(
-            returnType: BuiltValueNullFieldError.checkNotNull(
-                returnType, r'MemoizedGetter', 'returnType'),
-            nullabilitySuffix: BuiltValueNullFieldError.checkNotNull(
-                nullabilitySuffix, r'MemoizedGetter', 'nullabilitySuffix'),
-            name: BuiltValueNullFieldError.checkNotNull(
-                name, r'MemoizedGetter', 'name'));
+          returnType: BuiltValueNullFieldError.checkNotNull(
+              returnType, r'MemoizedGetter', 'returnType'),
+          nullabilitySuffix: BuiltValueNullFieldError.checkNotNull(
+              nullabilitySuffix, r'MemoizedGetter', 'nullabilitySuffix'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'MemoizedGetter', 'name'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -213,13 +213,14 @@ class SerializerSourceClassBuilder
   _$SerializerSourceClass _build() {
     final _$result = _$v ??
         new _$SerializerSourceClass._(
-            parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
-                parsedLibraryResults,
-                r'SerializerSourceClass',
-                'parsedLibraryResults'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'SerializerSourceClass', 'element'),
-            builderElement: builderElement);
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'SerializerSourceClass',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'SerializerSourceClass', 'element'),
+          builderElement: builderElement,
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -226,17 +226,18 @@ class SerializerSourceFieldBuilder
   _$SerializerSourceField _build() {
     final _$result = _$v ??
         new _$SerializerSourceField._(
-            parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
-                parsedLibraryResults,
-                r'SerializerSourceField',
-                'parsedLibraryResults'),
-            settings: BuiltValueNullFieldError.checkNotNull(
-                settings, r'SerializerSourceField', 'settings'),
-            parsedLibrary: BuiltValueNullFieldError.checkNotNull(
-                parsedLibrary, r'SerializerSourceField', 'parsedLibrary'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'SerializerSourceField', 'element'),
-            builderElement: builderElement);
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'SerializerSourceField',
+              'parsedLibraryResults'),
+          settings: BuiltValueNullFieldError.checkNotNull(
+              settings, r'SerializerSourceField', 'settings'),
+          parsedLibrary: BuiltValueNullFieldError.checkNotNull(
+              parsedLibrary, r'SerializerSourceField', 'parsedLibrary'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'SerializerSourceField', 'element'),
+          builderElement: builderElement,
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -140,12 +140,13 @@ class SerializerSourceLibraryBuilder
   _$SerializerSourceLibrary _build() {
     final _$result = _$v ??
         new _$SerializerSourceLibrary._(
-            parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
-                parsedLibraryResults,
-                r'SerializerSourceLibrary',
-                'parsedLibraryResults'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'SerializerSourceLibrary', 'element'));
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'SerializerSourceLibrary',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'SerializerSourceLibrary', 'element'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -1104,20 +1104,23 @@ abstract class ValueSourceClass
     }
     result.writeln('_\$result = _\$v ?? ');
     result.writeln('new $implName$_generics._(');
-    result.write(fieldBuilders.keys.map((field) {
-      final fieldBuilder = fieldBuilders[field];
-      if (needsNullCheck.contains(field)) {
-        if (genericFields.containsKey(field)) {
-          final genericType = genericFields[field];
-          return '$field: null is $genericType ? $fieldBuilder as $genericType '
-              ': BuiltValueNullFieldError.checkNotNull($fieldBuilder'
-              ", r'$name', '${escapeString(field)}')";
-        }
-        return '$field: BuiltValueNullFieldError.checkNotNull($fieldBuilder, '
-            "r'$name', '${escapeString(field)}')";
-      }
-      return '$field: $fieldBuilder';
-    }).join(','));
+    result.write(fieldBuilders.keys
+        .map((field) {
+          final fieldBuilder = fieldBuilders[field];
+          if (needsNullCheck.contains(field)) {
+            if (genericFields.containsKey(field)) {
+              final genericType = genericFields[field];
+              return '$field: null is $genericType ? $fieldBuilder as $genericType '
+                  ': BuiltValueNullFieldError.checkNotNull($fieldBuilder'
+                  ", r'$name', '${escapeString(field)}')";
+            }
+            return '$field: BuiltValueNullFieldError.checkNotNull($fieldBuilder, '
+                "r'$name', '${escapeString(field)}')";
+          }
+          return '$field: $fieldBuilder';
+        })
+        .map((fieldBuilder) => '$fieldBuilder,')
+        .join(''));
     result.writeln(');');
 
     if (needsTryCatchOnBuild) {

--- a/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_value_generator/lib/src/value_source_class.g.dart
@@ -294,12 +294,13 @@ class ValueSourceClassBuilder
   _$ValueSourceClass _build() {
     final _$result = _$v ??
         new _$ValueSourceClass._(
-            parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
-                parsedLibraryResults,
-                r'ValueSourceClass',
-                'parsedLibraryResults'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'ValueSourceClass', 'element'));
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'ValueSourceClass',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'ValueSourceClass', 'element'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_value_generator/lib/src/value_source_field.g.dart
@@ -223,17 +223,18 @@ class ValueSourceFieldBuilder
   _$ValueSourceField _build() {
     final _$result = _$v ??
         new _$ValueSourceField._(
-            parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
-                parsedLibraryResults,
-                r'ValueSourceField',
-                'parsedLibraryResults'),
-            settings: BuiltValueNullFieldError.checkNotNull(
-                settings, r'ValueSourceField', 'settings'),
-            parsedLibrary: BuiltValueNullFieldError.checkNotNull(
-                parsedLibrary, r'ValueSourceField', 'parsedLibrary'),
-            element: BuiltValueNullFieldError.checkNotNull(
-                element, r'ValueSourceField', 'element'),
-            builderElement: builderElement);
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'ValueSourceField',
+              'parsedLibraryResults'),
+          settings: BuiltValueNullFieldError.checkNotNull(
+              settings, r'ValueSourceField', 'settings'),
+          parsedLibrary: BuiltValueNullFieldError.checkNotNull(
+              parsedLibrary, r'ValueSourceField', 'parsedLibrary'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'ValueSourceField', 'element'),
+          builderElement: builderElement,
+        );
     replace(_$result);
     return _$result;
   }

--- a/built_value_test/test/values.g.dart
+++ b/built_value_test/test/values.g.dart
@@ -152,13 +152,14 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
     try {
       _$result = _$v ??
           new _$SimpleValue._(
-              anInt: BuiltValueNullFieldError.checkNotNull(
-                  anInt, r'SimpleValue', 'anInt'),
-              list: list.build(),
-              multimap: multimap.build(),
-              map: map.build(),
-              aSet: aSet.build(),
-              setMultimap: setMultimap.build());
+            anInt: BuiltValueNullFieldError.checkNotNull(
+                anInt, r'SimpleValue', 'anInt'),
+            list: list.build(),
+            multimap: multimap.build(),
+            map: map.build(),
+            aSet: aSet.build(),
+            setMultimap: setMultimap.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -275,7 +276,9 @@ class CompoundValueBuilder
     try {
       _$result = _$v ??
           new _$CompoundValue._(
-              simpleValue: simpleValue.build(), string: string);
+            simpleValue: simpleValue.build(),
+            string: string,
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -378,10 +381,11 @@ class ComparedValueBuilder
   _$ComparedValue _build() {
     final _$result = _$v ??
         new _$ComparedValue._(
-            name: BuiltValueNullFieldError.checkNotNull(
-                name, r'ComparedValue', 'name'),
-            onChanged: BuiltValueNullFieldError.checkNotNull(
-                onChanged, r'ComparedValue', 'onChanged'));
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'ComparedValue', 'name'),
+          onChanged: BuiltValueNullFieldError.checkNotNull(
+              onChanged, r'ComparedValue', 'onChanged'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/chat_example/lib/data_model/data_model.g.dart
+++ b/chat_example/lib/data_model/data_model.g.dart
@@ -521,9 +521,9 @@ class ChatBuilder implements Builder<Chat, ChatBuilder> {
     try {
       _$result = _$v ??
           new _$Chat._(
-              text:
-                  BuiltValueNullFieldError.checkNotNull(text, r'Chat', 'text'),
-              targets: targets.build());
+            text: BuiltValueNullFieldError.checkNotNull(text, r'Chat', 'text'),
+            targets: targets.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -627,10 +627,11 @@ class LoginBuilder implements Builder<Login, LoginBuilder> {
   _$Login _build() {
     final _$result = _$v ??
         new _$Login._(
-            username: BuiltValueNullFieldError.checkNotNull(
-                username, r'Login', 'username'),
-            password: BuiltValueNullFieldError.checkNotNull(
-                password, r'Login', 'password'));
+          username: BuiltValueNullFieldError.checkNotNull(
+              username, r'Login', 'username'),
+          password: BuiltValueNullFieldError.checkNotNull(
+              password, r'Login', 'password'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -721,10 +722,10 @@ class StatusBuilder implements Builder<Status, StatusBuilder> {
   _$Status _build() {
     final _$result = _$v ??
         new _$Status._(
-            message: BuiltValueNullFieldError.checkNotNull(
-                message, r'Status', 'message'),
-            type:
-                BuiltValueNullFieldError.checkNotNull(type, r'Status', 'type'));
+          message: BuiltValueNullFieldError.checkNotNull(
+              message, r'Status', 'message'),
+          type: BuiltValueNullFieldError.checkNotNull(type, r'Status', 'type'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -808,7 +809,10 @@ class ListUsersBuilder implements Builder<ListUsers, ListUsersBuilder> {
   _$ListUsers _build() {
     _$ListUsers _$result;
     try {
-      _$result = _$v ?? new _$ListUsers._(statusTypes: statusTypes.build());
+      _$result = _$v ??
+          new _$ListUsers._(
+            statusTypes: statusTypes.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -925,12 +929,13 @@ class ShowChatBuilder implements Builder<ShowChat, ShowChatBuilder> {
   _$ShowChat _build() {
     final _$result = _$v ??
         new _$ShowChat._(
-            username: BuiltValueNullFieldError.checkNotNull(
-                username, r'ShowChat', 'username'),
-            private: BuiltValueNullFieldError.checkNotNull(
-                private, r'ShowChat', 'private'),
-            text: BuiltValueNullFieldError.checkNotNull(
-                text, r'ShowChat', 'text'));
+          username: BuiltValueNullFieldError.checkNotNull(
+              username, r'ShowChat', 'username'),
+          private: BuiltValueNullFieldError.checkNotNull(
+              private, r'ShowChat', 'private'),
+          text:
+              BuiltValueNullFieldError.checkNotNull(text, r'ShowChat', 'text'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1023,9 +1028,10 @@ class WelcomeBuilder implements Builder<Welcome, WelcomeBuilder> {
     try {
       _$result = _$v ??
           new _$Welcome._(
-              log: log.build(),
-              message: BuiltValueNullFieldError.checkNotNull(
-                  message, r'Welcome', 'message'));
+            log: log.build(),
+            message: BuiltValueNullFieldError.checkNotNull(
+                message, r'Welcome', 'message'),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1123,7 +1129,10 @@ class ListUsersResponseBuilder
   _$ListUsersResponse _build() {
     _$ListUsersResponse _$result;
     try {
-      _$result = _$v ?? new _$ListUsersResponse._(statuses: statuses.build());
+      _$result = _$v ??
+          new _$ListUsersResponse._(
+            statuses: statuses.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/end_to_end_test/lib/collections.g.dart
+++ b/end_to_end_test/lib/collections.g.dart
@@ -544,23 +544,24 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
     try {
       _$result = _$v ??
           new _$Collections._(
-              list: list.build(),
-              set: set.build(),
-              map: map.build(),
-              listMultimap: listMultimap.build(),
-              setMultimap: setMultimap.build(),
-              nullsInList: nullsInList.build(),
-              nullsInSet: nullsInSet.build(),
-              nullsInMap: nullsInMap.build(),
-              nullsInListMultimap: nullsInListMultimap.build(),
-              nullsInSetMultimap: nullsInSetMultimap.build(),
-              nullableList: _nullableList?.build(),
-              nullableSet: _nullableSet?.build(),
-              nullableMap: _nullableMap?.build(),
-              nullableListMultimap: _nullableListMultimap?.build(),
-              nullableSetMultimap: _nullableSetMultimap?.build(),
-              nullableInGenericsList: nullableInGenericsList.build(),
-              nestedNullablesList: nestedNullablesList.build());
+            list: list.build(),
+            set: set.build(),
+            map: map.build(),
+            listMultimap: listMultimap.build(),
+            setMultimap: setMultimap.build(),
+            nullsInList: nullsInList.build(),
+            nullsInSet: nullsInSet.build(),
+            nullsInMap: nullsInMap.build(),
+            nullsInListMultimap: nullsInListMultimap.build(),
+            nullsInSetMultimap: nullsInSetMultimap.build(),
+            nullableList: _nullableList?.build(),
+            nullableSet: _nullableSet?.build(),
+            nullableMap: _nullableMap?.build(),
+            nullableListMultimap: _nullableListMultimap?.build(),
+            nullableSetMultimap: _nullableSetMultimap?.build(),
+            nullableInGenericsList: nullableInGenericsList.build(),
+            nestedNullablesList: nestedNullablesList.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/end_to_end_test/lib/generics.g.dart
+++ b/end_to_end_test/lib/generics.g.dart
@@ -721,8 +721,9 @@ class GenericValueBuilder<T>
   _$GenericValue<T> _build() {
     final _$result = _$v ??
         new _$GenericValue<T>._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'GenericValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'GenericValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -814,8 +815,9 @@ class InitializeGenericValueBuilder<T>
   _$InitializeGenericValue<T> _build() {
     final _$result = _$v ??
         new _$InitializeGenericValue<T>._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'InitializeGenericValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'InitializeGenericValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -914,9 +916,10 @@ class BoundGenericValueBuilder<T extends num>
   _$BoundGenericValue<T> _build() {
     final _$result = _$v ??
         new _$BoundGenericValue<T>._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'BoundGenericValue', 'value'),
-            nullableValue: nullableValue);
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'BoundGenericValue', 'value'),
+          nullableValue: nullableValue,
+        );
     replace(_$result);
     return _$result;
   }
@@ -1019,11 +1022,12 @@ class BoundNullableGenericValueBuilder<T extends num?>
   _$BoundNullableGenericValue<T> _build() {
     final _$result = _$v ??
         new _$BoundNullableGenericValue<T>._(
-            value: null is T
-                ? value as T
-                : BuiltValueNullFieldError.checkNotNull(
-                    value, r'BoundNullableGenericValue', 'value'),
-            nullableValue: nullableValue);
+          value: null is T
+              ? value as T
+              : BuiltValueNullFieldError.checkNotNull(
+                  value, r'BoundNullableGenericValue', 'value'),
+          nullableValue: nullableValue,
+        );
     replace(_$result);
     return _$result;
   }
@@ -1113,8 +1117,10 @@ class CollectionGenericValueBuilder<T>
   _$CollectionGenericValue<T> _build() {
     _$CollectionGenericValue<T> _$result;
     try {
-      _$result =
-          _$v ?? new _$CollectionGenericValue<T>._(values: values.build());
+      _$result = _$v ??
+          new _$CollectionGenericValue<T>._(
+            values: values.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1249,9 +1255,10 @@ class GenericContainerBuilder
     try {
       _$result = _$v ??
           new _$GenericContainer._(
-              genericValue: genericValue.build(),
-              boundGenericValue: boundGenericValue.build(),
-              collectionGenericValue: collectionGenericValue.build());
+            genericValue: genericValue.build(),
+            boundGenericValue: boundGenericValue.build(),
+            collectionGenericValue: collectionGenericValue.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1353,8 +1360,9 @@ class DynamicGenericContainerBuilder
   _$DynamicGenericContainer _build() {
     final _$result = _$v ??
         new _$DynamicGenericContainer._(
-            foo: BuiltValueNullFieldError.checkNotNull(
-                foo, r'DynamicGenericContainer', 'foo'));
+          foo: BuiltValueNullFieldError.checkNotNull(
+              foo, r'DynamicGenericContainer', 'foo'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1468,8 +1476,9 @@ class PassthroughGenericContainerBuilder<T>
     try {
       _$result = _$v ??
           new _$PassthroughGenericContainer<T>._(
-              genericValue: genericValue.build(),
-              collectionGenericValue: collectionGenericValue.build());
+            genericValue: genericValue.build(),
+            collectionGenericValue: collectionGenericValue.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1569,7 +1578,10 @@ class NestedGenericContainerBuilder
   _$NestedGenericContainer _build() {
     _$NestedGenericContainer _$result;
     try {
-      _$result = _$v ?? new _$NestedGenericContainer._(map: map.build());
+      _$result = _$v ??
+          new _$NestedGenericContainer._(
+            map: map.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1679,8 +1691,9 @@ class _$CustomBuilderGenericValueBuilder<T>
   _$CustomBuilderGenericValue<T> _build() {
     final _$result = _$v ??
         new _$CustomBuilderGenericValue<T>._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'CustomBuilderGenericValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'CustomBuilderGenericValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1763,8 +1776,9 @@ class ConcreteGenericBuilder
   _$ConcreteGeneric _build() {
     final _$result = _$v ??
         new _$ConcreteGeneric._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'ConcreteGeneric', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'ConcreteGeneric', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1854,8 +1868,9 @@ class GenericFunctionBuilder<T>
   _$GenericFunction<T> _build() {
     final _$result = _$v ??
         new _$GenericFunction<T>._(
-            function: BuiltValueNullFieldError.checkNotNull(
-                function, r'GenericFunction', 'function'));
+          function: BuiltValueNullFieldError.checkNotNull(
+              function, r'GenericFunction', 'function'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1938,8 +1953,9 @@ class NonBuiltGenericBuilder
   _$NonBuiltGeneric _build() {
     final _$result = _$v ??
         new _$NonBuiltGeneric._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'NonBuiltGeneric', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'NonBuiltGeneric', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -2092,7 +2108,10 @@ class ConstAndGenericBuilder<T>
   _$ConstAndGeneric<T> _build() {
     _$ConstAndGeneric<T> _$result;
     try {
-      _$result = _$v ?? new _$ConstAndGeneric<T>._(map: map.build());
+      _$result = _$v ??
+          new _$ConstAndGeneric<T>._(
+            map: map.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/end_to_end_test/lib/imported_values.g.dart
+++ b/end_to_end_test/lib/imported_values.g.dart
@@ -277,8 +277,9 @@ class ImportedValueBuilder
     try {
       _$result = _$v ??
           new _$ImportedValue._(
-              simpleValue: simpleValue.build(),
-              simpleValues: simpleValues.build());
+            simpleValue: simpleValue.build(),
+            simpleValues: simpleValues.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -408,10 +409,11 @@ class _$ImportedCustomValueBuilder extends ImportedCustomValueBuilder {
   _$ImportedCustomValue _build() {
     final _$result = _$v ??
         new _$ImportedCustomValue._(
-            simpleValue: BuiltValueNullFieldError.checkNotNull(
-                simpleValue, r'ImportedCustomValue', 'simpleValue'),
-            simpleValues: BuiltValueNullFieldError.checkNotNull(
-                simpleValues, r'ImportedCustomValue', 'simpleValues'));
+          simpleValue: BuiltValueNullFieldError.checkNotNull(
+              simpleValue, r'ImportedCustomValue', 'simpleValue'),
+          simpleValues: BuiltValueNullFieldError.checkNotNull(
+              simpleValues, r'ImportedCustomValue', 'simpleValues'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -531,8 +533,9 @@ class _$ImportedCustomNestedValueBuilder
     try {
       _$result = _$v ??
           new _$ImportedCustomNestedValue._(
-              simpleValue: simpleValue.build(),
-              simpleValues: simpleValues.build());
+            simpleValue: simpleValue.build(),
+            simpleValues: simpleValues.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/end_to_end_test/lib/interfaces.g.dart
+++ b/end_to_end_test/lib/interfaces.g.dart
@@ -228,10 +228,11 @@ class ValueWithIntBuilder
   _$ValueWithInt _build() {
     final _$result = _$v ??
         new _$ValueWithInt._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValueWithInt', 'anInt'),
-            note: BuiltValueNullFieldError.checkNotNull(
-                note, r'ValueWithInt', 'note'));
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithInt', 'anInt'),
+          note: BuiltValueNullFieldError.checkNotNull(
+              note, r'ValueWithInt', 'note'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -314,8 +315,9 @@ class ValueWithHasIntBuilder
   _$ValueWithHasInt _build() {
     final _$result = _$v ??
         new _$ValueWithHasInt._(
-            hasInt: BuiltValueNullFieldError.checkNotNull(
-                hasInt, r'ValueWithHasInt', 'hasInt'));
+          hasInt: BuiltValueNullFieldError.checkNotNull(
+              hasInt, r'ValueWithHasInt', 'hasInt'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/mixins.g.dart
+++ b/end_to_end_test/lib/mixins.g.dart
@@ -103,8 +103,9 @@ class UsesMixinBuilder implements Builder<UsesMixin, UsesMixinBuilder> {
   _$UsesMixin _build() {
     final _$result = _$v ??
         new _$UsesMixin._(
-            typeDef: BuiltValueNullFieldError.checkNotNull(
-                typeDef, r'UsesMixin', 'typeDef'));
+          typeDef: BuiltValueNullFieldError.checkNotNull(
+              typeDef, r'UsesMixin', 'typeDef'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -193,10 +194,9 @@ class GetsCorrectFieldsViaMixinsBuilder
   _$GetsCorrectFieldsViaMixins _build() {
     final _$result = _$v ??
         new _$GetsCorrectFieldsViaMixins._(
-            shouldBeAField: BuiltValueNullFieldError.checkNotNull(
-                shouldBeAField,
-                r'GetsCorrectFieldsViaMixins',
-                'shouldBeAField'));
+          shouldBeAField: BuiltValueNullFieldError.checkNotNull(
+              shouldBeAField, r'GetsCorrectFieldsViaMixins', 'shouldBeAField'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/polymorphism.g.dart
+++ b/end_to_end_test/lib/polymorphism.g.dart
@@ -461,8 +461,9 @@ class CatBuilder implements Builder<Cat, CatBuilder>, MammalBuilder {
   _$Cat _build() {
     final _$result = _$v ??
         new _$Cat._(
-            tail: BuiltValueNullFieldError.checkNotNull(tail, r'Cat', 'tail'),
-            legs: BuiltValueNullFieldError.checkNotNull(legs, r'Cat', 'legs'));
+          tail: BuiltValueNullFieldError.checkNotNull(tail, r'Cat', 'tail'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Cat', 'legs'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -553,8 +554,9 @@ class FishBuilder implements Builder<Fish, FishBuilder>, AnimalBuilder {
   _$Fish _build() {
     final _$result = _$v ??
         new _$Fish._(
-            fins: BuiltValueNullFieldError.checkNotNull(fins, r'Fish', 'fins'),
-            legs: BuiltValueNullFieldError.checkNotNull(legs, r'Fish', 'legs'));
+          fins: BuiltValueNullFieldError.checkNotNull(fins, r'Fish', 'fins'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Fish', 'legs'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -645,9 +647,9 @@ class RobotBuilder implements Builder<Robot, RobotBuilder> {
   _$Robot _build() {
     final _$result = _$v ??
         new _$Robot._(
-            fins: BuiltValueNullFieldError.checkNotNull(fins, r'Robot', 'fins'),
-            legs:
-                BuiltValueNullFieldError.checkNotNull(legs, r'Robot', 'legs'));
+          fins: BuiltValueNullFieldError.checkNotNull(fins, r'Robot', 'fins'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Robot', 'legs'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -746,9 +748,10 @@ class CageBuilder implements Builder<Cage, CageBuilder> {
     try {
       _$result = _$v ??
           new _$Cage._(
-              inhabitant: BuiltValueNullFieldError.checkNotNull(
-                  inhabitant, r'Cage', 'inhabitant'),
-              otherInhabitants: otherInhabitants.build());
+            inhabitant: BuiltValueNullFieldError.checkNotNull(
+                inhabitant, r'Cage', 'inhabitant'),
+            otherInhabitants: otherInhabitants.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -839,8 +842,9 @@ class StandardCatBuilder implements Builder<StandardCat, StandardCatBuilder> {
   _$StandardCat _build() {
     final _$result = _$v ??
         new _$StandardCat._(
-            tail: BuiltValueNullFieldError.checkNotNull(
-                tail, r'StandardCat', 'tail'));
+          tail: BuiltValueNullFieldError.checkNotNull(
+              tail, r'StandardCat', 'tail'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -928,8 +932,9 @@ class HasStringBuilder
   _$HasString _build() {
     final _$result = _$v ??
         new _$HasString._(
-            field: BuiltValueNullFieldError.checkNotNull(
-                field, r'HasString', 'field'));
+          field: BuiltValueNullFieldError.checkNotNull(
+              field, r'HasString', 'field'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1010,8 +1015,9 @@ class HasDoubleBuilder
   _$HasDouble _build() {
     final _$result = _$v ??
         new _$HasDouble._(
-            field: BuiltValueNullFieldError.checkNotNull(
-                field, r'HasDouble', 'field'));
+          field: BuiltValueNullFieldError.checkNotNull(
+              field, r'HasDouble', 'field'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1108,10 +1114,11 @@ class UsesChainedInterfaceBuilder
   _$UsesChainedInterface _build() {
     final _$result = _$v ??
         new _$UsesChainedInterface._(
-            bar: BuiltValueNullFieldError.checkNotNull(
-                bar, r'UsesChainedInterface', 'bar'),
-            foo: BuiltValueNullFieldError.checkNotNull(
-                foo, r'UsesChainedInterface', 'foo'));
+          bar: BuiltValueNullFieldError.checkNotNull(
+              bar, r'UsesChainedInterface', 'bar'),
+          foo: BuiltValueNullFieldError.checkNotNull(
+              foo, r'UsesChainedInterface', 'foo'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1196,8 +1203,9 @@ class UsesHandCodedBuilder
   _$UsesHandCoded _build() {
     final _$result = _$v ??
         new _$UsesHandCoded._(
-            fieldInBaseBuilder: BuiltValueNullFieldError.checkNotNull(
-                fieldInBaseBuilder, r'UsesHandCoded', 'fieldInBaseBuilder'));
+          fieldInBaseBuilder: BuiltValueNullFieldError.checkNotNull(
+              fieldInBaseBuilder, r'UsesHandCoded', 'fieldInBaseBuilder'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1370,9 +1378,10 @@ class CarBuilder implements Builder<Car, CarBuilder>, VehicleBuilder {
     try {
       _$result = _$v ??
           new _$Car._(
-              seatsCount: BuiltValueNullFieldError.checkNotNull(
-                  seatsCount, r'Car', 'seatsCount'),
-              color: color.build());
+            seatsCount: BuiltValueNullFieldError.checkNotNull(
+                seatsCount, r'Car', 'seatsCount'),
+            color: color.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1481,9 +1490,10 @@ class MixinCarBuilder
     try {
       _$result = _$v ??
           new _$MixinCar._(
-              seatsCount: BuiltValueNullFieldError.checkNotNull(
-                  seatsCount, r'MixinCar', 'seatsCount'),
-              color: color.build());
+            seatsCount: BuiltValueNullFieldError.checkNotNull(
+                seatsCount, r'MixinCar', 'seatsCount'),
+            color: color.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1575,8 +1585,9 @@ class VehicleColorBuilder
   _$VehicleColor _build() {
     final _$result = _$v ??
         new _$VehicleColor._(
-            label: BuiltValueNullFieldError.checkNotNull(
-                label, r'VehicleColor', 'label'));
+          label: BuiltValueNullFieldError.checkNotNull(
+              label, r'VehicleColor', 'label'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/records.g.dart
+++ b/end_to_end_test/lib/records.g.dart
@@ -157,8 +157,9 @@ class SimpleRecordValueBuilder
   _$SimpleRecordValue _build() {
     final _$result = _$v ??
         new _$SimpleRecordValue._(
-            record: BuiltValueNullFieldError.checkNotNull(
-                record, r'SimpleRecordValue', 'record'));
+          record: BuiltValueNullFieldError.checkNotNull(
+              record, r'SimpleRecordValue', 'record'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -425,30 +426,32 @@ class ComplexRecordValueBuilder
   _$ComplexRecordValue _build() {
     final _$result = _$v ??
         new _$ComplexRecordValue._(
-            record2: BuiltValueNullFieldError.checkNotNull(
-                record2, r'ComplexRecordValue', 'record2'),
-            record2p: BuiltValueNullFieldError.checkNotNull(
-                record2p, r'ComplexRecordValue', 'record2p'),
-            record2n: record2n,
-            record3: BuiltValueNullFieldError.checkNotNull(
-                record3, r'ComplexRecordValue', 'record3'),
-            record3p: BuiltValueNullFieldError.checkNotNull(
-                record3p, r'ComplexRecordValue', 'record3p'),
-            record3n: record3n,
-            record4: BuiltValueNullFieldError.checkNotNull(
-                record4, r'ComplexRecordValue', 'record4'),
-            record4p: BuiltValueNullFieldError.checkNotNull(
-                record4p, r'ComplexRecordValue', 'record4p'),
-            record4n: record4n,
-            record5: BuiltValueNullFieldError.checkNotNull(
-                record5, r'ComplexRecordValue', 'record5'),
-            record5p: BuiltValueNullFieldError.checkNotNull(
-                record5p, r'ComplexRecordValue', 'record5p'),
-            record5n: record5n,
-            record6: BuiltValueNullFieldError.checkNotNull(
-                record6, r'ComplexRecordValue', 'record6'),
-            record6p: BuiltValueNullFieldError.checkNotNull(record6p, r'ComplexRecordValue', 'record6p'),
-            record6n: record6n);
+          record2: BuiltValueNullFieldError.checkNotNull(
+              record2, r'ComplexRecordValue', 'record2'),
+          record2p: BuiltValueNullFieldError.checkNotNull(
+              record2p, r'ComplexRecordValue', 'record2p'),
+          record2n: record2n,
+          record3: BuiltValueNullFieldError.checkNotNull(
+              record3, r'ComplexRecordValue', 'record3'),
+          record3p: BuiltValueNullFieldError.checkNotNull(
+              record3p, r'ComplexRecordValue', 'record3p'),
+          record3n: record3n,
+          record4: BuiltValueNullFieldError.checkNotNull(
+              record4, r'ComplexRecordValue', 'record4'),
+          record4p: BuiltValueNullFieldError.checkNotNull(
+              record4p, r'ComplexRecordValue', 'record4p'),
+          record4n: record4n,
+          record5: BuiltValueNullFieldError.checkNotNull(
+              record5, r'ComplexRecordValue', 'record5'),
+          record5p: BuiltValueNullFieldError.checkNotNull(
+              record5p, r'ComplexRecordValue', 'record5p'),
+          record5n: record5n,
+          record6: BuiltValueNullFieldError.checkNotNull(
+              record6, r'ComplexRecordValue', 'record6'),
+          record6p: BuiltValueNullFieldError.checkNotNull(
+              record6p, r'ComplexRecordValue', 'record6p'),
+          record6n: record6n,
+        );
     replace(_$result);
     return _$result;
   }
@@ -559,10 +562,11 @@ class SerializableRecordValueBuilder
   _$SerializableRecordValue _build() {
     final _$result = _$v ??
         new _$SerializableRecordValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'SerializableRecordValue', 'value'),
-            record: record,
-            intOrList: intOrList);
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'SerializableRecordValue', 'value'),
+          record: record,
+          intOrList: intOrList,
+        );
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/lib/standard_json.g.dart
+++ b/end_to_end_test/lib/standard_json.g.dart
@@ -485,20 +485,21 @@ class StandardJsonValueBuilder
     try {
       _$result = _$v ??
           new _$StandardJsonValue._(
-              number: BuiltValueNullFieldError.checkNotNull(
-                  number, r'StandardJsonValue', 'number'),
-              text: BuiltValueNullFieldError.checkNotNull(
-                  text, r'StandardJsonValue', 'text'),
-              value: value.build(),
-              keyValues: keyValues.build(),
-              zoo: zoo.build(),
-              uniqueZoo: uniqueZoo.build(),
-              strings: _strings?.build(),
-              nullsInList: nullsInList.build(),
-              nullsInSet: nullsInSet.build(),
-              nullsInMap: nullsInMap.build(),
-              object: object,
-              objects: objects.build());
+            number: BuiltValueNullFieldError.checkNotNull(
+                number, r'StandardJsonValue', 'number'),
+            text: BuiltValueNullFieldError.checkNotNull(
+                text, r'StandardJsonValue', 'text'),
+            value: value.build(),
+            keyValues: keyValues.build(),
+            zoo: zoo.build(),
+            uniqueZoo: uniqueZoo.build(),
+            strings: _strings?.build(),
+            nullsInList: nullsInList.build(),
+            nullsInSet: nullsInSet.build(),
+            nullsInMap: nullsInMap.build(),
+            object: object,
+            objects: objects.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -676,13 +677,14 @@ class ComplexValueBuilder
     try {
       _$result = _$v ??
           new _$ComplexValue._(
-              primitive: BuiltValueNullFieldError.checkNotNull(
-                  primitive, r'ComplexValue', 'primitive'),
-              nullablePrimitive: nullablePrimitive,
-              nullablePrimitiveDoNotUse: nullablePrimitiveDoNotUse,
-              value: value.build(),
-              nullableValue: _nullableValue?.build(),
-              nullableValueDoNotUse: _nullableValueDoNotUse?.build());
+            primitive: BuiltValueNullFieldError.checkNotNull(
+                primitive, r'ComplexValue', 'primitive'),
+            nullablePrimitive: nullablePrimitive,
+            nullablePrimitiveDoNotUse: nullablePrimitiveDoNotUse,
+            value: value.build(),
+            nullableValue: _nullableValue?.build(),
+            nullableValueDoNotUse: _nullableValueDoNotUse?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/end_to_end_test/lib/values.g.dart
+++ b/end_to_end_test/lib/values.g.dart
@@ -2015,10 +2015,11 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
   _$SimpleValue _build() {
     final _$result = _$v ??
         new _$SimpleValue._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'SimpleValue', 'anInt'),
-            aString: aString,
-            $mustBeEscaped: $mustBeEscaped);
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'SimpleValue', 'anInt'),
+          aString: aString,
+          $mustBeEscaped: $mustBeEscaped,
+        );
     replace(_$result);
     return _$result;
   }
@@ -2119,8 +2120,9 @@ class CompoundValueBuilder
     try {
       _$result = _$v ??
           new _$CompoundValue._(
-              simpleValue: simpleValue.build(),
-              validatedValue: _validatedValue?.build());
+            simpleValue: simpleValue.build(),
+            validatedValue: _validatedValue?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -2233,9 +2235,10 @@ class CompoundValueNoNestingBuilder
   _$CompoundValueNoNesting _build() {
     final _$result = _$v ??
         new _$CompoundValueNoNesting._(
-            simpleValue: BuiltValueNullFieldError.checkNotNull(
-                simpleValue, r'CompoundValueNoNesting', 'simpleValue'),
-            validatedValue: validatedValue);
+          simpleValue: BuiltValueNullFieldError.checkNotNull(
+              simpleValue, r'CompoundValueNoNesting', 'simpleValue'),
+          validatedValue: validatedValue,
+        );
     replace(_$result);
     return _$result;
   }
@@ -2324,8 +2327,9 @@ class CompoundValueNoAutoNestingBuilder
     try {
       _$result = _$v ??
           new _$CompoundValueNoAutoNesting._(
-              value: BuiltValueNullFieldError.checkNotNull(
-                  _value?.build(), r'CompoundValueNoAutoNesting', 'value'));
+            value: BuiltValueNullFieldError.checkNotNull(
+                _value?.build(), r'CompoundValueNoAutoNesting', 'value'),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -2440,9 +2444,10 @@ class CompoundValueComparableBuildersBuilder
   _$CompoundValueComparableBuilders _build() {
     final _$result = _$v ??
         new _$CompoundValueComparableBuilders._(
-            simpleValue: BuiltValueNullFieldError.checkNotNull(
-                simpleValue, r'CompoundValueComparableBuilders', 'simpleValue'),
-            validatedValue: validatedValue);
+          simpleValue: BuiltValueNullFieldError.checkNotNull(
+              simpleValue, r'CompoundValueComparableBuilders', 'simpleValue'),
+          validatedValue: validatedValue,
+        );
     replace(_$result);
     return _$result;
   }
@@ -2594,11 +2599,12 @@ class CompoundValueNoNestingFieldBuilder
     try {
       _$result = _$v ??
           new _$CompoundValueNoNestingField._(
-              simpleValue: BuiltValueNullFieldError.checkNotNull(
-                  simpleValue, r'CompoundValueNoNestingField', 'simpleValue'),
-              validatedValue: validatedValue,
-              simpleValueWithNested: simpleValueWithNested.build(),
-              validatedValueWithNested: _validatedValueWithNested?.build());
+            simpleValue: BuiltValueNullFieldError.checkNotNull(
+                simpleValue, r'CompoundValueNoNestingField', 'simpleValue'),
+            validatedValue: validatedValue,
+            simpleValueWithNested: simpleValueWithNested.build(),
+            validatedValueWithNested: _validatedValueWithNested?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -2745,11 +2751,12 @@ class CompoundValueNestingFieldBuilder
     try {
       _$result = _$v ??
           new _$CompoundValueNestingField._(
-              simpleValue: BuiltValueNullFieldError.checkNotNull(
-                  simpleValue, r'CompoundValueNestingField', 'simpleValue'),
-              validatedValue: validatedValue,
-              simpleValueWithNested: simpleValueWithNested.build(),
-              validatedValueWithNested: _validatedValueWithNested?.build());
+            simpleValue: BuiltValueNullFieldError.checkNotNull(
+                simpleValue, r'CompoundValueNestingField', 'simpleValue'),
+            validatedValue: validatedValue,
+            simpleValueWithNested: simpleValueWithNested.build(),
+            validatedValueWithNested: _validatedValueWithNested?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -2870,9 +2877,10 @@ class CompoundValueNoAutoNestingFieldBuilder
     try {
       _$result = _$v ??
           new _$CompoundValueNoAutoNestingField._(
-              value: BuiltValueNullFieldError.checkNotNull(
-                  _value?.build(), r'CompoundValueNoAutoNestingField', 'value'),
-              valueWithAutoCreate: valueWithAutoCreate.build());
+            value: BuiltValueNullFieldError.checkNotNull(
+                _value?.build(), r'CompoundValueNoAutoNestingField', 'value'),
+            valueWithAutoCreate: valueWithAutoCreate.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -2993,8 +3001,9 @@ class CompoundValueAutoNestingFieldBuilder
     try {
       _$result = _$v ??
           new _$CompoundValueAutoNestingField._(
-              value: value.build(),
-              valueWithAutoCreate: valueWithAutoCreate.build());
+            value: value.build(),
+            valueWithAutoCreate: valueWithAutoCreate.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -3125,7 +3134,9 @@ class _$CompoundValueExplicitNoNestingBuilder
     try {
       _$result = _$v ??
           new _$CompoundValueExplicitNoNesting._(
-              simpleValue: simpleValue.build(), validatedValue: validatedValue);
+            simpleValue: simpleValue.build(),
+            validatedValue: validatedValue,
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -3230,8 +3241,10 @@ class _$ExplicitNestedListBuilder extends ExplicitNestedListBuilder {
   _$ExplicitNestedList _build() {
     _$ExplicitNestedList _$result;
     try {
-      _$result =
-          _$v ?? new _$ExplicitNestedList._(nestedList: nestedList.build());
+      _$result = _$v ??
+          new _$ExplicitNestedList._(
+            nestedList: nestedList.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -3341,7 +3354,8 @@ class _$ExplicitNonNullBuilderNullableSetterBuilder
     try {
       _$result = _$v ??
           new _$ExplicitNonNullBuilderNullableSetter._(
-              simpleValue: _simpleValue?.build());
+            simpleValue: _simpleValue?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -3452,7 +3466,8 @@ class _$ExplicitNonNullBuilderNullableFieldBuilder
     try {
       _$result = _$v ??
           new _$ExplicitNonNullBuilderNullableField._(
-              simpleValue: super.simpleValue?.build());
+            simpleValue: super.simpleValue?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -3565,8 +3580,9 @@ class DerivedValueBuilder
   _$DerivedValue _build() {
     final _$result = _$v ??
         new _$DerivedValue._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'DerivedValue', 'anInt'));
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'DerivedValue', 'anInt'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -3659,9 +3675,10 @@ class ValueWithCodeBuilder
   _$ValueWithCode _build() {
     final _$result = _$v ??
         new _$ValueWithCode._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValueWithCode', 'anInt'),
-            aString: aString);
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithCode', 'anInt'),
+          aString: aString,
+        );
     replace(_$result);
     return _$result;
   }
@@ -3795,10 +3812,11 @@ class _$ValueWithDefaultsBuilder extends ValueWithDefaultsBuilder {
     try {
       _$result = _$v ??
           new _$ValueWithDefaults._(
-              anInt: BuiltValueNullFieldError.checkNotNull(
-                  anInt, r'ValueWithDefaults', 'anInt'),
-              aString: aString,
-              value: value.build());
+            anInt: BuiltValueNullFieldError.checkNotNull(
+                anInt, r'ValueWithDefaults', 'anInt'),
+            aString: aString,
+            value: value.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -3903,8 +3921,9 @@ class _$ValueWithBuilderSmartsBuilder extends ValueWithBuilderSmartsBuilder {
   _$ValueWithBuilderSmarts _build() {
     final _$result = _$v ??
         new _$ValueWithBuilderSmarts._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'ValueWithBuilderSmarts', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'ValueWithBuilderSmarts', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -3998,9 +4017,10 @@ class ValidatedValueBuilder
   _$ValidatedValue _build() {
     final _$result = _$v ??
         new _$ValidatedValue._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValidatedValue', 'anInt'),
-            aString: aString);
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValidatedValue', 'anInt'),
+          aString: aString,
+        );
     replace(_$result);
     return _$result;
   }
@@ -4099,9 +4119,10 @@ class ValueUsingImportAsBuilder
   _$ValueUsingImportAs _build() {
     final _$result = _$v ??
         new _$ValueUsingImportAs._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'ValueUsingImportAs', 'value'),
-            nullableValue: nullableValue);
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'ValueUsingImportAs', 'value'),
+          nullableValue: nullableValue,
+        );
     replace(_$result);
     return _$result;
   }
@@ -4368,27 +4389,29 @@ class PrimitivesValueBuilder
   _$PrimitivesValue _build() {
     final _$result = _$v ??
         new _$PrimitivesValue._(
-            boolean: BuiltValueNullFieldError.checkNotNull(
-                boolean, r'PrimitivesValue', 'boolean'),
-            integer: BuiltValueNullFieldError.checkNotNull(
-                integer, r'PrimitivesValue', 'integer'),
-            int64: BuiltValueNullFieldError.checkNotNull(
-                int64, r'PrimitivesValue', 'int64'),
-            dbl: BuiltValueNullFieldError.checkNotNull(
-                dbl, r'PrimitivesValue', 'dbl'),
-            number: BuiltValueNullFieldError.checkNotNull(
-                number, r'PrimitivesValue', 'number'),
-            string: BuiltValueNullFieldError.checkNotNull(
-                string, r'PrimitivesValue', 'string'),
-            dateTime: BuiltValueNullFieldError.checkNotNull(
-                dateTime, r'PrimitivesValue', 'dateTime'),
-            duration: BuiltValueNullFieldError.checkNotNull(
-                duration, r'PrimitivesValue', 'duration'),
-            regExp: BuiltValueNullFieldError.checkNotNull(
-                regExp, r'PrimitivesValue', 'regExp'),
-            uri:
-                BuiltValueNullFieldError.checkNotNull(uri, r'PrimitivesValue', 'uri'),
-            bigInt: BuiltValueNullFieldError.checkNotNull(bigInt, r'PrimitivesValue', 'bigInt'));
+          boolean: BuiltValueNullFieldError.checkNotNull(
+              boolean, r'PrimitivesValue', 'boolean'),
+          integer: BuiltValueNullFieldError.checkNotNull(
+              integer, r'PrimitivesValue', 'integer'),
+          int64: BuiltValueNullFieldError.checkNotNull(
+              int64, r'PrimitivesValue', 'int64'),
+          dbl: BuiltValueNullFieldError.checkNotNull(
+              dbl, r'PrimitivesValue', 'dbl'),
+          number: BuiltValueNullFieldError.checkNotNull(
+              number, r'PrimitivesValue', 'number'),
+          string: BuiltValueNullFieldError.checkNotNull(
+              string, r'PrimitivesValue', 'string'),
+          dateTime: BuiltValueNullFieldError.checkNotNull(
+              dateTime, r'PrimitivesValue', 'dateTime'),
+          duration: BuiltValueNullFieldError.checkNotNull(
+              duration, r'PrimitivesValue', 'duration'),
+          regExp: BuiltValueNullFieldError.checkNotNull(
+              regExp, r'PrimitivesValue', 'regExp'),
+          uri: BuiltValueNullFieldError.checkNotNull(
+              uri, r'PrimitivesValue', 'uri'),
+          bigInt: BuiltValueNullFieldError.checkNotNull(
+              bigInt, r'PrimitivesValue', 'bigInt'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -4472,8 +4495,9 @@ class FunctionValueBuilder
   _$FunctionValue _build() {
     final _$result = _$v ??
         new _$FunctionValue._(
-            function: BuiltValueNullFieldError.checkNotNull(
-                function, r'FunctionValue', 'function'));
+          function: BuiltValueNullFieldError.checkNotNull(
+              function, r'FunctionValue', 'function'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -4563,8 +4587,10 @@ class ListOfFunctionValueBuilder
   _$ListOfFunctionValue _build() {
     _$ListOfFunctionValue _$result;
     try {
-      _$result =
-          _$v ?? new _$ListOfFunctionValue._(functions: functions.build());
+      _$result = _$v ??
+          new _$ListOfFunctionValue._(
+            functions: functions.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -4675,9 +4701,10 @@ class PartiallySerializableValueBuilder
   _$PartiallySerializableValue _build() {
     final _$result = _$v ??
         new _$PartiallySerializableValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'PartiallySerializableValue', 'value'),
-            transientValue: transientValue);
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'PartiallySerializableValue', 'value'),
+          transientValue: transientValue,
+        );
     replace(_$result);
     return _$result;
   }
@@ -4761,8 +4788,9 @@ class NamedFactoryValueBuilder
   _$NamedFactoryValue _build() {
     final _$result = _$v ??
         new _$NamedFactoryValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'NamedFactoryValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'NamedFactoryValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -4843,8 +4871,9 @@ class WireNameValueBuilder
   _$WireNameValue _build() {
     final _$result = _$v ??
         new _$WireNameValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'WireNameValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'WireNameValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -4962,9 +4991,10 @@ class FieldDiscoveryValueBuilder
     try {
       _$result = _$v ??
           new _$FieldDiscoveryValue._(
-              value: value.build(),
-              values: values.build(),
-              recursiveValue: _recursiveValue?.build());
+            value: value.build(),
+            values: values.build(),
+            recursiveValue: _recursiveValue?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -5064,7 +5094,10 @@ class DiscoverableValueBuilder
   _$DiscoverableValue _build() {
     _$DiscoverableValue _$result;
     try {
-      _$result = _$v ?? new _$DiscoverableValue._(value: value.build());
+      _$result = _$v ??
+          new _$DiscoverableValue._(
+            value: value.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -5162,8 +5195,9 @@ class SecondDiscoverableValueBuilder
   _$SecondDiscoverableValue _build() {
     final _$result = _$v ??
         new _$SecondDiscoverableValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'SecondDiscoverableValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'SecondDiscoverableValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -5249,8 +5283,9 @@ class ThirdDiscoverableValueBuilder
   _$ThirdDiscoverableValue _build() {
     final _$result = _$v ??
         new _$ThirdDiscoverableValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'ThirdDiscoverableValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'ThirdDiscoverableValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -5334,7 +5369,10 @@ class RecursiveValueABuilder
   _$RecursiveValueA _build() {
     _$RecursiveValueA _$result;
     try {
-      _$result = _$v ?? new _$RecursiveValueA._(value: value.build());
+      _$result = _$v ??
+          new _$RecursiveValueA._(
+            value: value.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -5429,7 +5467,10 @@ class RecursiveValueBBuilder
   _$RecursiveValueB _build() {
     _$RecursiveValueB _$result;
     try {
-      _$result = _$v ?? new _$RecursiveValueB._(value: value.build());
+      _$result = _$v ??
+          new _$RecursiveValueB._(
+            value: value.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -5527,8 +5568,9 @@ class ValueWithCustomSerializerBuilder
   _$ValueWithCustomSerializer _build() {
     final _$result = _$v ??
         new _$ValueWithCustomSerializer._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'ValueWithCustomSerializer', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'ValueWithCustomSerializer', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -5615,8 +5657,9 @@ class ValueWithOnSetBuilder
   _$ValueWithOnSet _build() {
     final _$result = _$v ??
         new _$ValueWithOnSet._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'ValueWithOnSet', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'ValueWithOnSet', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -5751,8 +5794,9 @@ class OtherValueBuilder implements Builder<OtherValue, OtherValueBuilder> {
   _$OtherValue _build() {
     final _$result = _$v ??
         new _$OtherValue._(
-            other: BuiltValueNullFieldError.checkNotNull(
-                other, r'OtherValue', 'other'));
+          other: BuiltValueNullFieldError.checkNotNull(
+              other, r'OtherValue', 'other'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -5862,12 +5906,13 @@ class DefaultsForFieldSettingsValueBuilder
   _$DefaultsForFieldSettingsValue _build() {
     final _$result = _$v ??
         new _$DefaultsForFieldSettingsValue._(
-            ignored: BuiltValueNullFieldError.checkNotNull(
-                ignored, r'DefaultsForFieldSettingsValue', 'ignored'),
-            compared: BuiltValueNullFieldError.checkNotNull(
-                compared, r'DefaultsForFieldSettingsValue', 'compared'),
-            serialized: BuiltValueNullFieldError.checkNotNull(
-                serialized, r'DefaultsForFieldSettingsValue', 'serialized'));
+          ignored: BuiltValueNullFieldError.checkNotNull(
+              ignored, r'DefaultsForFieldSettingsValue', 'ignored'),
+          compared: BuiltValueNullFieldError.checkNotNull(
+              compared, r'DefaultsForFieldSettingsValue', 'compared'),
+          serialized: BuiltValueNullFieldError.checkNotNull(
+              serialized, r'DefaultsForFieldSettingsValue', 'serialized'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -6058,19 +6103,20 @@ class ValueWithBuilderInitializerBuilder
     try {
       _$result = _$v ??
           new _$ValueWithBuilderInitializer._(
-              anInt: BuiltValueNullFieldError.checkNotNull(
-                  anInt, r'ValueWithBuilderInitializer', 'anInt'),
-              anIntWithDefault: BuiltValueNullFieldError.checkNotNull(
-                  anIntWithDefault,
-                  r'ValueWithBuilderInitializer',
-                  'anIntWithDefault'),
-              nullableInt: nullableInt,
-              nullableIntWithDefault: nullableIntWithDefault,
-              nestedValue: nestedValue.build(),
-              nestedValueWithDefault: nestedValueWithDefault.build(),
-              nullableNestedValue: _nullableNestedValue?.build(),
-              nullableNestedValueWithDefault:
-                  _nullableNestedValueWithDefault?.build());
+            anInt: BuiltValueNullFieldError.checkNotNull(
+                anInt, r'ValueWithBuilderInitializer', 'anInt'),
+            anIntWithDefault: BuiltValueNullFieldError.checkNotNull(
+                anIntWithDefault,
+                r'ValueWithBuilderInitializer',
+                'anIntWithDefault'),
+            nullableInt: nullableInt,
+            nullableIntWithDefault: nullableIntWithDefault,
+            nestedValue: nestedValue.build(),
+            nestedValueWithDefault: nestedValueWithDefault.build(),
+            nullableNestedValue: _nullableNestedValue?.build(),
+            nullableNestedValueWithDefault:
+                _nullableNestedValueWithDefault?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -6175,8 +6221,9 @@ class ValueWithBuilderFinalizerBuilder
     ValueWithBuilderFinalizer._finalizeBuilder(this);
     final _$result = _$v ??
         new _$ValueWithBuilderFinalizer._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValueWithBuilderFinalizer', 'anInt'));
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithBuilderFinalizer', 'anInt'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -6271,8 +6318,10 @@ class ValueWithGenericBuilderInitializerBuilder<T>
   ValueWithGenericBuilderInitializer<T> build() => _build();
 
   _$ValueWithGenericBuilderInitializer<T> _build() {
-    final _$result =
-        _$v ?? new _$ValueWithGenericBuilderInitializer<T>._(value: value);
+    final _$result = _$v ??
+        new _$ValueWithGenericBuilderInitializer<T>._(
+          value: value,
+        );
     replace(_$result);
     return _$result;
   }
@@ -6364,8 +6413,9 @@ class HashcodeValueBuilder
   _$HashcodeValue _build() {
     final _$result = _$v ??
         new _$HashcodeValue._(
-            x: BuiltValueNullFieldError.checkNotNull(x, r'HashcodeValue', 'x'),
-            y: BuiltValueNullFieldError.checkNotNull(y, r'HashcodeValue', 'y'));
+          x: BuiltValueNullFieldError.checkNotNull(x, r'HashcodeValue', 'x'),
+          y: BuiltValueNullFieldError.checkNotNull(y, r'HashcodeValue', 'y'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -6462,10 +6512,11 @@ class MemoizedHashcodeValueBuilder
   _$MemoizedHashcodeValue _build() {
     final _$result = _$v ??
         new _$MemoizedHashcodeValue._(
-            x: BuiltValueNullFieldError.checkNotNull(
-                x, r'MemoizedHashcodeValue', 'x'),
-            y: BuiltValueNullFieldError.checkNotNull(
-                y, r'MemoizedHashcodeValue', 'y'));
+          x: BuiltValueNullFieldError.checkNotNull(
+              x, r'MemoizedHashcodeValue', 'x'),
+          y: BuiltValueNullFieldError.checkNotNull(
+              y, r'MemoizedHashcodeValue', 'y'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -6603,7 +6654,10 @@ class SerializesNullsValueBuilder
   SerializesNullsValue build() => _build();
 
   _$SerializesNullsValue _build() {
-    final _$result = _$v ?? new _$SerializesNullsValue._(value: value);
+    final _$result = _$v ??
+        new _$SerializesNullsValue._(
+          value: value,
+        );
     replace(_$result);
     return _$result;
   }
@@ -6684,7 +6738,10 @@ class NullableObjectValueBuilder
   NullableObjectValue build() => _build();
 
   _$NullableObjectValue _build() {
-    final _$result = _$v ?? new _$NullableObjectValue._(value: value);
+    final _$result = _$v ??
+        new _$NullableObjectValue._(
+          value: value,
+        );
     replace(_$result);
     return _$result;
   }
@@ -6812,11 +6869,12 @@ class ValueWithHooksBuilder
     try {
       _$result = _$v ??
           new _$ValueWithHooks._(
-              hook1Count: BuiltValueNullFieldError.checkNotNull(
-                  hook1Count, r'ValueWithHooks', 'hook1Count'),
-              hook2Count: BuiltValueNullFieldError.checkNotNull(
-                  hook2Count, r'ValueWithHooks', 'hook2Count'),
-              hookOrdering: hookOrdering.build());
+            hook1Count: BuiltValueNullFieldError.checkNotNull(
+                hook1Count, r'ValueWithHooks', 'hook1Count'),
+            hook2Count: BuiltValueNullFieldError.checkNotNull(
+                hook2Count, r'ValueWithHooks', 'hook2Count'),
+            hookOrdering: hookOrdering.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -6973,13 +7031,14 @@ class $ValueSpecialBuilder
     try {
       _$result = _$v ??
           new _$$ValueSpecial._(
-              anInt: BuiltValueNullFieldError.checkNotNull(
-                  anInt, r'$ValueSpecial', 'anInt'),
-              aString: aString,
-              $mustBeEscaped: $mustBeEscaped,
-              $mustAlsoEscaped: _$mustAlsoEscaped?.build(),
-              $assert: _$assert?.build(),
-              $10: _$10?.build());
+            anInt: BuiltValueNullFieldError.checkNotNull(
+                anInt, r'$ValueSpecial', 'anInt'),
+            aString: aString,
+            $mustBeEscaped: $mustBeEscaped,
+            $mustAlsoEscaped: _$mustAlsoEscaped?.build(),
+            $assert: _$assert?.build(),
+            $10: _$10?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -7150,10 +7209,11 @@ class _$ValueWithAwkwardNestedBuilderBuilder
     try {
       _$result = _$v ??
           new _$ValueWithAwkwardNestedBuilder._(
-              value1: super.value1?.build(),
-              value2: super.value2?.build(),
-              values: values.build(),
-              map: map.build());
+            value1: super.value1?.build(),
+            value2: super.value2?.build(),
+            values: values.build(),
+            map: map.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -7442,25 +7502,47 @@ class VariousFunctionsValueBuilder
   _$VariousFunctionsValue _build() {
     final _$result = _$v ??
         new _$VariousFunctionsValue._(
-            bareFunction: BuiltValueNullFieldError.checkNotNull(
-                bareFunction, r'VariousFunctionsValue', 'bareFunction'),
-            positionalFunction: BuiltValueNullFieldError.checkNotNull(
-                positionalFunction, r'VariousFunctionsValue', 'positionalFunction'),
-            optionalFunction: BuiltValueNullFieldError.checkNotNull(
-                optionalFunction, r'VariousFunctionsValue', 'optionalFunction'),
-            positionalNamedFunction: BuiltValueNullFieldError.checkNotNull(
-                positionalNamedFunction, r'VariousFunctionsValue', 'positionalNamedFunction'),
-            namedFunction: BuiltValueNullFieldError.checkNotNull(
-                namedFunction, r'VariousFunctionsValue', 'namedFunction'),
-            requiredNamedFunction: BuiltValueNullFieldError.checkNotNull(
-                requiredNamedFunction, r'VariousFunctionsValue', 'requiredNamedFunction'),
-            mixinBareFunction: BuiltValueNullFieldError.checkNotNull(
-                mixinBareFunction, r'VariousFunctionsValue', 'mixinBareFunction'),
-            mixinPositionalFunction: BuiltValueNullFieldError.checkNotNull(mixinPositionalFunction, r'VariousFunctionsValue', 'mixinPositionalFunction'),
-            mixinOptionalFunction: BuiltValueNullFieldError.checkNotNull(mixinOptionalFunction, r'VariousFunctionsValue', 'mixinOptionalFunction'),
-            mixinPositionalNamedFunction: BuiltValueNullFieldError.checkNotNull(mixinPositionalNamedFunction, r'VariousFunctionsValue', 'mixinPositionalNamedFunction'),
-            mixinNamedFunction: BuiltValueNullFieldError.checkNotNull(mixinNamedFunction, r'VariousFunctionsValue', 'mixinNamedFunction'),
-            mixinRequiredNamedFunction: BuiltValueNullFieldError.checkNotNull(mixinRequiredNamedFunction, r'VariousFunctionsValue', 'mixinRequiredNamedFunction'));
+          bareFunction: BuiltValueNullFieldError.checkNotNull(
+              bareFunction, r'VariousFunctionsValue', 'bareFunction'),
+          positionalFunction: BuiltValueNullFieldError.checkNotNull(
+              positionalFunction,
+              r'VariousFunctionsValue',
+              'positionalFunction'),
+          optionalFunction: BuiltValueNullFieldError.checkNotNull(
+              optionalFunction, r'VariousFunctionsValue', 'optionalFunction'),
+          positionalNamedFunction: BuiltValueNullFieldError.checkNotNull(
+              positionalNamedFunction,
+              r'VariousFunctionsValue',
+              'positionalNamedFunction'),
+          namedFunction: BuiltValueNullFieldError.checkNotNull(
+              namedFunction, r'VariousFunctionsValue', 'namedFunction'),
+          requiredNamedFunction: BuiltValueNullFieldError.checkNotNull(
+              requiredNamedFunction,
+              r'VariousFunctionsValue',
+              'requiredNamedFunction'),
+          mixinBareFunction: BuiltValueNullFieldError.checkNotNull(
+              mixinBareFunction, r'VariousFunctionsValue', 'mixinBareFunction'),
+          mixinPositionalFunction: BuiltValueNullFieldError.checkNotNull(
+              mixinPositionalFunction,
+              r'VariousFunctionsValue',
+              'mixinPositionalFunction'),
+          mixinOptionalFunction: BuiltValueNullFieldError.checkNotNull(
+              mixinOptionalFunction,
+              r'VariousFunctionsValue',
+              'mixinOptionalFunction'),
+          mixinPositionalNamedFunction: BuiltValueNullFieldError.checkNotNull(
+              mixinPositionalNamedFunction,
+              r'VariousFunctionsValue',
+              'mixinPositionalNamedFunction'),
+          mixinNamedFunction: BuiltValueNullFieldError.checkNotNull(
+              mixinNamedFunction,
+              r'VariousFunctionsValue',
+              'mixinNamedFunction'),
+          mixinRequiredNamedFunction: BuiltValueNullFieldError.checkNotNull(
+              mixinRequiredNamedFunction,
+              r'VariousFunctionsValue',
+              'mixinRequiredNamedFunction'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/end_to_end_test/test/private_value_test.g.dart
+++ b/end_to_end_test/test/private_value_test.g.dart
@@ -81,8 +81,9 @@ class _PrivateValueBuilder
   _$PrivateValue _build() {
     final _$result = _$v ??
         new _$PrivateValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'_PrivateValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'_PrivateValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/example/lib/collections.g.dart
+++ b/example/lib/collections.g.dart
@@ -357,16 +357,17 @@ class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
     try {
       _$result = _$v ??
           new _$Collections._(
-              list: list.build(),
-              set: set.build(),
-              map: map.build(),
-              listMultimap: listMultimap.build(),
-              setMultimap: setMultimap.build(),
-              nullableList: _nullableList?.build(),
-              nullableSet: _nullableSet?.build(),
-              nullableMap: _nullableMap?.build(),
-              nullableListMultimap: _nullableListMultimap?.build(),
-              nullableSetMultimap: _nullableSetMultimap?.build());
+            list: list.build(),
+            set: set.build(),
+            map: map.build(),
+            listMultimap: listMultimap.build(),
+            setMultimap: setMultimap.build(),
+            nullableList: _nullableList?.build(),
+            nullableSet: _nullableSet?.build(),
+            nullableMap: _nullableMap?.build(),
+            nullableListMultimap: _nullableListMultimap?.build(),
+            nullableSetMultimap: _nullableSetMultimap?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/example/lib/generics.g.dart
+++ b/example/lib/generics.g.dart
@@ -334,8 +334,9 @@ class GenericValueBuilder<T>
   _$GenericValue<T> _build() {
     final _$result = _$v ??
         new _$GenericValue<T>._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'GenericValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'GenericValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -423,8 +424,9 @@ class BoundGenericValueBuilder<T extends num>
   _$BoundGenericValue<T> _build() {
     final _$result = _$v ??
         new _$BoundGenericValue<T>._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'BoundGenericValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'BoundGenericValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -514,8 +516,10 @@ class CollectionGenericValueBuilder<T>
   _$CollectionGenericValue<T> _build() {
     _$CollectionGenericValue<T> _$result;
     try {
-      _$result =
-          _$v ?? new _$CollectionGenericValue<T>._(values: values.build());
+      _$result = _$v ??
+          new _$CollectionGenericValue<T>._(
+            values: values.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -650,9 +654,10 @@ class GenericContainerBuilder
     try {
       _$result = _$v ??
           new _$GenericContainer._(
-              genericValue: genericValue.build(),
-              boundGenericValue: boundGenericValue.build(),
-              collectionGenericValue: collectionGenericValue.build());
+            genericValue: genericValue.build(),
+            boundGenericValue: boundGenericValue.build(),
+            collectionGenericValue: collectionGenericValue.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {

--- a/example/lib/interfaces.g.dart
+++ b/example/lib/interfaces.g.dart
@@ -199,10 +199,11 @@ class _$ValueWithIntBuilder extends ValueWithIntBuilder {
   _$ValueWithInt _build() {
     final _$result = _$v ??
         new _$ValueWithInt._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValueWithInt', 'anInt'),
-            note: BuiltValueNullFieldError.checkNotNull(
-                note, r'ValueWithInt', 'note'));
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithInt', 'anInt'),
+          note: BuiltValueNullFieldError.checkNotNull(
+              note, r'ValueWithInt', 'note'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/example/lib/polymorphism.g.dart
+++ b/example/lib/polymorphism.g.dart
@@ -191,8 +191,9 @@ class CatBuilder implements Builder<Cat, CatBuilder>, AnimalBuilder {
   _$Cat _build() {
     final _$result = _$v ??
         new _$Cat._(
-            tail: BuiltValueNullFieldError.checkNotNull(tail, r'Cat', 'tail'),
-            legs: BuiltValueNullFieldError.checkNotNull(legs, r'Cat', 'legs'));
+          tail: BuiltValueNullFieldError.checkNotNull(tail, r'Cat', 'tail'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Cat', 'legs'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -283,8 +284,9 @@ class FishBuilder implements Builder<Fish, FishBuilder>, AnimalBuilder {
   _$Fish _build() {
     final _$result = _$v ??
         new _$Fish._(
-            fins: BuiltValueNullFieldError.checkNotNull(fins, r'Fish', 'fins'),
-            legs: BuiltValueNullFieldError.checkNotNull(legs, r'Fish', 'legs'));
+          fins: BuiltValueNullFieldError.checkNotNull(fins, r'Fish', 'fins'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Fish', 'legs'),
+        );
     replace(_$result);
     return _$result;
   }

--- a/example/lib/values.g.dart
+++ b/example/lib/values.g.dart
@@ -395,9 +395,10 @@ class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
   _$SimpleValue _build() {
     final _$result = _$v ??
         new _$SimpleValue._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'SimpleValue', 'anInt'),
-            aString: aString);
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'SimpleValue', 'anInt'),
+          aString: aString,
+        );
     replace(_$result);
     return _$result;
   }
@@ -480,8 +481,9 @@ class VerySimpleValueBuilder
   _$VerySimpleValue _build() {
     final _$result = _$v ??
         new _$VerySimpleValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'VerySimpleValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'VerySimpleValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -582,8 +584,9 @@ class CompoundValueBuilder
     try {
       _$result = _$v ??
           new _$CompoundValue._(
-              simpleValue: simpleValue.build(),
-              validatedValue: _validatedValue?.build());
+            simpleValue: simpleValue.build(),
+            validatedValue: _validatedValue?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -690,9 +693,10 @@ class ValidatedValueBuilder
   _$ValidatedValue _build() {
     final _$result = _$v ??
         new _$ValidatedValue._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValidatedValue', 'anInt'),
-            aString: aString);
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValidatedValue', 'anInt'),
+          aString: aString,
+        );
     replace(_$result);
     return _$result;
   }
@@ -785,9 +789,10 @@ class ValueWithCodeBuilder
   _$ValueWithCode _build() {
     final _$result = _$v ??
         new _$ValueWithCode._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValueWithCode', 'anInt'),
-            aString: aString);
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithCode', 'anInt'),
+          aString: aString,
+        );
     replace(_$result);
     return _$result;
   }
@@ -898,9 +903,10 @@ class _$ValueWithDefaultsBuilder extends ValueWithDefaultsBuilder {
   _$ValueWithDefaults _build() {
     final _$result = _$v ??
         new _$ValueWithDefaults._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'ValueWithDefaults', 'anInt'),
-            aString: aString);
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithDefaults', 'anInt'),
+          aString: aString,
+        );
     replace(_$result);
     return _$result;
   }
@@ -989,8 +995,9 @@ class DerivedValueBuilder
   _$DerivedValue _build() {
     final _$result = _$v ??
         new _$DerivedValue._(
-            anInt: BuiltValueNullFieldError.checkNotNull(
-                anInt, r'DerivedValue', 'anInt'));
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'DerivedValue', 'anInt'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1099,10 +1106,11 @@ class AccountBuilder implements Builder<Account, AccountBuilder> {
     try {
       _$result = _$v ??
           new _$Account._(
-              id: BuiltValueNullFieldError.checkNotNull(id, r'Account', 'id'),
-              name: BuiltValueNullFieldError.checkNotNull(
-                  name, r'Account', 'name'),
-              keyValues: keyValues.build());
+            id: BuiltValueNullFieldError.checkNotNull(id, r'Account', 'id'),
+            name:
+                BuiltValueNullFieldError.checkNotNull(name, r'Account', 'name'),
+            keyValues: keyValues.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
@@ -1194,8 +1202,9 @@ class WireNameValueBuilder
   _$WireNameValue _build() {
     final _$result = _$v ??
         new _$WireNameValue._(
-            value: BuiltValueNullFieldError.checkNotNull(
-                value, r'WireNameValue', 'value'));
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'WireNameValue', 'value'),
+        );
     replace(_$result);
     return _$result;
   }


### PR DESCRIPTION
For #1335 

Before:

```
dart format --language-version=3.6 */lib/*.g.dart
Formatted 20 files (0 changed) in 3.55 seconds.
```

After:

```
dart format --language-version=3.6 */lib/*.g.dart
Formatted 20 files (0 changed) in 1.01 seconds.
```

Note that the speedup is more than 3.5x as "dart format" has some startup time.