### PR TITLE
Support analyzer v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+# 8.9.5
+
+- Allow `built_value_generator` to use `analyzer 7.0.0`.
+
 # 8.9.4
 
-- Allow `build_value_generator` to use `source_gen 3.0.0`.
+- Allow `built_value_generator` to use `source_gen 2.0.0`.
 
 # 8.9.3
 

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark
-version: 8.9.4
+version: 8.9.5
 publish_to: none
 description: >
   Benchmark, not for publishing.
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
-  built_value_generator: ^8.9.4
+  built_value_generator: ^8.9.5
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0

--- a/built_value/pubspec.yaml
+++ b/built_value/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value
-version: 8.9.4
+version: 8.9.5
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the runtime dependency.

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_generator
-version: 8.9.4
+version: 8.9.5
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the dev dependency.
@@ -13,7 +13,7 @@ environment:
   sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=6.9.0 <7.0.0'
+  analyzer: '>=6.9.0 <8.0.0'
   build: '>=1.0.0 <3.0.0'
   build_config: '>=0.3.1 <2.0.0'
   built_collection: ^5.0.0

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_test
-version: 8.9.4
+version: 8.9.5
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library provides test support.
@@ -21,7 +21,7 @@ dependencies:
   quiver: '>=0.21.0 <4.0.0'
 
 dev_dependencies:
-  built_value_generator: ^8.9.4
+  built_value_generator: ^8.9.5
   build_runner: '>=1.0.0 <3.0.0'
   pedantic: ^1.4.0
   test: ^1.0.0

--- a/chat_example/lib/client/html_display.dart
+++ b/chat_example/lib/client/html_display.dart
@@ -3,9 +3,10 @@
 // license that can be found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:html';
+import 'dart:js_interop';
 
 import 'package:chat_example/client/display.dart';
+import 'package:web/web.dart';
 
 /// [Display] using `dart:html`.
 class HtmlDisplay implements Display {
@@ -13,7 +14,7 @@ class HtmlDisplay implements Display {
   final HtmlEscape _htmlEscape = const HtmlEscape();
 
   factory HtmlDisplay() {
-    return HtmlDisplay._(querySelector('#text')!);
+    return HtmlDisplay._(document.querySelector('#text')!);
   }
 
   HtmlDisplay._(this._element) {
@@ -22,16 +23,16 @@ class HtmlDisplay implements Display {
 
   @override
   void addLocal(String text) {
-    _element.innerHtml = _element.innerHtml! +
+    _element.textContent = _element.textContent! +
         '<div class="local">'
             '${_htmlEscape.convert(text).replaceAll('\n', '<br>')}</div>';
-    window.scrollTo(0, document.body!.scrollHeight);
+    window.scrollTo(0.toJS, document.body!.scrollHeight);
   }
 
   @override
   void add(String text) {
-    _element.innerHtml = _element.innerHtml! +
+    _element.textContent = _element.textContent! +
         '${_htmlEscape.convert(text).replaceAll('\n', '<br>')}<br>';
-    window.scrollTo(0, document.body!.scrollHeight);
+    window.scrollTo(0.toJS, document.body!.scrollHeight);
   }
 }

--- a/chat_example/lib/client/http_client_connection.dart
+++ b/chat_example/lib/client/http_client_connection.dart
@@ -3,9 +3,10 @@
 // license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html';
+import 'dart:js_interop';
 
 import 'package:chat_example/client/client_connection.dart';
+import 'package:web/web.dart';
 
 /// [ClientConnection] using a web socket.
 class HttpClientConnection implements ClientConnection {
@@ -27,6 +28,6 @@ class HttpClientConnection implements ClientConnection {
 
   @override
   void sendToServer(String data) {
-    _websocket.send(data);
+    _websocket.send(data.toJS);
   }
 }

--- a/chat_example/lib/client/input.dart
+++ b/chat_example/lib/client/input.dart
@@ -3,18 +3,19 @@
 // license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html';
+
+import 'package:web/web.dart';
 
 /// An input box using `dart:html`.
 class Input {
   final StreamController<String> _streamController = StreamController<String>();
 
   Input() {
-    final input = querySelector('#input') as InputElement;
+    final input = document.querySelector('#input')! as HTMLInputElement;
 
     input.onKeyPress.listen((keyEvent) {
       if (keyEvent.keyCode == KeyCode.ENTER) {
-        _streamController.add(input.value!);
+        _streamController.add(input.value);
         input.value = '';
       }
     });

--- a/chat_example/lib/client/layout.dart
+++ b/chat_example/lib/client/layout.dart
@@ -2,14 +2,14 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'dart:html';
+import 'package:web/web.dart';
 
 /// Forces focus to the input box.
 class Layout {
   Layout() {
-    final screen = querySelector('#screen')!;
-    final text = querySelector('#text')!;
-    final input = querySelector('#input')!;
+    final screen = document.querySelector('#screen')!;
+    final text = document.querySelector('#text')!;
+    final input = document.querySelector('#input')! as HTMLInputElement;
 
     input.focus();
 

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 homepage: https://github.com/google/built_value.dart
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   built_collection: ^5.0.0
@@ -14,6 +14,7 @@ dependencies:
   shelf: ^1.0.0
   shelf_proxy: ^1.0.0
   shelf_web_socket: ^1.0.0
+  web: ^1.1.1
   web_socket_channel: ^2.0.0
 
 dev_dependencies:

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chat_example
-version: 8.9.4
+version: 8.9.5
 publish_to: none
 description: >
   Just an example, not for publishing.
@@ -20,6 +20,6 @@ dev_dependencies:
   build_runner: any
   build_test: any
   build_web_compilers: any
-  built_value_generator: ^8.9.4
+  built_value_generator: ^8.9.5
   pedantic: ^1.4.0
   test: ^1.0.0

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: end_to_end_test
-version: 8.9.4
+version: 8.9.5
 publish_to: none
 description: >
   Tests, not for publishing.
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   build: '>=1.0.0 <3.0.0'
   build_runner: '>=1.0.0 <3.0.0'
-  built_value_generator: ^8.9.4
+  built_value_generator: ^8.9.5
   fixnum: ^1.0.0
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
-  built_value_generator: ^8.9.4
+  built_value_generator: ^8.9.5
   pedantic: ^1.4.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0


### PR DESCRIPTION
As a followup of #1343 I tried analyzer version 7 on this branch and everything seems to be working. But I also saw #1340 saying there were pending changes, so I'm not sure if this is mergeable.

I've taken the opportunity to also migrate the chat_example to use the `web` package instead of `dart:html` to avoid analysis errors.

@davidmorgan 