### PR TITLE
Use renamed `source_gen` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 8.9.6 (unreleased)
+
+- Changes for post-element2-migration `source_gen`.
+
 # 8.9.5
 
 - Allow `built_value_generator` to use `analyzer 7.0.0`.

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -20,11 +20,20 @@ dev_dependencies:
   test: ^1.0.0
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/_fe_analyzer_shared
+      ref: 3.8.0-158.0.dev
+  analyzer:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analyzer
+      ref: 3.8.0-158.0.dev
   built_value:
     path: ../built_value
   built_value_generator:
     path: ../built_value_generator
-  analyzer: ^7.2.0
   build:
    git:
      url: https://github.com/dart-lang/build.git
@@ -34,6 +43,11 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/build.git
       path: build_resolvers
+      ref: resolver-2-methods
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
       ref: resolver-2-methods
   source_gen:
     git:

--- a/built_value_generator/lib/built_value_generator.dart
+++ b/built_value_generator/lib/built_value_generator.dart
@@ -27,7 +27,7 @@ class BuiltValueGenerator extends Generator {
     while (true) {
       try {
         libraryElement = await buildStep.resolver.libraryFor2(
-            await buildStep.resolver.assetIdForElement2(library.element2));
+            await buildStep.resolver.assetIdForElement2(library.element));
         parsedLibraryResults.parsedLibraryResultOrThrowingMock(libraryElement);
         break;
       } catch (_) {

--- a/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_value_generator/lib/src/enum_source_class.dart
@@ -74,7 +74,7 @@ abstract class EnumSourceClass
   BuiltList<String> get constructors =>
       BuiltList<String>(element.constructors2.map((element) {
         final declaration =
-            parsedLibrary.getElementDeclaration2(element.firstFragment);
+            parsedLibrary.getFragmentDeclaration(element.firstFragment);
         return declaration?.node.toSource() ?? '';
       }));
 
@@ -83,7 +83,7 @@ abstract class EnumSourceClass
     var getter = element.getGetter2('values');
     if (getter == null) return null;
     var source = parsedLibrary
-        .getElementDeclaration2(getter.firstFragment)!
+        .getFragmentDeclaration(getter.firstFragment)!
         .node
         .toSource();
     var matches = RegExp(r'static BuiltSet<' +
@@ -98,7 +98,7 @@ abstract class EnumSourceClass
     var getter = element.getMethod2('valueOf');
     if (getter == null) return null;
     var source = parsedLibrary
-        .getElementDeclaration2(getter.firstFragment)!
+        .getFragmentDeclaration(getter.firstFragment)!
         .node
         .toSource();
     var matches = RegExp(r'static ' +

--- a/built_value_generator/lib/src/enum_source_field.dart
+++ b/built_value_generator/lib/src/enum_source_field.dart
@@ -48,7 +48,7 @@ abstract class EnumSourceField
   String get generatedIdentifier {
     var fieldName = element.displayName;
     return parsedLibrary
-        .getElementDeclaration2(element.firstFragment)!
+        .getFragmentDeclaration(element.firstFragment)!
         .node
         .toSource()
         .substring('$fieldName = '.length);

--- a/built_value_generator/lib/src/field_mixin.dart
+++ b/built_value_generator/lib/src/field_mixin.dart
@@ -30,7 +30,7 @@ mixin FieldMixin {
     // Go via AST to allow use of unresolvable types not yet generated;
     // this includes generated Builder types.
     result = parsedLibrary
-        .getElementDeclaration2(builderElement!.firstFragment)
+        .getFragmentDeclaration(builderElement!.firstFragment)
         ?.node
         .parent
         ?.childEntities
@@ -41,7 +41,7 @@ mixin FieldMixin {
 
     result = builderElement!.getter2 != null
         ? (parsedLibrary
-                .getElementDeclaration2(builderElement!.getter2!.firstFragment)
+                .getFragmentDeclaration(builderElement!.getter2!.firstFragment)
                 ?.node as MethodDeclaration?)
             ?.returnType
             .toString()

--- a/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_value_generator/lib/src/serializer_source_class.dart
@@ -100,7 +100,7 @@ abstract class SerializerSourceClass
     if (serializerFields.isEmpty) return '';
     var serializerField = serializerFields.single;
     var result = parsedLibrary
-            .getElementDeclaration2(serializerField.getter2!.firstFragment)
+            .getFragmentDeclaration(serializerField.getter2!.firstFragment)
             ?.node
             .toSource() ??
         '';

--- a/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_value_generator/lib/src/serializer_source_field.dart
@@ -112,7 +112,7 @@ abstract class SerializerSourceField
   @memoized
   String get typeWithPrefixAndNullabilitySuffix {
     var declaration =
-        parsedLibrary.getElementDeclaration2(element.getter2!.firstFragment)!;
+        parsedLibrary.getFragmentDeclaration(element.getter2!.firstFragment)!;
     var typeFromAst =
         (declaration.node as MethodDeclaration).returnType?.toString() ??
             'dynamic';

--- a/built_value_generator/lib/src/value_source_class.dart
+++ b/built_value_generator/lib/src/value_source_class.dart
@@ -7,9 +7,9 @@ library built_value_generator.source_class;
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element2.dart';
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value_generator/src/fixes.dart';
@@ -173,7 +173,7 @@ abstract class ValueSourceClass
 
   @memoized
   ClassDeclaration get classDeclaration {
-    return parsedLibrary.getElementDeclaration2(element.firstFragment)!.node
+    return parsedLibrary.getFragmentDeclaration(element.firstFragment)!.node
         as ClassDeclaration;
   }
 
@@ -277,7 +277,7 @@ abstract class ValueSourceClass
           .where((constructor) =>
               !constructor.isFactory && !constructor.isSynthetic)
           .map((constructor) => parsedLibrary
-              .getElementDeclaration2(constructor.firstFragment)!
+              .getFragmentDeclaration(constructor.firstFragment)!
               .node as ConstructorDeclaration));
 
   @memoized
@@ -285,7 +285,7 @@ abstract class ValueSourceClass
       BuiltList<ConstructorDeclaration>(element.constructors2
           .where((constructor) => constructor.isFactory)
           .map((factory) => parsedLibrary
-              .getElementDeclaration2(factory.firstFragment)!
+              .getFragmentDeclaration(factory.firstFragment)!
               .node as ConstructorDeclaration));
 
   @memoized
@@ -297,7 +297,7 @@ abstract class ValueSourceClass
           .where((constructor) =>
               !constructor.isFactory && !constructor.isSynthetic)
           .map((constructor) => parsedLibrary
-              .getElementDeclaration2(constructor.firstFragment)!
+              .getFragmentDeclaration(constructor.firstFragment)!
               .node
               .toSource()));
 
@@ -306,7 +306,7 @@ abstract class ValueSourceClass
       BuiltList<String>(builderElement!.constructors2
           .where((constructor) => constructor.isFactory)
           .map((factory) => parsedLibrary
-              .getElementDeclaration2(factory.firstFragment)!
+              .getFragmentDeclaration(factory.firstFragment)!
               .node
               .toSource()));
 
@@ -520,10 +520,10 @@ abstract class ValueSourceClass
           method.returnType is VoidType &&
           method.formalParameters.length == 1 &&
           parsedLibrary
-              .getElementDeclaration2(method.formalParameters[0].firstFragment)!
+              .getFragmentDeclaration(method.formalParameters[0].firstFragment)!
               .node is SimpleFormalParameter &&
           DartTypes.stripGenerics((parsedLibrary
-                      .getElementDeclaration2(
+                      .getFragmentDeclaration(
                           method.formalParameters[0].firstFragment)!
                       .node as SimpleFormalParameter)
                   .type!

--- a/built_value_generator/lib/src/value_source_field.dart
+++ b/built_value_generator/lib/src/value_source_field.dart
@@ -67,7 +67,7 @@ abstract class ValueSourceField
   @memoized
   String get typeWithPrefix {
     var typeFromAst = (parsedLibrary
-                .getElementDeclaration2(element.getter2!.firstFragment)!
+                .getFragmentDeclaration(element.getter2!.firstFragment)!
                 .node as MethodDeclaration)
             .returnType
             ?.toSource() ??
@@ -183,7 +183,7 @@ abstract class ValueSourceField
       // Go via AST to allow use of unresolvable types not yet generated;
       // this includes generated Builder types.
       result = parsedLibrary
-          .getElementDeclaration2(builderElement!.firstFragment)
+          .getFragmentDeclaration(builderElement!.firstFragment)
           ?.node
           .parent
           ?.childEntities
@@ -194,7 +194,7 @@ abstract class ValueSourceField
     if (result == null || result == 'dynamic') {
       result = builderElement!.setter2 != null
           ? (parsedLibrary
-                  .getElementDeclaration2(
+                  .getFragmentDeclaration(
                       builderElement!.setter2!.firstFragment)
                   ?.node as MethodDeclaration?)
               ?.parameters!
@@ -215,7 +215,7 @@ abstract class ValueSourceField
     // If it's a real field, it's a [VariableDeclaration] which is guaranteed
     // to have parent node [VariableDeclarationList] giving the type.
     var fieldDeclaration =
-        parsedLibrary.getElementDeclaration2(builderElement!.firstFragment);
+        parsedLibrary.getFragmentDeclaration(builderElement!.firstFragment);
     if (fieldDeclaration != null) {
       return _removeNullabilitySuffix(
           (((fieldDeclaration.node as VariableDeclaration).parent)
@@ -226,7 +226,7 @@ abstract class ValueSourceField
     } else {
       // Otherwise it's an explicit getter/setter pair; get the type from the getter.
       return _removeNullabilitySuffix((parsedLibrary
-                  .getElementDeclaration2(
+                  .getFragmentDeclaration(
                       builderElement!.getter2!.firstFragment)!
                   .node as MethodDeclaration)
               .returnType

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=7.2.0 <8.0.0'
+  analyzer: '>=7.3.0 <8.0.0'
   build: '>=1.0.0 <3.0.0'
   build_config: '>=0.3.1 <2.0.0'
   built_collection: ^5.0.0
@@ -28,9 +28,18 @@ dev_dependencies:
   test: ^1.0.0
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/_fe_analyzer_shared
+      ref: 3.8.0-158.0.dev
+  analyzer:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analyzer
+      ref: 3.8.0-158.0.dev
   built_value:
     path: ../built_value
-  analyzer: ^7.2.0
   build:
    git:
      url: https://github.com/dart-lang/build.git
@@ -40,6 +49,11 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/build.git
       path: build_resolvers
+      ref: resolver-2-methods
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
       ref: resolver-2-methods
   source_gen:
     git:

--- a/built_value_test/pubspec.yaml
+++ b/built_value_test/pubspec.yaml
@@ -27,11 +27,20 @@ dev_dependencies:
   test: ^1.0.0
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/_fe_analyzer_shared
+      ref: 3.8.0-158.0.dev
+  analyzer:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analyzer
+      ref: 3.8.0-158.0.dev
   built_value:
     path: ../built_value
   built_value_generator:
     path: ../built_value_generator
-  analyzer: ^7.2.0
   build:
    git:
      url: https://github.com/dart-lang/build.git
@@ -41,6 +50,11 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/build.git
       path: build_resolvers
+      ref: resolver-2-methods
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
       ref: resolver-2-methods
   source_gen:
     git:

--- a/chat_example/pubspec.yaml
+++ b/chat_example/pubspec.yaml
@@ -25,11 +25,20 @@ dev_dependencies:
   test: ^1.0.0
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/_fe_analyzer_shared
+      ref: 3.8.0-158.0.dev
+  analyzer:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analyzer
+      ref: 3.8.0-158.0.dev
   built_value:
     path: ../built_value
   built_value_generator:
     path: ../built_value_generator
-  analyzer: ^7.2.0
   build:
    git:
      url: https://github.com/dart-lang/build.git
@@ -39,6 +48,11 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/build.git
       path: build_resolvers
+      ref: resolver-2-methods
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
       ref: resolver-2-methods
   source_gen:
     git:

--- a/end_to_end_test/pubspec.yaml
+++ b/end_to_end_test/pubspec.yaml
@@ -22,11 +22,20 @@ dev_dependencies:
   test: ^1.16.0
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/_fe_analyzer_shared
+      ref: 3.8.0-158.0.dev
+  analyzer:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analyzer
+      ref: 3.8.0-158.0.dev
   built_value:
     path: ../built_value
   built_value_generator:
     path: ../built_value_generator
-  analyzer: ^7.2.0
   build:
    git:
      url: https://github.com/dart-lang/build.git
@@ -36,6 +45,11 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/build.git
       path: build_resolvers
+      ref: resolver-2-methods
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
       ref: resolver-2-methods
   source_gen:
     git:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,11 +19,20 @@ dev_dependencies:
   test: ^1.0.0
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/_fe_analyzer_shared
+      ref: 3.8.0-158.0.dev
+  analyzer:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analyzer
+      ref: 3.8.0-158.0.dev
   built_value:
     path: ../built_value
   built_value_generator:
     path: ../built_value_generator
-  analyzer: ^7.2.0
   build:
    git:
      url: https://github.com/dart-lang/build.git
@@ -33,6 +42,11 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/build.git
       path: build_resolvers
+      ref: resolver-2-methods
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
       ref: resolver-2-methods
   source_gen:
     git:


### PR DESCRIPTION
`library.element2` -> `library.element`

Incidental changes: stop using method that's now deprecated in the analyzer, change dep pinning to something that currently builds.