### PR TITLE
Remove use of deprecated @nullable from docs and comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,6 @@ a client for a JSON API representing a person that looks like the following:
 
 The corresponding dart class employing `built_value` might look like this. Note
 that it is using the
-[`@nullable`](https://pub.dev/documentation/built_value/latest/built_value/nullable-constant.html)
-annotation to indicate that the field does not have to be present on the
-response, as well as the
 [`@BuiltValueField`](https://pub.dev/documentation/built_value/latest/built_value/BuiltValueField-class.html)
 annotation to map between the property name on the response and the name of the
 member variable in the `Person` class.
@@ -224,17 +221,13 @@ part 'person.g.dart';
 abstract class Person implements Built<Person, PersonBuilder> {
   static Serializer<Person> get serializer => _$personSerializer;
 
-  // Can never be null.
   int get id;
 
-  @nullable
-  int get age;
+  int? get age;
 
-  @nullable
   @BuiltValueField(wireName: 'first_name')
-  String get firstName;
+  String? get firstName;
 
-  @nullable
   BuiltList<String> get hobbies;
 
   Person._();

--- a/end_to_end_test/test/mixins_test.dart
+++ b/end_to_end_test/test/mixins_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 void main() {
   group(GetsCorrectFieldsViaMixins, () {
     test('has correct fields', () {
-      // If it has any unwanted fields they will not be @nullable so this will
+      // If it has any unwanted fields they will not be nullable so this will
       // throw.
       var value = GetsCorrectFieldsViaMixins((b) => b..shouldBeAField = 1);
       expect(value.shouldBeAField, 1);


### PR DESCRIPTION
Fix #1338 